### PR TITLE
Added the dark and light mode icons to the top header

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -417,16 +417,11 @@ These are concrete, fixable inconsistencies observed in the current web code.
    toaster colors are an inconsistency — they won't track the palette and have no
    token equivalent for an RN port.
 
-4. **Stale comment in `styles.css`** (line ~52): "The app currently boots dark
-   (AppBoot.tsx); a theme toggle will activate this." The toggle is already
-   implemented (Settings → Appearance, `settings/index.lazy.tsx` calling
-   `setTheme`). The comment should be updated.
-
-5. **Toaster `success`/`error` contrast is not covered by `contrast.test.ts`.**
+4. **Toaster `success`/`error` contrast is not covered by `contrast.test.ts`.**
    The contrast test guards token pairs but not these hardcoded toast colors, so
    they could regress accessibility silently.
 
-6. **No exported numeric scale for spacing/radius/typography.** Radius is a token
+5. **No exported numeric scale for spacing/radius/typography.** Radius is a token
    (`--radius`) but spacing/type rely entirely on Tailwind utility literals
    scattered across components, so there's no single place that defines the
    intended scale (this matters for keeping an RN client aligned).

--- a/web/e2e/general-settings.spec.ts
+++ b/web/e2e/general-settings.spec.ts
@@ -173,6 +173,10 @@ async function activeElementName(page: Page) {
 
 async function expectNewIntegrationControls(page: Page) {
   await expect(
+    page.getByRole("heading", { name: "Appearance" }),
+  ).toHaveCount(0);
+  await expect(page.getByText("Dark mode")).toHaveCount(0);
+  await expect(
     page.getByRole("textbox", { name: "Jellyfin base URL" }),
   ).toBeVisible();
   await expect(

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -269,6 +269,9 @@ test("home page is clean, responsive, and accessible", async ({ page }) => {
   const browserIssues = trackBrowserIssues(page);
   const unexpectedApiRequests = await mockHomeApi(page);
 
+  await page.addInitScript(() => {
+    window.localStorage.removeItem("igloo-theme");
+  });
   await page.goto("/");
 
   await expect(page).toHaveTitle("Home - Igloo");
@@ -287,7 +290,10 @@ test("home page is clean, responsive, and accessible", async ({ page }) => {
   await expect(
     page.getByRole("button", { name: "Notifications" }),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Cast" })).toBeVisible();
+  const themeToggle = page.getByRole("button", {
+    name: "Switch to light theme",
+  });
+  await expect(themeToggle).toBeVisible();
 
   for (const name of [
     "Watch Rooms",
@@ -306,6 +312,14 @@ test("home page is clean, responsive, and accessible", async ({ page }) => {
   await expect(skipLink).toBeFocused();
   await page.keyboard.press("Enter");
   await expect(page.getByRole("main")).toBeFocused();
+
+  await themeToggle.click();
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("igloo-theme")))
+    .toBe("light");
+  await expect(
+    page.getByRole("button", { name: "Switch to dark theme" }),
+  ).toBeVisible();
 
   const main = page.getByRole("main");
   for (const viewport of [

--- a/web/src/assets/styles.css
+++ b/web/src/assets/styles.css
@@ -52,7 +52,7 @@
   /* Light igloo palette — icy glacier on a cool near-white canvas.
      Mirrors the .dark token set below (the dark igloo theme). Both themes are
      contrast-verified by src/test/contrast.test.ts. See docs/design-system.md §5.3.
-     The app currently boots dark (AppBoot.tsx); a theme toggle will activate this. */
+     The app boots from the stored browser theme, defaulting to dark. */
   --radius: 0.625rem;
   --background: oklch(0.974 0.009 247.9); /* icy canvas #F2F7FC */
   --foreground: oklch(0.187 0.034 260.2); /* navy ink #0A1322 */

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { Search, Cast } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import NotificationBell from "@/components/NotificationBell";
+import ThemeToggle from "@/components/ThemeToggle";
 import { inputIconClassName, lightInputClassName } from "@/lib/input-styles";
 
 export default function Header() {
@@ -66,15 +66,7 @@ export default function Header() {
       {/* Utility buttons */}
       <nav className="ml-auto flex shrink-0 items-center gap-1">
         <NotificationBell />
-
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="Cast"
-          className="text-muted-foreground hover:bg-accent hover:text-foreground"
-        >
-          <Cast aria-hidden="true" />
-        </Button>
+        <ThemeToggle />
       </nav>
     </>
   );

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+import { useSyncExternalStore } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getStoredTheme, setTheme, subscribeTheme } from "@/lib/theme";
+
+export default function ThemeToggle() {
+  const theme = useSyncExternalStore(subscribeTheme, getStoredTheme);
+  const nextTheme = theme === "dark" ? "light" : "dark";
+  const label =
+    nextTheme === "light" ? "Switch to light theme" : "Switch to dark theme";
+  const Icon = nextTheme === "light" ? Sun : Moon;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      type="button"
+      aria-label={label}
+      title={label}
+      className="text-muted-foreground hover:bg-muted hover:text-foreground"
+      onClick={() => setTheme(nextTheme)}
+    >
+      <Icon aria-hidden="true" />
+    </Button>
+  );
+}

--- a/web/src/routes/_auth/settings/index.lazy.tsx
+++ b/web/src/routes/_auth/settings/index.lazy.tsx
@@ -15,7 +15,6 @@ import {
   HardDrive,
   KeyRound,
   MonitorCog,
-  Moon,
   RotateCcw,
   Save,
   Sliders,
@@ -45,7 +44,6 @@ import {
   PLAYBACK_SETTINGS_KEY,
 } from "@/lib/constants";
 import { updateGeneralSettings } from "@/lib/api";
-import { getStoredTheme, setTheme, type Theme } from "@/lib/theme";
 import { generalSettingsQueryOpts } from "@/lib/query-opts";
 import {
   showActionFailed,
@@ -233,17 +231,6 @@ function GeneralSettingsForm({ settings }: GeneralSettingsFormProps) {
   const transcodeDirId = useId();
   const enableWatcherId = useId();
   const downloadImagesId = useId();
-  const darkModeId = useId();
-
-  // Theme is a per-device display preference stored in localStorage, not part of
-  // the backend settings form — see @/lib/theme.
-  const [theme, setThemeState] = useState<Theme>(getStoredTheme);
-
-  const handleThemeChange = (dark: boolean) => {
-    const next: Theme = dark ? "dark" : "light";
-    setTheme(next);
-    setThemeState(next);
-  };
 
   const [form, setForm] = useState<UpdateGeneralSettingsRequest>(() =>
     formFromSettings(settings),
@@ -469,33 +456,6 @@ function GeneralSettingsForm({ settings }: GeneralSettingsFormProps) {
             Configure application behavior, integrations, and local storage.
           </CardDescription>
         </CardHeader>
-      </Card>
-
-      <Card
-        className={cn(
-          "border-border/50 bg-muted/30",
-          MOTION_SETTINGS_SURFACE_CLASS,
-        )}
-      >
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-foreground">
-            <Moon className="size-5 text-primary" aria-hidden="true" />
-            Appearance
-          </CardTitle>
-          <CardDescription className="text-muted-foreground">
-            Choose how Igloo looks on this device. Saved in your browser.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-2">
-          <SwitchField
-            id={darkModeId}
-            label="Dark mode"
-            description="Use the dark igloo theme. Turn off for the light theme."
-            checked={theme === "dark"}
-            onCheckedChange={handleThemeChange}
-            icon={<Moon className="size-5 text-primary" aria-hidden="true" />}
-          />
-        </CardContent>
       </Card>
 
       <Card

--- a/web/src/test/theme-toggle.test.tsx
+++ b/web/src/test/theme-toggle.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import ThemeToggle from "@/components/ThemeToggle";
+import { THEME_COLORS, THEME_STORAGE_KEY } from "@/lib/theme";
+
+function themeColorMeta() {
+  return document
+    .querySelector('meta[name="theme-color"]')
+    ?.getAttribute("content");
+}
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+    document.head.innerHTML =
+      '<meta name="theme-color" content="#000000" />';
+  });
+
+  it("toggles the browser theme preference from the top bar", async () => {
+    const user = userEvent.setup();
+
+    render(<ThemeToggle />);
+
+    const lightButton = screen.getByRole("button", {
+      name: "Switch to light theme",
+    });
+    expect(lightButton).toHaveAttribute("title", "Switch to light theme");
+
+    await user.click(lightButton);
+
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(themeColorMeta()).toBe(THEME_COLORS.light);
+
+    const darkButton = screen.getByRole("button", {
+      name: "Switch to dark theme",
+    });
+    expect(darkButton).toHaveAttribute("title", "Switch to dark theme");
+
+    await user.click(darkButton);
+
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(themeColorMeta()).toBe(THEME_COLORS.dark);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme toggle in the app header, letting you switch between light and dark mode.
  * The app now remembers your theme choice and updates the page appearance accordingly.

* **Bug Fixes**
  * Cleaned up Settings by removing the redundant Appearance/dark mode section.
  * Improved UI coverage so theme behavior and settings visibility are verified more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->