### PR TITLE
Fixed the audio player

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -87,9 +87,11 @@ Notes:
 - **Untokenized exceptions to be aware of** (do not hunt for a token for these):
   - `boot.css` splash-message greys `#64748B` (light) / `#94A3B8` (dark) are
     hardcoded, not drawn from `muted-foreground`.
-  - The media cards (`MovieCard`, `AlbumCard`) use raw `bg-black/30`, `bg-black/40`,
-    `text-white`, and a `from-black/90` poster gradient. White-on-darkened-poster is a
-    legitimate over-media pattern; port it as literal black/alpha + white, not tokens.
+  - The media cards use raw black/alpha + white over posters: `MovieCard` uses
+    `bg-black/30` (dim overlay), `text-white`, and a `from-black/90` poster gradient;
+    `AlbumCard` uses `bg-black/40` (dim overlay). Both share `shadow-black/30`.
+    White-on-darkened-poster is a legitimate over-media pattern; port it as literal
+    black/alpha + white, not tokens.
 - All token pairs pass their contrast budget in both themes (verified by
   `contrast.test.ts`); e.g. `success-foreground` on `success` measures ~4.96:1 (light)
   and ~9.73:1 (dark).
@@ -350,8 +352,10 @@ All media cards share style constants in `web/src/lib/constants.ts`
   tracks". No Play button; focus just zooms + lifts.
 - **`TrackItem.tsx`** — list row, variants `library | playlist | musician | album`. In
   album variant a track index swaps to a spinner/primary color when playing. **Caveat**:
-  in musician/album variants the Play button is `opacity-0` until hover — on TV, always
-  show it or reveal on **row focus**. Rows also carry a Like heart and an actions menu.
+  in musician/album variants the Play button is `sm:opacity-0` until hover (`sm:opacity-0
+  sm:group-hover:opacity-100`), so it hides only on `sm`+ screens and is always visible on
+  touch/small screens — on TV, always show it or reveal on **row focus**. Rows also carry a
+  Like heart and an actions menu.
 
 ### 3.4 Media playback UX
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -352,10 +352,12 @@ All media cards share style constants in `web/src/lib/constants.ts`
   tracks". No Play button; focus just zooms + lifts.
 - **`TrackItem.tsx`** — list row, variants `library | playlist | musician | album`. In
   album variant a track index swaps to a spinner/primary color when playing. **Caveat**:
-  in musician/album variants the Play button is `sm:opacity-0` until hover (`sm:opacity-0
-  sm:group-hover:opacity-100`), so it hides only on `sm`+ screens and is always visible on
-  touch/small screens — on TV, always show it or reveal on **row focus**. Rows also carry a
-  Like heart and an actions menu.
+  in musician/album variants the Play button is always visible on touch/small screens but
+  hidden on `sm`+ until row hover or keyboard focus (`sm:opacity-0 sm:group-hover:opacity-100
+  sm:focus-visible:opacity-100`), and it stays visible on the **current track** regardless —
+  a port must keep the keyboard-focus and current-track paths so the control is never hidden
+  from keyboard users or on the active row. On TV, always show it or reveal on **row focus**.
+  Rows also carry a Like heart and an actions menu.
 
 ### 3.4 Media playback UX
 

--- a/docs/ffmpeg.md
+++ b/docs/ffmpeg.md
@@ -72,7 +72,9 @@ When a client requests a personal HLS playlist:
 
 `audio_track` is omitted for video-only movies. Igloo loads the movie and stream metadata from the database, creates a temp directory, starts FFmpeg in the background, caches the session, and returns a VOD-style playlist to the browser. Segment requests then read files from the session temp directory as FFmpeg produces them.
 
-Personal HLS sessions are keyed by movie ID, requested profile, audio track, playback session ID, and start time. If the same request arrives again, Igloo refreshes the cached session TTL and reuses the process. When a new personal session is created for the same movie, user, and playback session ID, older sessions for that playback session are cleaned up so seeks and reloads do not leave extra FFmpeg processes running. Concurrent creation is deduplicated with singleflight so multiple near-simultaneous manifest requests do not start duplicate transcodes for the same session.
+Personal HLS sessions are keyed by movie ID, requested profile, audio track, playback session ID, and start time. If the same request arrives again, Igloo refreshes the cached session TTL and reuses the process. When a new personal session is created for the same movie, user, and playback session ID, older sessions for that playback session are cleaned up so seeks and reloads do not leave extra FFmpeg processes running. Concurrent creation is deduplicated with singleflight so multiple near-simultaneous manifest requests do not start duplicate transcodes for the same session. Clients can also tear a playback session's HLS sessions down explicitly with `POST /api/movies/{id}/hls/session/stop`.
+
+HLS requests additionally accept an optional `reload` query parameter. It is an opaque client-supplied value that is echoed into the rewritten playlist asset URLs; it is not part of the session cache key.
 
 FFmpeg runs with `context.Background()` after session creation. This is deliberate: an HLS process must outlive the HTTP request that created it, because the browser will request the manifest and segments as separate requests. The session cache owns the lifecycle. Expiration, eviction, room cleanup, or server shutdown stops the process and removes the temp directory.
 
@@ -160,25 +162,29 @@ The `fast` preset is a practical default for self-hosted playback: it improves s
 When the source frame rate is known, Igloo sets a fixed 4-second GOP:
 
 ```text
--g:v:0 <segment_time*fps> -keyint_min:v:0 <segment_time*fps>
+-g:v:0 <ceil(segment_time*fps)> -keyint_min:v:0 <ceil(segment_time*fps)>
 ```
 
-Hardware encoders rely on that fixed GOP when the frame rate is known. Software transcodes, and hardware transcodes with unknown frame rate, also use forced keyframe expressions:
+Every transcode, regardless of encoder, also uses a forced keyframe expression:
 
 ```text
 -force_key_frames:0 expr:gte(t,n_forced*4)
 ```
 
-Both paths align keyframes with the 4-second HLS segment target. Without predictable keyframes, HLS segments can drift, seek behavior gets worse, and browsers may wait longer for independently decodable frames.
+The GOP flags make the GOP the right size, while `-force_key_frames` is what actually pins keyframes to the exact segment timestamps so every HLS segment starts on an IDR frame. GOP counting alone drifts on VFR sources and non-integer frame rates (23.976 fps rounds to a 96-frame GOP, which is about 4.004 seconds), splitting segments later and later. Without predictable keyframes, HLS segments can drift, seek behavior gets worse, and browsers may wait longer for independently decodable frames.
 
 FFmpeg also runs with:
 
 - `-fflags +genpts` to generate timestamps when sources have missing or awkward presentation timestamps.
 - `-analyzeduration 5000000` and `-probesize 5000000` to give FFmpeg enough input data to identify streams without making startup unbounded.
+- `-readrate 4` and `-readrate_initial_burst 60`, when the FFmpeg build supports those CLI options, so a session reads input at most 4x realtime after an initial 60-second burst instead of racing arbitrarily far ahead of playback.
+- `-map_metadata -1` and `-map_chapters -1` to keep source metadata and chapter markers out of HLS output.
 - `-avoid_negative_ts make_zero` to normalize output timestamps.
 - `-max_muxing_queue_size 1024` to tolerate sources with stream timing that would otherwise overflow FFmpeg's muxing queue.
 
-Igloo does not pass `-threads` to FFmpeg. libx264 and the hardware encoders choose their own per-process thread behavior. Total pressure on a home server is bounded by the HLS transcode limiter instead: `HLS_MAX_CPU_TRANSCODES` sets the maximum number of concurrent HLS FFmpeg sessions, and the default is `max(1, runtime.NumCPU()/4)`.
+Transcodes also tag output color explicitly: the output gets `-color_primaries bt709 -color_trc bt709 -colorspace bt709`, every video filter chain ends with a matching `setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709`, and `-pix_fmt yuv420p` is set for all encoders except `h264_qsv` and the CUDA filter paths, which control their pixel format inside the filter chain.
+
+Igloo does not pass `-threads` to FFmpeg. libx264 and the hardware encoders choose their own per-process thread behavior. Total pressure on a home server is bounded by the HLS transcode limiter instead: `HLS_MAX_CPU_TRANSCODES` sets the maximum number of concurrent HLS transcode sessions, and the default is `max(1, runtime.NumCPU()/4)`. Copy-video (remux) sessions bypass the limiter because they do not encode video.
 
 ## Audio Handling
 
@@ -222,7 +228,7 @@ The FFmpeg encoder mapping is:
 | --- | --- | --- | --- |
 | `cpu` | none | `libx264` | Any supported runtime |
 | `apple` | `-hwaccel videotoolbox` | `h264_videotoolbox` | macOS with VideoToolbox-capable FFmpeg |
-| `nvidia` | software decode; CUDA filter device only when `scale_cuda`/`tonemap_cuda` probes pass | `h264_nvenc` | Linux with NVIDIA driver/runtime support |
+| `nvidia` | `-hwaccel cuda` when the `cuda` hwaccel is probed; CUDA filter device only when `scale_cuda`/`tonemap_cuda` probes pass | `h264_nvenc` | Linux with NVIDIA driver/runtime support |
 | `intel` | software decode by default; QSV filter device only when SDR `scale_qsv` is probed usable | `h264_qsv` | Linux with Intel QSV support |
 
 NVIDIA adds:
@@ -243,7 +249,7 @@ Igloo only sends those Intel encoder options when the probed FFmpeg build lists 
 
 At startup, after the `-version` executability check, Igloo probes FFmpeg for encoders, filters, hardware acceleration methods, key filter options, encoder options, and selected runtime filter chains. CPU, unknown devices, missing hardware encoders, failed NVENC runtime probes, failed QSV runtime probes, and missing Apple VideoToolbox encoder support fall back to `libx264`. This is intentional: an invalid or unavailable hardware mode should not create a new unsupported encoder path inside the argument builder. The settings API validates known device names, but the HLS builder still has a safe CPU fallback.
 
-NVIDIA encode is checked with a short runtime encode probe, not just by looking for `h264_nvenc` in `ffmpeg -encoders`. Igloo does not use `-hwaccel cuda` for HLS because hardware decode support depends on the source codec and profile. For SDR transcodes, NVIDIA normally uses software decode and software scaling into `yuv420p` frames before `h264_nvenc` encode:
+NVIDIA encode is checked with a short runtime encode probe, not just by looking for `h264_nvenc` in `ffmpeg -encoders`. When the probed build supports the `cuda` hwaccel, NVIDIA transcodes add `-hwaccel cuda` without `-hwaccel_output_format`: FFmpeg decodes on the GPU when the source codec is supported and transparently falls back to software decode otherwise, and decoded frames land in system memory either way, so the same filter chains work in both cases. For SDR transcodes, NVIDIA normally uses software scaling into `yuv420p` frames before `h264_nvenc` encode:
 
 ```text
 scale=-2:<height>,format=yuv420p
@@ -256,9 +262,7 @@ If NVENC is usable and FFmpeg also exposes `cuda`, `hwupload`, `scale_cuda`, the
 -vf format=nv12,hwupload,scale_cuda=w=-2:h=<height>:format=yuv420p
 ```
 
-Igloo does not use `-hwaccel cuda` for this path. Software decode avoids failing playback on files whose source decode path is unsupported by the GPU while still allowing CUDA filters and NVENC encode when those runtime probes pass.
-
-Intel QSV encode is checked with a short runtime encode probe, not just by looking for `h264_qsv` in `ffmpeg -encoders`. For SDR transcodes, Igloo normally uses software decode and software scaling into `nv12` frames before `h264_qsv` encode:
+Intel QSV encode is checked with a short runtime encode probe, not just by looking for `h264_qsv` in `ffmpeg -encoders`. Unlike CUDA, QSV decode is intentionally not enabled: FFmpeg's generic `-hwaccel qsv` does not fall back to software decode as reliably across driver stacks. For SDR transcodes, Igloo uses software decode and normally software scaling into `nv12` frames before `h264_qsv` encode:
 
 ```text
 scale=-2:<height>,format=nv12
@@ -270,8 +274,6 @@ If QSV encode is usable and FFmpeg also exposes `qsv`, `scale_qsv`, the `scale_q
 -init_hw_device qsv=igloo_qsv -filter_hw_device igloo_qsv
 -vf format=nv12,hwupload=extra_hw_frames=64,scale_qsv=w=-2:h=<height>:format=nv12
 ```
-
-Igloo does not use `-hwaccel qsv` for the default Intel encode-only path.
 
 NVIDIA and Intel hardware acceleration require host drivers, device access, and an FFmpeg build with the matching encoder support. Apple VideoToolbox is available only on macOS builds with a VideoToolbox-capable FFmpeg binary.
 
@@ -335,7 +337,7 @@ The HLS manifest accepts a `start` query parameter. When `start` is greater than
 
 Igloo exposes the rebased session as a VOD playlist. The files on disk start at `segment_0.m4s`, but the UI keeps absolute movie time. When a seek requires a different offset, the client asks for a manifest with a new `start` value and Igloo creates a new session.
 
-Final playlists from completed rebased sessions can include accurate FFmpeg segment durations for the generated portion. Igloo fills earlier timeline space with placeholder durations so hls.js has a coherent total-duration timeline.
+A rebased session's playlist covers only the remaining time from the start offset to the end of the movie. While FFmpeg is still encoding, Igloo generates the VOD playlist from that remaining duration; after FFmpeg exits successfully, the finalized FFmpeg playlist with accurate segment durations is served with only its asset URLs rewritten. The client is responsible for mapping session-local playback time back to absolute movie time in the UI.
 
 This is more complex than exposing FFmpeg's event playlist directly, but it gives browser players the behavior users expect from a movie: visible duration, seeking, resume, and a stable VOD presentation.
 
@@ -362,7 +364,7 @@ The endpoint:
 uses `trackIndex` as the 0-based index into the movie's stored subtitle rows. It then maps that row back to the absolute ffprobe stream index and runs FFmpeg:
 
 ```text
-ffmpeg -v error -y -i <source> -map 0:<stream_index> -c:s webvtt -f webvtt pipe:1
+ffmpeg -v error -i <source> -map 0:<stream_index> -c:s webvtt -f webvtt pipe:1
 ```
 
 The output is returned directly from stdout and cached for one hour by movie ID and stream index. The request has a 60-second timeout so a difficult subtitle track cannot tie up a request indefinitely.
@@ -383,7 +385,7 @@ For binary deployments:
 
 - `TRANSCODE_DIR` seeds the Settings transcode directory on first launch; after that, edit it from Settings.
 - HLS temp output is written below the Settings transcode directory.
-- `HLS_MAX_CPU_TRANSCODES` is read at startup and limits concurrent HLS FFmpeg sessions. It is not stored in Settings.
+- `HLS_MAX_CPU_TRANSCODES` is read at startup and limits concurrent HLS transcode sessions; copy-video (remux) sessions are not counted. It is not stored in Settings.
 - Configured media directories should be readable by the Igloo process. Igloo does not need write access to media libraries.
 
 For local development:

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren } from "react";
+import { useContext, type PropsWithChildren } from "react";
 import Header from "@/components/Header";
 import AppSidebar from "@/components/app-sidebar";
 import {
@@ -6,8 +6,20 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { AudioPlayerStateContext } from "@/context/AudioPlayerContext";
+import { cn } from "@/lib/utils";
 
 export default function AppShell({ children }: PropsWithChildren) {
+  // Read the context directly (not useAudioPlayerState) so the shell also
+  // renders outside AudioPlayerProvider, e.g. in isolated tests.
+  const playerState = useContext(AudioPlayerStateContext);
+  // The minimized audio player is a fixed bottom bar; reserve space for it so
+  // the last rows of any page stay reachable while music plays.
+  const isMiniPlayerVisible =
+    playerState !== null &&
+    playerState.currentTrack !== null &&
+    !playerState.isExpanded;
+
   const handleSkipToContent = () => {
     requestAnimationFrame(() => {
       document.getElementById("main")?.focus();
@@ -36,7 +48,12 @@ export default function AppShell({ children }: PropsWithChildren) {
           <Header />
         </header>
 
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto px-4 py-6 sm:px-6 lg:px-8">
+        <div
+          className={cn(
+            "flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto px-4 py-6 sm:px-6 lg:px-8",
+            isMiniPlayerVisible && "pb-28 sm:pb-24",
+          )}
+        >
           {children}
         </div>
       </SidebarInset>

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -114,6 +114,13 @@ export default function AudioPlayer({
     currentTrackId !== lastState.trackId ||
     isPlaying !== lastState.isPlaying
   ) {
+    if (currentTrackId !== lastState.trackId) {
+      // The <audio> element persists across track changes, so the old track's
+      // position/duration would otherwise show until the new track's
+      // timeupdate/durationchange events fire.
+      setCurrentTime(0);
+      setDuration(0);
+    }
     if (!track) {
       setAnnouncement("");
     } else if (lastState.trackId !== null) {
@@ -190,11 +197,14 @@ export default function AudioPlayer({
   }, [isExpanded]);
 
   useEffect(() => {
-    if (
-      !track ||
-      !("mediaSession" in navigator) ||
-      typeof MediaMetadata === "undefined"
-    ) {
+    if (!("mediaSession" in navigator)) {
+      return;
+    }
+
+    // Clear stale lock-screen/OS media info once playback stops; otherwise
+    // the last track keeps showing after the player is closed.
+    if (!track || typeof MediaMetadata === "undefined") {
+      navigator.mediaSession.metadata = null;
       return;
     }
 

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -679,6 +679,7 @@ export default function AudioPlayer({
                 duration={duration}
                 onSeek={handleSeek}
                 variant="expanded"
+                resetKey={track.id}
               />
 
               <div
@@ -849,6 +850,7 @@ export default function AudioPlayer({
                 duration={duration}
                 onSeek={handleSeek}
                 variant="minimized"
+                resetKey={track.id}
               />
 
               <div className="hidden sm:block">
@@ -890,6 +892,7 @@ export default function AudioPlayer({
               duration={duration}
               onSeek={handleSeek}
               variant="mobile"
+              resetKey={track.id}
             />
           </div>
         </div>

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -29,6 +29,10 @@ import { cn } from "@/lib/utils";
 type AudioPlayerProps = {
   track: TrackType | null;
   tracks: TrackType[];
+  // Played tracks trimmed from the front of an endless queue; added back into
+  // the "Track N of M" counter so it never jumps backwards. Finite queues
+  // never trim, so the default keeps the counter untouched.
+  trimmedCount?: number;
   albumCover: string | null;
   albumTitle: string;
   musicianName: string | null;
@@ -75,6 +79,7 @@ function mediaSessionSupported() {
 export default function AudioPlayer({
   track,
   tracks,
+  trimmedCount = 0,
   albumCover,
   albumTitle,
   musicianName,
@@ -751,7 +756,8 @@ export default function AudioPlayer({
               </div>
 
               <p className="mt-4 text-sm text-muted-foreground">
-                Track {currentIndex + 1} of {tracks.length}
+                Track {trimmedCount + currentIndex + 1} of{" "}
+                {trimmedCount + tracks.length}
               </p>
             </main>
           </DialogFullscreenContent>

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -43,6 +43,27 @@ type AudioPlayerProps = {
   isKeyboardSuspended?: boolean;
 };
 
+// "Previous" restarts the current track instead of navigating once playback
+// has passed this many seconds.
+const RESTART_THRESHOLD_SECONDS = 3;
+
+// Controls whose native keyboard interaction must win over the global
+// playback shortcuts.
+const INTERACTIVE_SELECTOR =
+  'button, a[href], select, summary, [role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"], [role="option"], [role="tab"], [role="radio"], [role="checkbox"], [role="switch"], [role="slider"], [role="spinbutton"]';
+
+// Overlays that own their keyboard interaction entirely. The player's own
+// fullscreen dialog is exempted via the data-audio-player marker.
+const FOREIGN_OVERLAY_SELECTOR =
+  '[role="dialog"]:not([data-audio-player]), [role="alertdialog"], [role="menu"], [role="listbox"]';
+
+const ARROW_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+]);
+
 function mediaSessionSupported() {
   return (
     typeof navigator !== "undefined" &&
@@ -110,7 +131,7 @@ export default function AudioPlayer({
   const currentIndex = track ? tracks.findIndex(t => t.id === track.id) : -1;
   const hasPrevious = currentIndex > 0;
   const hasNext = currentIndex < tracks.length - 1 && currentIndex !== -1;
-  const prevAriaLabel = hasPrevious ? "Previous track" : "No previous track";
+  const prevAriaLabel = "Previous track";
   const nextAriaLabel = hasNext ? "Next track" : "No next track";
   const playPauseAriaLabel = isPlaying ? "Pause" : "Play";
   const streamUrl = track ? `/api/music/tracks/${track.id}/stream` : null;
@@ -123,6 +144,23 @@ export default function AudioPlayer({
       await audio.play();
     } catch {
       // Autoplay can still be blocked by the browser in some cases.
+    }
+  };
+
+  // Spotify-style previous: within the first few seconds go to the previous
+  // track; otherwise (or when there is no previous track) restart the current
+  // one. The button therefore never needs to be disabled.
+  const playPrevious = () => {
+    const audio = audioRef.current;
+
+    if (hasPrevious && (audio?.currentTime ?? 0) <= RESTART_THRESHOLD_SECONDS) {
+      onTrackChange(tracks[currentIndex - 1]);
+      return;
+    }
+
+    if (audio) {
+      audio.currentTime = 0;
+      setCurrentTime(0);
     }
   };
 
@@ -197,9 +235,7 @@ export default function AudioPlayer({
   });
 
   const handleMediaSessionPrevious = useEffectEvent(() => {
-    if (hasPrevious) {
-      onTrackChange(tracks[currentIndex - 1]);
-    }
+    playPrevious();
   });
 
   const handleMediaSessionNext = useEffectEvent(() => {
@@ -388,18 +424,42 @@ export default function AudioPlayer({
       return;
     }
 
-    const target = event.target as HTMLElement;
+    const target = event.target instanceof HTMLElement ? event.target : null;
 
     if (
-      target.tagName === "INPUT" ||
-      target.tagName === "TEXTAREA" ||
-      target.isContentEditable
+      target &&
+      (target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable)
     ) {
       return;
     }
 
     if (event.ctrlKey || event.metaKey || event.altKey) {
       return;
+    }
+
+    if (target) {
+      if (target.closest(FOREIGN_OVERLAY_SELECTOR)) {
+        return;
+      }
+
+      const interactive = target.closest(INTERACTIVE_SELECTOR);
+      if (interactive) {
+        // Space must activate the focused control everywhere, and arrow keys
+        // belong to widgets like tabs and radios — except inside the player's
+        // own chrome, where arrows keep seeking and adjusting volume.
+        if (event.key === " ") {
+          return;
+        }
+
+        if (
+          ARROW_KEYS.has(event.key) &&
+          !interactive.closest("[data-audio-player]")
+        ) {
+          return;
+        }
+      }
     }
 
     switch (event.key) {
@@ -441,9 +501,7 @@ export default function AudioPlayer({
       case "P":
       case "MediaTrackPrevious":
         event.preventDefault();
-        if (hasPrevious) {
-          onTrackChange(tracks[currentIndex - 1]);
-        }
+        playPrevious();
         break;
       case "r":
       case "R":
@@ -473,12 +531,6 @@ export default function AudioPlayer({
       void playAudio();
     } else {
       audio.pause();
-    }
-  };
-
-  const playPrevious = () => {
-    if (hasPrevious) {
-      onTrackChange(tracks[currentIndex - 1]);
     }
   };
 
@@ -517,8 +569,16 @@ export default function AudioPlayer({
   return (
     <>
       <audio ref={audioRef} preload="metadata" className="hidden">
-        {streamUrl && <source src={streamUrl} type={track.mime_type} />}
+        {streamUrl && (
+          <source src={streamUrl} type={track.mime_type || undefined} />
+        )}
       </audio>
+
+      {/* Rendered outside the dialog so track changes and play/pause are
+          still announced while the player is minimized. */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </div>
 
       <Dialog
         open={isExpanded}
@@ -530,6 +590,7 @@ export default function AudioPlayer({
       >
         {isExpanded && (
           <DialogFullscreenContent
+            data-audio-player=""
             className={cn(
               MOTION_MEDIA_OVERLAY_ENTER_CLASS,
               "flex flex-col bg-linear-to-b from-background via-muted to-background",
@@ -548,10 +609,6 @@ export default function AudioPlayer({
             <DialogDescription className="sr-only">
               Press Escape to minimize.
             </DialogDescription>
-
-            <div className="sr-only" aria-live="polite" aria-atomic="true">
-              {announcement}
-            </div>
 
             <header className="flex items-center justify-between px-6 py-4">
               <button
@@ -632,10 +689,9 @@ export default function AudioPlayer({
                 <button
                   type="button"
                   onClick={playPrevious}
-                  disabled={!hasPrevious}
                   className={cn(
                     MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-14 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none disabled:cursor-not-allowed disabled:opacity-30",
+                    "flex size-14 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none",
                   )}
                   aria-label={prevAriaLabel}
                 >
@@ -665,10 +721,10 @@ export default function AudioPlayer({
                 <button
                   type="button"
                   onClick={playNext}
-                  disabled={!hasNext}
+                  aria-disabled={!hasNext}
                   className={cn(
                     MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-14 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none disabled:cursor-not-allowed disabled:opacity-30",
+                    "flex size-14 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-30",
                   )}
                   aria-label={nextAriaLabel}
                 >
@@ -695,6 +751,7 @@ export default function AudioPlayer({
         <div
           role="region"
           aria-label="Audio player"
+          data-audio-player=""
           className={cn(
             MOTION_PLAYER_CHROME_ENTER_CLASS,
             "fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 shadow-2xl shadow-black/50 backdrop-blur-lg",
@@ -745,10 +802,9 @@ export default function AudioPlayer({
                 <button
                   type="button"
                   onClick={playPrevious}
-                  disabled={!hasPrevious}
                   className={cn(
                     MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-30",
+                    "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-none",
                   )}
                   aria-label={prevAriaLabel}
                 >
@@ -777,10 +833,10 @@ export default function AudioPlayer({
                 <button
                   type="button"
                   onClick={playNext}
-                  disabled={!hasNext}
+                  aria-disabled={!hasNext}
                   className={cn(
                     MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-30",
+                    "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-30",
                   )}
                   aria-label={nextAriaLabel}
                 >

--- a/web/src/components/ProgressBar.tsx
+++ b/web/src/components/ProgressBar.tsx
@@ -20,6 +20,7 @@ type ProgressBarProps = {
   variant: ProgressBarVariant;
   ariaLabel?: string;
   groupLabel?: string;
+  resetKey?: string | number;
 };
 
 // Variant-specific styles
@@ -95,12 +96,20 @@ export default function ProgressBar({
   variant,
   ariaLabel = "Seek through track",
   groupLabel = "Playback progress",
+  resetKey,
 }: ProgressBarProps) {
   const styles = variantStyles[variant];
   // While the user is scrubbing, the media element's currentTime lags behind
   // (seeks are async), so the displayed position follows the pending scrub
   // value instead of snapping back to the stale currentTime prop.
   const [scrubTime, setScrubTime] = useState<number | null>(null);
+  // When the playing media changes (e.g. track auto-advance mid-drag), a
+  // pending scrub value belongs to the old media and must not carry over.
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    setScrubTime(null);
+  }
   const safeDuration =
     Number.isFinite(duration) && duration > 0 ? duration : 0;
   const isSeekable = safeDuration > 0;
@@ -194,6 +203,7 @@ export default function ProgressBar({
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         onPointerUp={clearScrub}
+        onPointerCancel={clearScrub}
         onBlur={clearScrub}
         tabIndex={isSeekable ? 0 : -1}
         className={cn(

--- a/web/src/components/ProgressBar.tsx
+++ b/web/src/components/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useState } from "react";
 import { formatTimeSeconds } from "@/lib/format";
 import {
   MOTION_PROGRESS_FILL_CLASS,
@@ -36,25 +36,25 @@ const variantStyles: Record<
 > = {
   expanded: {
     container: "mb-6 w-full max-w-md",
-    bar: "group relative h-2 cursor-pointer rounded-full bg-muted focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none",
+    bar: "group relative h-2 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
     thumb:
-      "absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-lg group-hover:opacity-100 group-focus:opacity-100",
+      "absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100",
     timeText: "text-sm text-muted-foreground tabular-nums",
     showTimes: true,
     timesLayout: "below",
   },
   minimized: {
     container: "hidden max-w-md flex-1 items-center gap-3 sm:flex",
-    bar: "group relative h-1.5 flex-1 cursor-pointer rounded-full bg-muted focus:ring-2 focus:ring-ring focus:outline-none",
+    bar: "group relative h-1.5 flex-1 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring",
     thumb:
-      "absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-md group-hover:opacity-100 group-focus:opacity-100",
+      "absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-md group-hover:opacity-100 group-focus-within:opacity-100",
     timeText: "w-10 text-xs text-muted-foreground tabular-nums",
     showTimes: true,
     timesLayout: "inline",
   },
   mobile: {
     container: "mt-2 sm:hidden",
-    bar: "relative h-1 cursor-pointer rounded-full bg-muted focus:ring-2 focus:ring-ring focus:outline-none",
+    bar: "relative h-1 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring",
     thumb: "", // No thumb on mobile for cleaner look
     timeText: "text-xs text-muted-foreground tabular-nums",
     showTimes: true,
@@ -62,18 +62,18 @@ const variantStyles: Record<
   },
   video: {
     container: "mb-4 w-full",
-    bar: "group relative h-2 cursor-pointer rounded-full bg-muted focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none",
+    bar: "group relative h-2 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
     thumb:
-      "absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-lg group-hover:opacity-100 group-focus:opacity-100",
+      "absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100",
     timeText: "text-sm text-muted-foreground tabular-nums",
     showTimes: true,
     timesLayout: "below",
   },
   trailer: {
     container: "mb-4 w-full",
-    bar: "group relative h-1.5 cursor-pointer rounded-full bg-muted focus:ring-2 focus:ring-ring focus:outline-none",
+    bar: "group relative h-1.5 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring",
     thumb:
-      "absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-md group-hover:opacity-100 group-focus:opacity-100",
+      "absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-md group-hover:opacity-100 group-focus-within:opacity-100",
     timeText: "text-sm text-muted-foreground tabular-nums",
     showTimes: false,
     timesLayout: "below",
@@ -97,12 +97,15 @@ export default function ProgressBar({
   groupLabel = "Playback progress",
 }: ProgressBarProps) {
   const styles = variantStyles[variant];
-  const activePointerIdRef = useRef<number | null>(null);
+  // While the user is scrubbing, the media element's currentTime lags behind
+  // (seeks are async), so the displayed position follows the pending scrub
+  // value instead of snapping back to the stale currentTime prop.
+  const [scrubTime, setScrubTime] = useState<number | null>(null);
   const safeDuration =
     Number.isFinite(duration) && duration > 0 ? duration : 0;
   const isSeekable = safeDuration > 0;
   const safeCurrentTime = isSeekable
-    ? clampToRange(currentTime, 0, safeDuration)
+    ? clampToRange(scrubTime ?? currentTime, 0, safeDuration)
     : 0;
   const progress = isSeekable ? (safeCurrentTime / safeDuration) * 100 : 0;
   const pageSeekStep = Math.min(30, Math.max(10, safeDuration * 0.1));
@@ -120,61 +123,18 @@ export default function ProgressBar({
     onSeek(clampToRange(nextTime, 0, safeDuration));
   };
 
-  const getSeekTime = (e: React.PointerEvent<HTMLDivElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!isSeekable) {
-      return 0;
-    }
-
-    const rect = e.currentTarget.getBoundingClientRect();
-    if (rect.width <= 0) {
-      return 0;
-    }
-
-    const x = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
-    return (x / rect.width) * safeDuration;
-  };
-
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isSeekable || !e.isPrimary || activePointerIdRef.current !== null) return;
-
-    activePointerIdRef.current = e.pointerId;
-    e.currentTarget.setPointerCapture?.(e.pointerId);
-    seekTo(getSeekTime(e));
-  };
-
-  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isSeekable || activePointerIdRef.current !== e.pointerId) return;
-
-    seekTo(getSeekTime(e));
-  };
-
-  const releasePointerDrag = (e: React.PointerEvent<HTMLDivElement>) => {
-    const activePointerId = activePointerIdRef.current;
-    if (
-      activePointerId !== null &&
-      e.currentTarget.hasPointerCapture?.(activePointerId)
-    ) {
-      e.currentTarget.releasePointerCapture(activePointerId);
-    }
-    activePointerIdRef.current = null;
-  };
-
-  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (activePointerIdRef.current !== e.pointerId) return;
-
-    if (isSeekable) {
-      seekTo(getSeekTime(e));
-    }
-
-    releasePointerDrag(e);
-  };
-
-  const handlePointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (activePointerIdRef.current !== e.pointerId) {
       return;
     }
 
-    releasePointerDrag(e);
+    const nextTime = clampToRange(e.target.valueAsNumber, 0, safeDuration);
+    setScrubTime(nextTime);
+    onSeek(nextTime);
+  };
+
+  const clearScrub = () => {
+    setScrubTime(null);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -211,31 +171,7 @@ export default function ProgressBar({
   };
 
   const slider = (
-    <div
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerCancel}
-      onKeyDown={handleKeyDown}
-      tabIndex={isSeekable ? 0 : -1}
-      className={cn(
-        styles.bar,
-        isSeekable && "touch-none",
-        !isSeekable && "cursor-default opacity-60",
-      )}
-      role="slider"
-      aria-label={ariaLabel}
-      aria-disabled={!isSeekable}
-      aria-orientation="horizontal"
-      aria-valuenow={Math.round(safeCurrentTime)}
-      aria-valuemin={0}
-      aria-valuemax={Math.round(safeDuration)}
-      aria-valuetext={
-        isSeekable
-          ? `${formatTimeSeconds(safeCurrentTime)} of ${formatTimeSeconds(safeDuration)}`
-          : "Seek unavailable"
-      }
-    >
+    <div className={cn(styles.bar, !isSeekable && "opacity-60")}>
       <div
         className={fillClassName}
         style={{ width: `${progress}%` }}
@@ -246,6 +182,32 @@ export default function ProgressBar({
           style={{ left: `${progress}%` }}
         />
       )}
+      {/* A transparent native range input handles all interaction: unlike a
+          custom role="slider" div, it stays operable with iOS VoiceOver's
+          adjustable gestures, which never reach pointer or keydown handlers. */}
+      <input
+        type="range"
+        min={0}
+        max={isSeekable ? safeDuration : 0}
+        step={1}
+        value={safeCurrentTime}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onPointerUp={clearScrub}
+        onBlur={clearScrub}
+        tabIndex={isSeekable ? 0 : -1}
+        className={cn(
+          "absolute top-1/2 left-0 h-6 w-full -translate-y-1/2 appearance-none bg-transparent opacity-0 focus:outline-none",
+          isSeekable ? "cursor-pointer touch-none" : "cursor-default",
+        )}
+        aria-label={ariaLabel}
+        aria-disabled={!isSeekable}
+        aria-valuetext={
+          isSeekable
+            ? `${formatTimeSeconds(safeCurrentTime)} of ${formatTimeSeconds(safeDuration)}`
+            : "Seek unavailable"
+        }
+      />
     </div>
   );
 

--- a/web/src/components/VolumeControl.tsx
+++ b/web/src/components/VolumeControl.tsx
@@ -182,9 +182,6 @@ export default function VolumeControl({
       onChange={handleVolumeChange}
       className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
       aria-label="Volume"
-      aria-valuenow={volumePercent}
-      aria-valuemin={0}
-      aria-valuemax={100}
       aria-valuetext={`${volumePercent}% volume`}
     />
   );

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -20,12 +20,16 @@ import {
   convertToAudioTrack,
   extractTrackMetadata,
   shuffleArray,
+  trimQueueHistory,
 } from "@/lib/audio-utils";
 
 const MINIMUM_PLAY_SECONDS = 30;
 const COMPLETION_THRESHOLD = 0.8;
 const PLAY_CHECK_INTERVAL_MS = 5000;
 const MAX_SHUFFLE_FETCH_ATTEMPTS = 3;
+// Endless queues (shuffle, play all) are trimmed when a new batch is appended;
+// this many played tracks stay reachable via previous-track navigation.
+const MAX_TRACKS_BEHIND = 50;
 
 type QueueState = Omit<
   AudioPlayerState,
@@ -41,6 +45,7 @@ function createInitialQueueState(): QueueState {
     musicianName: null,
     isShuffleMode: false,
     isPlayAllMode: false,
+    trimmedCount: 0,
   };
 }
 
@@ -89,6 +94,32 @@ export function AudioPlayerProvider({
       trackMusiciansRef.current.set(track.id, musician);
       trackAlbumTitlesRef.current.set(track.id, albumTitle);
     }
+  };
+
+  // Append a fetched batch to an endless queue, trimming played tracks beyond
+  // MAX_TRACKS_BEHIND and pruning their metadata so multi-hour shuffle or
+  // play-all sessions stay bounded. The map deletions are idempotent, so
+  // StrictMode's double-invoked updater is harmless.
+  const appendToQueue = (appended: TrackType[]) => {
+    setQueueState(prev => {
+      const { tracks: kept, dropped } = trimQueueHistory(
+        prev.tracks,
+        prev.currentTrack?.id ?? null,
+        MAX_TRACKS_BEHIND,
+      );
+
+      for (const track of dropped) {
+        trackCoversRef.current?.delete(track.id);
+        trackMusiciansRef.current?.delete(track.id);
+        trackAlbumTitlesRef.current?.delete(track.id);
+      }
+
+      return {
+        ...prev,
+        tracks: [...kept, ...appended],
+        trimmedCount: prev.trimmedCount + dropped.length,
+      };
+    });
   };
 
   const clearMetadataRefs = () => {
@@ -167,10 +198,7 @@ export function AudioPlayerProvider({
       }
 
       if (!isCancelled && collected.length > 0) {
-        setQueueState(prev => ({
-          ...prev,
-          tracks: [...prev.tracks, ...collected],
-        }));
+        appendToQueue(collected);
       }
 
       isFetchingMoreRef.current = false;
@@ -215,10 +243,7 @@ export function AudioPlayerProvider({
           playAllOffsetRef.current += rawTracks.length;
 
           if (newTracks.length > 0) {
-            setQueueState(prev => ({
-              ...prev,
-              tracks: [...prev.tracks, ...newTracks],
-            }));
+            appendToQueue(newTracks);
           }
         }
       } catch {
@@ -324,6 +349,7 @@ export function AudioPlayerProvider({
       musicianName: albumInfo.musician,
       isShuffleMode,
       isPlayAllMode,
+      trimmedCount: 0,
     });
     setIsExpanded(true);
   };
@@ -533,6 +559,7 @@ export function AudioPlayerProvider({
         <AudioPlayer
           track={queueState.currentTrack}
           tracks={queueState.tracks}
+          trimmedCount={queueState.trimmedCount}
           albumCover={queueState.albumCover}
           albumTitle={queueState.albumTitle}
           musicianName={queueState.musicianName}

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -84,13 +84,10 @@ export function AudioPlayerProvider({
     }
 
     for (const track of tracks) {
-      const { cover, musician } = extractTrackMetadata(track);
+      const { cover, musician, albumTitle } = extractTrackMetadata(track);
       trackCoversRef.current.set(track.id, cover);
       trackMusiciansRef.current.set(track.id, musician);
-      trackAlbumTitlesRef.current.set(
-        track.id,
-        track.album_title?.Valid ? track.album_title.String : "",
-      );
+      trackAlbumTitlesRef.current.set(track.id, albumTitle);
     }
   };
 
@@ -296,18 +293,43 @@ export function AudioPlayerProvider({
     return () => clearInterval(interval);
   }, [isPlaying, queueState.currentTrack?.id]);
 
-  const playTrack: AudioPlayerActions["playTrack"] = (track, playlist, albumInfo) => {
+  // Every playback entry point resets the metadata maps, seeds the queue, and
+  // expands the player. Mixed-list flows also pass rawTracks so setTrack can
+  // resolve per-track metadata on navigation; album flows leave the maps empty
+  // so the queue-wide albumInfo carries over.
+  const startQueue = ({
+    currentTrack,
+    tracks,
+    albumInfo,
+    rawTracks,
+    isShuffleMode = false,
+    isPlayAllMode = false,
+  }: {
+    currentTrack: TrackType;
+    tracks: TrackType[];
+    albumInfo: { cover: string | null; title: string; musician: string | null };
+    rawTracks?: PlayableTrackData[];
+    isShuffleMode?: boolean;
+    isPlayAllMode?: boolean;
+  }) => {
     clearMetadataRefs();
+    if (rawTracks) {
+      populateTrackMetadata(rawTracks);
+    }
     setQueueState({
-      currentTrack: track,
-      tracks: playlist,
+      currentTrack,
+      tracks,
       albumCover: albumInfo.cover,
       albumTitle: albumInfo.title,
       musicianName: albumInfo.musician,
-      isShuffleMode: false,
-      isPlayAllMode: false,
+      isShuffleMode,
+      isPlayAllMode,
     });
     setIsExpanded(true);
+  };
+
+  const playTrack: AudioPlayerActions["playTrack"] = (track, playlist, albumInfo) => {
+    startQueue({ currentTrack: track, tracks: playlist, albumInfo });
   };
 
   const playTrackFromList: AudioPlayerActions["playTrackFromList"] = (
@@ -330,40 +352,21 @@ export function AudioPlayerProvider({
     );
     if (!startRawTrack) return;
 
-    clearMetadataRefs();
-    populateTrackMetadata(uniqueRawTracks);
-
     const tracks = uniqueRawTracks.map(convertToAudioTrack);
-    const { cover, musician } = extractTrackMetadata(startRawTrack);
+    const { cover, musician, albumTitle } = extractTrackMetadata(startRawTrack);
 
-    setQueueState({
+    startQueue({
       currentTrack: tracks[uniqueRawTracks.indexOf(startRawTrack)],
       tracks,
-      albumCover: cover,
-      albumTitle: startRawTrack.album_title?.Valid
-        ? startRawTrack.album_title.String
-        : "",
-      musicianName: musician,
-      isShuffleMode: false,
-      isPlayAllMode: false,
+      albumInfo: { cover, title: albumTitle, musician },
+      rawTracks: uniqueRawTracks,
     });
-    setIsExpanded(true);
   };
 
   const playAlbum: AudioPlayerActions["playAlbum"] = (tracks, albumInfo) => {
     if (tracks.length === 0) return;
 
-    clearMetadataRefs();
-    setQueueState({
-      currentTrack: tracks[0],
-      tracks,
-      albumCover: albumInfo.cover,
-      albumTitle: albumInfo.title,
-      musicianName: albumInfo.musician,
-      isShuffleMode: false,
-      isPlayAllMode: false,
-    });
-    setIsExpanded(true);
+    startQueue({ currentTrack: tracks[0], tracks, albumInfo });
   };
 
   const shuffleAlbum: AudioPlayerActions["shuffleAlbum"] = (tracks, albumInfo) => {
@@ -371,17 +374,7 @@ export function AudioPlayerProvider({
 
     const shuffled = shuffleArray(tracks);
 
-    clearMetadataRefs();
-    setQueueState({
-      currentTrack: shuffled[0],
-      tracks: shuffled,
-      albumCover: albumInfo.cover,
-      albumTitle: albumInfo.title,
-      musicianName: albumInfo.musician,
-      isShuffleMode: false,
-      isPlayAllMode: false,
-    });
-    setIsExpanded(true);
+    startQueue({ currentTrack: shuffled[0], tracks: shuffled, albumInfo });
   };
 
   const startShufflePlayback: AudioPlayerActions["startShufflePlayback"] =
@@ -403,23 +396,15 @@ export function AudioPlayerProvider({
         return true;
       });
       const tracks = rawTracks.map(convertToAudioTrack);
+      const { cover, musician } = extractTrackMetadata(rawTracks[0]);
 
-      clearMetadataRefs();
-      populateTrackMetadata(rawTracks);
-
-      const firstTrack = rawTracks[0];
-      const { cover, musician } = extractTrackMetadata(firstTrack);
-
-      setQueueState({
+      startQueue({
         currentTrack: tracks[0],
         tracks,
-        albumCover: cover,
-        albumTitle: "Shuffle All",
-        musicianName: musician,
+        albumInfo: { cover, title: "Shuffle All", musician },
+        rawTracks,
         isShuffleMode: true,
-        isPlayAllMode: false,
       });
-      setIsExpanded(true);
     };
 
   const startPlayAllPlayback: AudioPlayerActions["startPlayAllPlayback"] =
@@ -431,26 +416,19 @@ export function AudioPlayerProvider({
 
       const rawTracks = response.data.tracks;
       const tracks = rawTracks.map(convertToAudioTrack);
+      const { cover, musician } = extractTrackMetadata(rawTracks[0]);
 
-      clearMetadataRefs();
-      populateTrackMetadata(rawTracks);
-
-      playAllOffsetRef.current = rawTracks.length;
-      playAllTotalRef.current = response.data.total;
-
-      const firstTrack = rawTracks[0];
-      const { cover, musician } = extractTrackMetadata(firstTrack);
-
-      setQueueState({
+      startQueue({
         currentTrack: tracks[0],
         tracks,
-        albumCover: cover,
-        albumTitle: "All Tracks",
-        musicianName: musician,
-        isShuffleMode: false,
+        albumInfo: { cover, title: "All Tracks", musician },
+        rawTracks,
         isPlayAllMode: true,
       });
-      setIsExpanded(true);
+
+      // After startQueue: clearMetadataRefs inside it zeroes these counters.
+      playAllOffsetRef.current = rawTracks.length;
+      playAllTotalRef.current = response.data.total;
     };
 
   const setTrack: AudioPlayerActions["setTrack"] = track => {

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -87,9 +87,10 @@ export function AudioPlayerProvider({
       const { cover, musician } = extractTrackMetadata(track);
       trackCoversRef.current.set(track.id, cover);
       trackMusiciansRef.current.set(track.id, musician);
-      if (track.album_title?.Valid) {
-        trackAlbumTitlesRef.current.set(track.id, track.album_title.String);
-      }
+      trackAlbumTitlesRef.current.set(
+        track.id,
+        track.album_title?.Valid ? track.album_title.String : "",
+      );
     }
   };
 
@@ -471,8 +472,9 @@ export function AudioPlayerProvider({
         musicianName: musicians?.has(track.id)
           ? (musicians.get(track.id) ?? null)
           : prev.musicianName,
-        albumTitle:
-          trackAlbumTitlesRef.current?.get(track.id) ?? prev.albumTitle,
+        albumTitle: trackAlbumTitlesRef.current?.has(track.id)
+          ? (trackAlbumTitlesRef.current.get(track.id) ?? "")
+          : prev.albumTitle,
       };
     });
   };

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -67,6 +67,7 @@ export function AudioPlayerProvider({
 
   const trackCoversRef = useRef<Map<number, string | null> | null>(null);
   const trackMusiciansRef = useRef<Map<number, string | null> | null>(null);
+  const trackAlbumTitlesRef = useRef<Map<number, string> | null>(null);
 
   const playAllOffsetRef = useRef(0);
   const playAllTotalRef = useRef(0);
@@ -78,17 +79,24 @@ export function AudioPlayerProvider({
     if (trackMusiciansRef.current === null) {
       trackMusiciansRef.current = new Map();
     }
+    if (trackAlbumTitlesRef.current === null) {
+      trackAlbumTitlesRef.current = new Map();
+    }
 
     for (const track of tracks) {
       const { cover, musician } = extractTrackMetadata(track);
       trackCoversRef.current.set(track.id, cover);
       trackMusiciansRef.current.set(track.id, musician);
+      if (track.album_title?.Valid) {
+        trackAlbumTitlesRef.current.set(track.id, track.album_title.String);
+      }
     }
   };
 
   const clearMetadataRefs = () => {
     trackCoversRef.current?.clear();
     trackMusiciansRef.current?.clear();
+    trackAlbumTitlesRef.current?.clear();
     playAllOffsetRef.current = 0;
     playAllTotalRef.current = 0;
   };
@@ -301,6 +309,46 @@ export function AudioPlayerProvider({
     setIsExpanded(true);
   };
 
+  const playTrackFromList: AudioPlayerActions["playTrackFromList"] = (
+    rawTracks,
+    startTrackId,
+  ) => {
+    // Mixed lists (search results, library tracks tab) can repeat an id;
+    // dedupe so findIndex-based prev/next navigation stays coherent.
+    const seenIds = new Set<number>();
+    const uniqueRawTracks = rawTracks.filter(track => {
+      if (seenIds.has(track.id)) {
+        return false;
+      }
+      seenIds.add(track.id);
+      return true;
+    });
+
+    const startRawTrack = uniqueRawTracks.find(
+      track => track.id === startTrackId,
+    );
+    if (!startRawTrack) return;
+
+    clearMetadataRefs();
+    populateTrackMetadata(uniqueRawTracks);
+
+    const tracks = uniqueRawTracks.map(convertToAudioTrack);
+    const { cover, musician } = extractTrackMetadata(startRawTrack);
+
+    setQueueState({
+      currentTrack: tracks[uniqueRawTracks.indexOf(startRawTrack)],
+      tracks,
+      albumCover: cover,
+      albumTitle: startRawTrack.album_title?.Valid
+        ? startRawTrack.album_title.String
+        : "",
+      musicianName: musician,
+      isShuffleMode: false,
+      isPlayAllMode: false,
+    });
+    setIsExpanded(true);
+  };
+
   const playAlbum: AudioPlayerActions["playAlbum"] = (tracks, albumInfo) => {
     if (tracks.length === 0) return;
 
@@ -342,7 +390,17 @@ export function AudioPlayerProvider({
         return;
       }
 
-      const rawTracks = response.data.tracks;
+      // The shuffle endpoint can repeat an id within one batch; dedupe so
+      // findIndex-based prev/next navigation stays coherent (the append
+      // effect above already dedupes subsequent batches).
+      const seenIds = new Set<number>();
+      const rawTracks = response.data.tracks.filter(track => {
+        if (seenIds.has(track.id)) {
+          return false;
+        }
+        seenIds.add(track.id);
+        return true;
+      });
       const tracks = rawTracks.map(convertToAudioTrack);
 
       clearMetadataRefs();
@@ -396,19 +454,25 @@ export function AudioPlayerProvider({
 
   const setTrack: AudioPlayerActions["setTrack"] = track => {
     setQueueState(prev => {
-      const isSpecialMode = prev.isShuffleMode || prev.isPlayAllMode;
-      const newAlbumCover = isSpecialMode
-        ? (trackCoversRef.current?.get(track.id) ?? null)
-        : prev.albumCover;
-      const newMusicianName = isSpecialMode
-        ? (trackMusiciansRef.current?.get(track.id) ?? null)
-        : prev.musicianName;
+      // Album/playlist flows clear the metadata maps, so their lookups miss
+      // and the queue-wide values carry over; mixed queues (shuffle, play
+      // all, search/library lists) resolve per-track metadata here. A track
+      // can legitimately map to null (no cover/musician), so distinguish
+      // "unmapped" from "mapped to null" via has().
+      const covers = trackCoversRef.current;
+      const musicians = trackMusiciansRef.current;
 
       return {
         ...prev,
         currentTrack: track,
-        albumCover: newAlbumCover,
-        musicianName: newMusicianName,
+        albumCover: covers?.has(track.id)
+          ? (covers.get(track.id) ?? null)
+          : prev.albumCover,
+        musicianName: musicians?.has(track.id)
+          ? (musicians.get(track.id) ?? null)
+          : prev.musicianName,
+        albumTitle:
+          trackAlbumTitlesRef.current?.get(track.id) ?? prev.albumTitle,
       };
     });
   };
@@ -467,6 +531,7 @@ export function AudioPlayerProvider({
 
   const actionsValue = {
     playTrack,
+    playTrackFromList,
     playAlbum,
     shuffleAlbum,
     startShufflePlayback,

--- a/web/src/lib/audio-utils.ts
+++ b/web/src/lib/audio-utils.ts
@@ -45,6 +45,30 @@ export function extractTrackMetadata(track: PlayableTrackData): {
   };
 }
 
+// Bound an endless queue's history: keep at most keepBehind tracks before the
+// current one and report what was dropped so callers can prune per-track
+// metadata. Returns the input array untouched when nothing needs trimming.
+export function trimQueueHistory<T extends { id: number }>(
+  tracks: T[],
+  currentTrackId: number | null,
+  keepBehind: number,
+): { tracks: T[]; dropped: T[] } {
+  const currentIndex =
+    currentTrackId === null
+      ? -1
+      : tracks.findIndex(track => track.id === currentTrackId);
+  const dropCount = currentIndex - keepBehind;
+
+  if (dropCount <= 0) {
+    return { tracks, dropped: [] };
+  }
+
+  return {
+    tracks: tracks.slice(dropCount),
+    dropped: tracks.slice(0, dropCount),
+  };
+}
+
 // Shuffle an array using the Fisher-Yates algorithm
 export function shuffleArray<T>(array: T[]) {
   const shuffled = [...array];

--- a/web/src/lib/audio-utils.ts
+++ b/web/src/lib/audio-utils.ts
@@ -32,14 +32,16 @@ export function convertToAudioTrack(track: PlayableTrackData) {
   };
 }
 
-// Extract cover and musician info from playable track data
+// Extract cover, musician, and album title info from playable track data
 export function extractTrackMetadata(track: PlayableTrackData): {
   cover: string | null;
   musician: string | null;
+  albumTitle: string;
 } {
   return {
     cover: track.album_cover.Valid ? track.album_cover.String : null,
     musician: track.musician_name.Valid ? track.musician_name.String : null,
+    albumTitle: track.album_title?.Valid ? track.album_title.String : "",
   };
 }
 

--- a/web/src/routes/_auth/music/index.tsx
+++ b/web/src/routes/_auth/music/index.tsx
@@ -717,6 +717,7 @@ function TracksTabContent() {
 
       <VirtualizedTracksList
         virtualItems={virtualItems}
+        allTracks={allTracks}
         likedSet={likedSet}
         totalTracks={totalTracks}
         hasNextPage={hasNextPage}
@@ -729,6 +730,7 @@ function TracksTabContent() {
 
 type VirtualizedTracksListProps = {
   virtualItems: VirtualItem[];
+  allTracks: TrackListItemType[];
   likedSet: Set<number>;
   totalTracks: number;
   hasNextPage: boolean;
@@ -738,6 +740,7 @@ type VirtualizedTracksListProps = {
 
 function VirtualizedTracksList({
   virtualItems,
+  allTracks,
   likedSet,
   totalTracks,
   hasNextPage,
@@ -747,6 +750,14 @@ function VirtualizedTracksList({
   "use no memo";
 
   const { listRef, scrollMargin } = useWindowScrollMargin<HTMLDivElement>();
+
+  // Rows are memoized (see TrackListItem), so they receive the loaded track
+  // list through a ref whose identity never changes; clicking play reads the
+  // freshest list from it to queue the whole tab.
+  const allTracksRef = useRef<TrackListItemType[]>(allTracks);
+  useEffect(() => {
+    allTracksRef.current = allTracks;
+  });
 
   const onChange = useVirtualizedInfiniteLoader({
     itemCount: virtualItems.length,
@@ -815,7 +826,11 @@ function VirtualizedTracksList({
               {item.type === "letter" ? (
                 <LetterHeader letter={item.letter} />
               ) : (
-                <TrackListItem track={item.track} isLiked={likedSet.has(item.track.id)} />
+                <TrackListItem
+                  track={item.track}
+                  isLiked={likedSet.has(item.track.id)}
+                  queueRef={allTracksRef}
+                />
               )}
             </div>
           );
@@ -925,21 +940,17 @@ function LetterHeader({ letter }: { letter: string }) {
 const TrackListItem = memo(function TrackListItem({
   track,
   isLiked,
+  queueRef,
 }: {
   track: TrackListItemType;
   isLiked: boolean;
+  queueRef: React.RefObject<TrackListItemType[]>;
 }) {
   const audioPlayer = useAudioPlayerActions();
   const playerState = useAudioPlayerState();
 
   const handlePlay = () => {
-    const audioTrack = convertToAudioTrack(track);
-
-    audioPlayer.playTrack(audioTrack, [audioTrack], {
-      cover: unwrapString(track.album_cover),
-      title: unwrapString(track.album_title) ?? "Unknown Album",
-      musician: unwrapString(track.musician_name),
-    });
+    audioPlayer.playTrackFromList(queueRef.current, track.id);
   };
 
   return (

--- a/web/src/routes/_auth/search/index.lazy.tsx
+++ b/web/src/routes/_auth/search/index.lazy.tsx
@@ -11,7 +11,6 @@ import TrackItem from "@/components/TrackItem";
 import { useContentFadeTransition } from "@/hooks/useContentFadeTransition";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
 import { useAudioPlayerState } from "@/hooks/useAudioPlayerState";
-import { convertToAudioTrack } from "@/lib/audio-utils";
 import {
   unwrapInt,
   unwrapString,
@@ -298,7 +297,7 @@ function AllResultsTab({ q }: { q: string }) {
           >
             {tracks.results.map((track) => (
               <li key={track.id} className="border-b border-border last:border-b-0">
-                <SearchTrackItem track={track} />
+                <SearchTrackItem track={track} queue={tracks.results} />
               </li>
             ))}
           </ul>
@@ -525,7 +524,7 @@ function TracksResultsTab({ q, page }: CategoryTabProps) {
               key={track.id}
               className="border-b border-border last:border-b-0"
             >
-              <SearchTrackItem track={track} />
+              <SearchTrackItem track={track} queue={items} />
             </li>
           ))}
         </ul>
@@ -636,29 +635,18 @@ function CategoryTabFrame<T>({
 // Track row that can play through the audio player
 // ---------------------------------------------------------------------------
 
-function SearchTrackItem({ track }: { track: TrackListItemType }) {
+function SearchTrackItem({
+  track,
+  queue,
+}: {
+  track: TrackListItemType;
+  queue: TrackListItemType[];
+}) {
   const audioPlayer = useAudioPlayerActions();
   const playerState = useAudioPlayerState();
 
   const handlePlay = () => {
-    const audioTrack = convertToAudioTrack({
-      id: track.id,
-      title: track.title,
-      file_path: track.file_path,
-      duration: track.duration,
-      codec: track.codec,
-      bit_rate: track.bit_rate,
-      album_id: track.album_id,
-      musician_id: track.musician_id,
-      album_cover: track.album_cover,
-      musician_name: track.musician_name,
-    });
-
-    audioPlayer.playTrack(audioTrack, [audioTrack], {
-      cover: unwrapString(track.album_cover),
-      title: unwrapString(track.album_title) ?? "Unknown Album",
-      musician: unwrapString(track.musician_name),
-    });
+    audioPlayer.playTrackFromList(queue, track.id);
   };
 
   return (

--- a/web/src/test/app-shell.test.tsx
+++ b/web/src/test/app-shell.test.tsx
@@ -1,7 +1,10 @@
 import type React from "react";
-import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppShell from "@/components/AppShell";
+import { AudioPlayerProvider } from "@/context/AudioPlayerContext";
+import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
+import { convertToAudioTrack } from "@/lib/audio-utils";
 
 vi.mock("@/components/app-sidebar", () => ({
   default: () => (
@@ -28,6 +31,45 @@ vi.mock("@/components/ui/sidebar", () => ({
   ),
 }));
 
+function PlayerHarness() {
+  const actions = useAudioPlayerActions();
+
+  const startPlayback = () => {
+    const testTrack = convertToAudioTrack({
+      id: 1,
+      title: "Test Track",
+      file_path: "/music/test.flac",
+      duration: 100,
+      codec: "flac",
+      bit_rate: 1,
+      album_id: { Int64: 0, Valid: false },
+      musician_id: { Int64: 0, Valid: false },
+      album_cover: { String: "", Valid: false },
+      musician_name: { String: "", Valid: false },
+    });
+
+    actions.playTrack(testTrack, [testTrack], {
+      cover: null,
+      title: "Test Album",
+      musician: null,
+    });
+  };
+
+  return (
+    <>
+      <button type="button" onClick={startPlayback}>
+        start playback
+      </button>
+      <button type="button" onClick={actions.minimize}>
+        minimize player
+      </button>
+      <button type="button" onClick={actions.stop}>
+        stop playback
+      </button>
+    </>
+  );
+}
+
 describe("AppShell", () => {
   it("renders one protected app shell around route content", () => {
     render(
@@ -51,5 +93,54 @@ describe("AppShell", () => {
     expect(
       within(main).getByRole("heading", { name: /route content/i }),
     ).toBeInTheDocument();
+  });
+
+  describe("minimized player spacing", () => {
+    const originalLoad = HTMLMediaElement.prototype.load;
+    const originalPlay = HTMLMediaElement.prototype.play;
+    const originalPause = HTMLMediaElement.prototype.pause;
+
+    beforeEach(() => {
+      HTMLMediaElement.prototype.load = vi.fn();
+      HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+      HTMLMediaElement.prototype.pause = vi.fn();
+    });
+
+    afterEach(() => {
+      HTMLMediaElement.prototype.load = originalLoad;
+      HTMLMediaElement.prototype.play = originalPlay;
+      HTMLMediaElement.prototype.pause = originalPause;
+    });
+
+    it("reserves bottom space only while the minimized player is visible", () => {
+      render(
+        <AudioPlayerProvider>
+          <AppShell>
+            <h1>Route content</h1>
+          </AppShell>
+          <PlayerHarness />
+        </AudioPlayerProvider>,
+      );
+
+      const main = screen.getByRole("main");
+      const scroller = main.querySelector(".overflow-y-auto");
+      if (!scroller) {
+        throw new Error("Scroll container was not rendered");
+      }
+
+      expect(scroller).not.toHaveClass("pb-28");
+
+      // Starting playback opens the expanded player: still no reserved space.
+      fireEvent.click(screen.getByRole("button", { name: "start playback" }));
+      expect(scroller).not.toHaveClass("pb-28");
+
+      // While the modal player dialog is open the harness is aria-hidden, so
+      // query by text instead of role.
+      fireEvent.click(screen.getByText("minimize player"));
+      expect(scroller).toHaveClass("pb-28", "sm:pb-24");
+
+      fireEvent.click(screen.getByRole("button", { name: "stop playback" }));
+      expect(scroller).not.toHaveClass("pb-28");
+    });
   });
 });

--- a/web/src/test/audio-player-endless-queue.test.tsx
+++ b/web/src/test/audio-player-endless-queue.test.tsx
@@ -1,0 +1,138 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AudioPlayerProvider } from "@/context/AudioPlayerContext";
+import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
+import { useAudioPlayerState } from "@/hooks/useAudioPlayerState";
+import { getShuffleTracks } from "@/lib/api";
+import type { TrackListItemType } from "@/types";
+
+vi.mock("@/lib/api", () => ({
+  getShuffleTracks: vi.fn(),
+  getTracksPaginated: vi.fn(),
+  recordPlayEvent: vi.fn(),
+}));
+
+const originalLoad = HTMLMediaElement.prototype.load;
+const originalPlay = HTMLMediaElement.prototype.play;
+const originalPause = HTMLMediaElement.prototype.pause;
+
+const BATCH_SIZE = 10;
+// Mirrors MAX_TRACKS_BEHIND in AudioPlayerContext plus the shuffle lookahead
+// threshold and one fetched batch — the ceiling a trimmed queue can reach.
+const MAX_EXPECTED_QUEUE_SIZE = 65;
+
+function rawTrack(id: number): TrackListItemType {
+  return {
+    id,
+    title: `Song ${id}`,
+    duration: 100,
+    codec: "flac",
+    bit_rate: 900000,
+    file_path: `/music/${id}.flac`,
+    album_id: { Int64: id, Valid: true },
+    album_title: { String: "", Valid: false },
+    album_cover: { String: "", Valid: false },
+    musician_id: { Int64: id, Valid: true },
+    musician_name: { String: "The Band", Valid: true },
+  };
+}
+
+function EndlessQueueHarness() {
+  const actions = useAudioPlayerActions();
+  const state = useAudioPlayerState();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => void actions.startShufflePlayback()}
+      >
+        start shuffle
+      </button>
+      <output aria-label="current track id">
+        {state.currentTrack?.id ?? ""}
+      </output>
+      <output aria-label="queue size">{state.tracks.length}</output>
+      <output aria-label="trimmed count">{state.trimmedCount}</output>
+    </div>
+  );
+}
+
+describe("endless shuffle queue", () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.load = vi.fn();
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+
+    let nextId = 1;
+    vi.mocked(getShuffleTracks).mockImplementation(async () => ({
+      error: false as const,
+      data: {
+        tracks: Array.from({ length: BATCH_SIZE }, () => rawTrack(nextId++)),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    HTMLMediaElement.prototype.load = originalLoad;
+    HTMLMediaElement.prototype.play = originalPlay;
+    HTMLMediaElement.prototype.pause = originalPause;
+  });
+
+  it(
+    "keeps the queue bounded and the track counter monotonic across trims",
+    async () => {
+      render(
+        <AudioPlayerProvider>
+          <EndlessQueueHarness />
+        </AudioPlayerProvider>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "start shuffle" }));
+      await waitFor(() => {
+        expect(screen.getByLabelText("current track id")).toHaveTextContent(
+          "1",
+        );
+      });
+
+      // Advance far enough past MAX_TRACKS_BEHIND that appends must trim
+      // (with 10-track batches the first trimming append lands at index 56).
+      // findByRole waits out in-flight fetches near the end of the queue.
+      for (let targetId = 2; targetId <= 66; targetId++) {
+        const nextButton = await screen.findByRole("button", {
+          name: "Next track",
+        });
+        fireEvent.click(nextButton);
+
+        await waitFor(() => {
+          expect(screen.getByLabelText("current track id")).toHaveTextContent(
+            String(targetId),
+          );
+        });
+      }
+
+      const trimmedCount = Number(
+        screen.getByLabelText("trimmed count").textContent,
+      );
+      const queueSize = Number(
+        screen.getByLabelText("queue size").textContent,
+      );
+
+      expect(trimmedCount).toBeGreaterThan(0);
+      expect(queueSize).toBeLessThanOrEqual(MAX_EXPECTED_QUEUE_SIZE);
+
+      // 65 next-clicks from track 1: the counter must read 66 with the
+      // trimmed history added back in, never jumping backwards.
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "P" &&
+            element.textContent === `Track 66 of ${trimmedCount + queueSize}`,
+        ),
+      ).toBeInTheDocument();
+    },
+    15000,
+  );
+});

--- a/web/src/test/audio-player-media-session.test.tsx
+++ b/web/src/test/audio-player-media-session.test.tsx
@@ -1,5 +1,12 @@
-import { createRef, useRef, useState } from "react";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { createRef, useRef, useState, type ReactNode } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AudioPlayer from "@/components/AudioPlayer";
@@ -36,7 +43,7 @@ function nullableInt64(value: number | null = null) {
   };
 }
 
-function track(): TrackType {
+function track(overrides: Partial<TrackType> = {}): TrackType {
   return {
     id: 42,
     title: "Alabaster",
@@ -63,6 +70,7 @@ function track(): TrackType {
     musician_id: nullableInt64(8),
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
   };
 }
 
@@ -77,31 +85,58 @@ function setAudioNumber(
   });
 }
 
+// setAudioNumber defines a read-only value; the restart tests need to observe
+// the `audio.currentTime = 0` assignment, so this installs a writable spy.
+function observeAudioCurrentTime(audio: HTMLAudioElement, initial: number) {
+  let currentValue = initial;
+  const set = vi.fn((next: number) => {
+    currentValue = next;
+  });
+
+  Object.defineProperty(audio, "currentTime", {
+    configurable: true,
+    get: () => currentValue,
+    set,
+  });
+
+  return set;
+}
+
 function renderAudioPlayer({
   isExpanded = false,
   onClose,
+  currentTrack = track(),
+  tracks = [currentTrack],
+  onTrackChange = vi.fn(),
+  siblings,
 }: {
   isExpanded?: boolean;
   onClose?: () => void;
+  currentTrack?: TrackType;
+  tracks?: TrackType[];
+  onTrackChange?: (nextTrack: TrackType) => void;
+  siblings?: ReactNode;
 } = {}) {
   const audioRef = createRef<HTMLAudioElement>();
-  const currentTrack = track();
   const view = render(
-    <AudioPlayer
-      track={currentTrack}
-      tracks={[currentTrack]}
-      albumCover="/covers/7.jpg"
-      albumTitle="Blue Record"
-      musicianName="The Band"
-      onTrackChange={vi.fn()}
-      audioRef={audioRef}
-      isPlaying={false}
-      onPlayStateChange={vi.fn()}
-      isExpanded={isExpanded}
-      onMinimize={vi.fn()}
-      onExpand={vi.fn()}
-      onClose={onClose}
-    />,
+    <>
+      {siblings}
+      <AudioPlayer
+        track={currentTrack}
+        tracks={tracks}
+        albumCover="/covers/7.jpg"
+        albumTitle="Blue Record"
+        musicianName="The Band"
+        onTrackChange={onTrackChange}
+        audioRef={audioRef}
+        isPlaying={false}
+        onPlayStateChange={vi.fn()}
+        isExpanded={isExpanded}
+        onMinimize={vi.fn()}
+        onExpand={vi.fn()}
+        onClose={onClose}
+      />
+    </>,
   );
 
   const audio = view.container.querySelector("audio");
@@ -283,13 +318,18 @@ describe("AudioPlayer Media Session", () => {
       }),
     ).toHaveClass(...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "));
     expect(
-      screen.getByRole("button", { name: "No previous track" }),
+      screen.getByRole("button", { name: "Previous track" }),
     ).toHaveClass(...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "));
+    expect(screen.getByRole("button", { name: "Previous track" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Play" })).toHaveClass(
       ...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "),
     );
     expect(screen.getByRole("button", { name: "No next track" })).toHaveClass(
       ...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "),
+    );
+    expect(screen.getByRole("button", { name: "No next track" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
     );
     expect(
       screen.getByRole("button", { name: "Stop playback and close player" }),
@@ -311,7 +351,7 @@ describe("AudioPlayer Media Session", () => {
       screen.getByRole("button", { name: "Stop playback and close player" }),
     ).toHaveClass(...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "));
     expect(
-      screen.getByRole("button", { name: "No previous track" }),
+      screen.getByRole("button", { name: "Previous track" }),
     ).toHaveClass(...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "));
     expect(screen.getByRole("button", { name: "Play" })).toHaveClass(
       ...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "),
@@ -384,6 +424,221 @@ describe("AudioPlayer Media Session", () => {
     });
     await waitFor(() => {
       expect(expandButton).toHaveFocus();
+    });
+  });
+
+  describe("previous and next controls", () => {
+    function secondTrack(): TrackType {
+      return track({
+        id: 43,
+        title: "Basalt",
+        file_path: "/music/basalt.flac",
+        file_name: "basalt.flac",
+      });
+    }
+
+    it("restarts the only track when previous is pressed", () => {
+      const onTrackChange = vi.fn();
+      const { audio } = renderAudioPlayer({ onTrackChange });
+      const setCurrentTime = observeAudioCurrentTime(audio, 42);
+
+      fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+
+      expect(onTrackChange).not.toHaveBeenCalled();
+      expect(setCurrentTime).toHaveBeenCalledWith(0);
+    });
+
+    it("restarts the current track when previous is pressed past the threshold", () => {
+      const first = track();
+      const current = secondTrack();
+      const onTrackChange = vi.fn();
+      const { audio } = renderAudioPlayer({
+        currentTrack: current,
+        tracks: [first, current],
+        onTrackChange,
+      });
+      const setCurrentTime = observeAudioCurrentTime(audio, 10);
+
+      fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+
+      expect(onTrackChange).not.toHaveBeenCalled();
+      expect(setCurrentTime).toHaveBeenCalledWith(0);
+    });
+
+    it("navigates to the previous track near the start of playback", () => {
+      const first = track();
+      const current = secondTrack();
+      const onTrackChange = vi.fn();
+      const { audio } = renderAudioPlayer({
+        currentTrack: current,
+        tracks: [first, current],
+        onTrackChange,
+      });
+      const setCurrentTime = observeAudioCurrentTime(audio, 1);
+
+      fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+
+      expect(onTrackChange).toHaveBeenCalledWith(first);
+      expect(setCurrentTime).not.toHaveBeenCalled();
+    });
+
+    it("applies the same previous behavior to the media session handler", () => {
+      const mediaSession = mockMediaSession();
+      const first = track();
+      const current = secondTrack();
+      const onTrackChange = vi.fn();
+      const { audio } = renderAudioPlayer({
+        currentTrack: current,
+        tracks: [first, current],
+        onTrackChange,
+      });
+      observeAudioCurrentTime(audio, 1);
+
+      const previousHandler = mediaSession.setActionHandler.mock.calls
+        .filter(([action, handler]) => action === "previoustrack" && handler)
+        .at(-1)?.[1] as (() => void) | undefined;
+      if (!previousHandler) {
+        throw new Error("previoustrack handler was not registered");
+      }
+
+      act(() => {
+        previousHandler();
+      });
+
+      expect(onTrackChange).toHaveBeenCalledWith(first);
+    });
+
+    it("applies the same previous behavior to the keyboard shortcut", () => {
+      const onTrackChange = vi.fn();
+      const { audio } = renderAudioPlayer({ onTrackChange });
+      const setCurrentTime = observeAudioCurrentTime(audio, 42);
+
+      fireEvent.keyDown(window, { key: "p" });
+
+      expect(onTrackChange).not.toHaveBeenCalled();
+      expect(setCurrentTime).toHaveBeenCalledWith(0);
+    });
+
+    it("keeps the next button focusable but inert on the last track", () => {
+      const onTrackChange = vi.fn();
+      renderAudioPlayer({ onTrackChange });
+
+      const nextButton = screen.getByRole("button", { name: "No next track" });
+      nextButton.focus();
+
+      fireEvent.click(nextButton);
+
+      expect(onTrackChange).not.toHaveBeenCalled();
+      expect(nextButton).toHaveAttribute("aria-disabled", "true");
+      expect(nextButton).toHaveFocus();
+    });
+  });
+
+  describe("global keyboard shortcut guards", () => {
+    const dialogStub = (
+      <div role="dialog" aria-label="Stub dialog">
+        <button type="button">Dialog button</button>
+      </div>
+    );
+
+    it("leaves Space to activate focused controls instead of toggling playback", () => {
+      const { audio } = renderAudioPlayer();
+      observeAudioCurrentTime(audio, 42);
+
+      const prevButton = screen.getByRole("button", { name: "Previous track" });
+      prevButton.focus();
+
+      const playMock = HTMLMediaElement.prototype.play as ReturnType<
+        typeof vi.fn
+      >;
+      const playCallsBefore = playMock.mock.calls.length;
+
+      const defaultNotPrevented = fireEvent.keyDown(prevButton, { key: " " });
+
+      expect(defaultNotPrevented).toBe(true);
+      expect(playMock.mock.calls.length).toBe(playCallsBefore);
+      expect(HTMLMediaElement.prototype.pause).not.toHaveBeenCalled();
+    });
+
+    it("ignores shortcuts fired from inside a foreign dialog", () => {
+      const onTrackChange = vi.fn();
+      const { audio } = renderAudioPlayer({
+        onTrackChange,
+        siblings: dialogStub,
+      });
+      const setCurrentTime = observeAudioCurrentTime(audio, 42);
+
+      const dialogButton = screen.getByRole("button", {
+        name: "Dialog button",
+      });
+      dialogButton.focus();
+
+      fireEvent.keyDown(dialogButton, { key: "p" });
+      fireEvent.keyDown(dialogButton, { key: "ArrowRight" });
+
+      expect(onTrackChange).not.toHaveBeenCalled();
+      expect(setCurrentTime).not.toHaveBeenCalled();
+    });
+
+    it("keeps arrow seeking off buttons outside the player but on inside it", () => {
+      const { audio } = renderAudioPlayer({
+        siblings: <button type="button">Outside button</button>,
+      });
+      setAudioNumber(audio, "duration", 120);
+      const setCurrentTime = observeAudioCurrentTime(audio, 30);
+
+      const outsideButton = screen.getByRole("button", {
+        name: "Outside button",
+      });
+      outsideButton.focus();
+      fireEvent.keyDown(outsideButton, { key: "ArrowRight" });
+      expect(setCurrentTime).not.toHaveBeenCalled();
+
+      const prevButton = screen.getByRole("button", { name: "Previous track" });
+      prevButton.focus();
+      fireEvent.keyDown(prevButton, { key: "ArrowRight" });
+      expect(setCurrentTime).toHaveBeenCalledWith(40);
+    });
+
+    it("still seeks with arrows from non-interactive targets", () => {
+      const { audio } = renderAudioPlayer();
+      setAudioNumber(audio, "duration", 120);
+      const setCurrentTime = observeAudioCurrentTime(audio, 30);
+
+      fireEvent.keyDown(document.body, { key: "ArrowRight" });
+
+      expect(setCurrentTime).toHaveBeenCalledWith(40);
+    });
+  });
+
+  describe("live region announcements", () => {
+    it("announces track changes while minimized", () => {
+      const audioRef = createRef<HTMLAudioElement>();
+      const first = track();
+      const second = track({ id: 43, title: "Basalt" });
+      const sharedProps = {
+        tracks: [first, second],
+        albumCover: "/covers/7.jpg",
+        albumTitle: "Blue Record",
+        musicianName: "The Band",
+        onTrackChange: vi.fn(),
+        audioRef,
+        isPlaying: false,
+        onPlayStateChange: vi.fn(),
+        isExpanded: false,
+        onMinimize: vi.fn(),
+        onExpand: vi.fn(),
+      };
+
+      const { rerender, container } = render(
+        <AudioPlayer track={first} {...sharedProps} />,
+      );
+
+      rerender(<AudioPlayer track={second} {...sharedProps} />);
+
+      const liveRegion = container.querySelector('[aria-live="polite"]');
+      expect(liveRegion).not.toBeNull();
+      expect(liveRegion).toHaveTextContent("Now playing: Basalt by The Band");
     });
   });
 });

--- a/web/src/test/audio-player-media-session.test.tsx
+++ b/web/src/test/audio-player-media-session.test.tsx
@@ -306,6 +306,79 @@ describe("AudioPlayer Media Session", () => {
     expect(() => renderAudioPlayer()).not.toThrow();
   });
 
+  it("clears media session metadata when playback stops", () => {
+    const mediaSession = mockMediaSession();
+    const sharedProps = {
+      tracks: [track()],
+      albumCover: "/covers/7.jpg",
+      albumTitle: "Blue Record",
+      musicianName: "The Band",
+      onTrackChange: vi.fn(),
+      audioRef: createRef<HTMLAudioElement>(),
+      isPlaying: false,
+      onPlayStateChange: vi.fn(),
+      isExpanded: false,
+      onMinimize: vi.fn(),
+      onExpand: vi.fn(),
+    };
+
+    const { rerender } = render(<AudioPlayer track={track()} {...sharedProps} />);
+    expect(mediaSession.metadata).not.toBeNull();
+
+    rerender(<AudioPlayer track={null} {...sharedProps} />);
+    expect(mediaSession.metadata).toBeNull();
+  });
+
+  it("resets the displayed position when the track changes", () => {
+    mockMediaSession();
+    const first = track();
+    const second = track({ id: 43, title: "Basalt" });
+    const sharedProps = {
+      tracks: [first, second],
+      albumCover: "/covers/7.jpg",
+      albumTitle: "Blue Record",
+      musicianName: "The Band",
+      onTrackChange: vi.fn(),
+      audioRef: createRef<HTMLAudioElement>(),
+      isPlaying: false,
+      onPlayStateChange: vi.fn(),
+      isExpanded: false,
+      onMinimize: vi.fn(),
+      onExpand: vi.fn(),
+    };
+
+    const { rerender, container } = render(
+      <AudioPlayer track={first} {...sharedProps} />,
+    );
+
+    const audio = container.querySelector("audio");
+    if (!audio) {
+      throw new Error("Audio element was not rendered");
+    }
+    setAudioNumber(audio, "duration", 120);
+    setAudioNumber(audio, "currentTime", 60);
+    act(() => {
+      audio.dispatchEvent(new Event("durationchange"));
+      audio.dispatchEvent(new Event("timeupdate"));
+    });
+
+    for (const slider of screen.getAllByRole("slider", {
+      name: "Seek through track",
+    })) {
+      expect((slider as HTMLInputElement).value).toBe("60");
+    }
+
+    // The new track's media events have not fired yet; the old position and
+    // duration must not linger on the progress bar.
+    rerender(<AudioPlayer track={second} {...sharedProps} />);
+
+    for (const slider of screen.getAllByRole("slider", {
+      name: "Seek through track",
+    })) {
+      expect((slider as HTMLInputElement).value).toBe("0");
+    }
+  });
+
   it("keeps minimized audio chrome labelled and reduced-motion safe", () => {
     renderAudioPlayer({ onClose: vi.fn() });
 

--- a/web/src/test/audio-player-queue.test.tsx
+++ b/web/src/test/audio-player-queue.test.tsx
@@ -17,7 +17,7 @@ function rawTrack({
 }: {
   id: number;
   title: string;
-  albumTitle: string;
+  albumTitle: string | null;
   musician: string;
   cover: string | null;
 }): PlayableTrackData {
@@ -34,7 +34,10 @@ function rawTrack({
       ? { String: cover, Valid: true }
       : { String: "", Valid: false },
     musician_name: { String: musician, Valid: true },
-    album_title: { String: albumTitle, Valid: true },
+    album_title:
+      albumTitle !== null
+        ? { String: albumTitle, Valid: true }
+        : { String: "", Valid: false },
   };
 }
 
@@ -144,6 +147,24 @@ describe("playTrackFromList", () => {
     expect(
       screen.getByRole("img", { name: "No album cover available" }),
     ).toBeInTheDocument();
+  });
+
+  it("clears the album title for a track without one instead of keeping the previous track's", () => {
+    const drift = rawTrack({
+      id: 4,
+      title: "Drift",
+      albumTitle: null,
+      musician: "Loose Single",
+      cover: null,
+    });
+
+    renderQueue([alabaster, drift], 1);
+
+    expect(screen.getByText("Stone Record")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+
+    expect(screen.queryByText("Stone Record")).not.toBeInTheDocument();
   });
 
   it("ignores a start track that is not in the list", () => {

--- a/web/src/test/audio-player-queue.test.tsx
+++ b/web/src/test/audio-player-queue.test.tsx
@@ -1,0 +1,154 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AudioPlayerProvider } from "@/context/AudioPlayerContext";
+import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
+import type { PlayableTrackData } from "@/types";
+
+const originalLoad = HTMLMediaElement.prototype.load;
+const originalPlay = HTMLMediaElement.prototype.play;
+const originalPause = HTMLMediaElement.prototype.pause;
+
+function rawTrack({
+  id,
+  title,
+  albumTitle,
+  musician,
+  cover,
+}: {
+  id: number;
+  title: string;
+  albumTitle: string;
+  musician: string;
+  cover: string | null;
+}): PlayableTrackData {
+  return {
+    id,
+    title,
+    file_path: `/music/${id}.flac`,
+    duration: 100,
+    codec: "flac",
+    bit_rate: 900000,
+    album_id: { Int64: id, Valid: true },
+    musician_id: { Int64: id, Valid: true },
+    album_cover: cover
+      ? { String: cover, Valid: true }
+      : { String: "", Valid: false },
+    musician_name: { String: musician, Valid: true },
+    album_title: { String: albumTitle, Valid: true },
+  };
+}
+
+function QueueHarness({
+  rawTracks,
+  startTrackId,
+}: {
+  rawTracks: PlayableTrackData[];
+  startTrackId: number;
+}) {
+  const actions = useAudioPlayerActions();
+
+  return (
+    <button
+      type="button"
+      onClick={() => actions.playTrackFromList(rawTracks, startTrackId)}
+    >
+      start queue
+    </button>
+  );
+}
+
+function renderQueue(rawTracks: PlayableTrackData[], startTrackId: number) {
+  render(
+    <AudioPlayerProvider>
+      <QueueHarness rawTracks={rawTracks} startTrackId={startTrackId} />
+    </AudioPlayerProvider>,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "start queue" }));
+}
+
+describe("playTrackFromList", () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.load = vi.fn();
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    HTMLMediaElement.prototype.load = originalLoad;
+    HTMLMediaElement.prototype.play = originalPlay;
+    HTMLMediaElement.prototype.pause = originalPause;
+  });
+
+  const alabaster = rawTrack({
+    id: 1,
+    title: "Alabaster",
+    albumTitle: "Stone Record",
+    musician: "The Band",
+    cover: "/covers/stone.jpg",
+  });
+  const basalt = rawTrack({
+    id: 2,
+    title: "Basalt",
+    albumTitle: "Dark Record",
+    musician: "Other Band",
+    cover: null,
+  });
+  const chalk = rawTrack({
+    id: 3,
+    title: "Chalk",
+    albumTitle: "White Record",
+    musician: "Third Band",
+    cover: "/covers/white.jpg",
+  });
+
+  it("queues the deduped list starting at the chosen track", () => {
+    // The duplicate Alabaster entry must be dropped from the queue.
+    renderQueue([alabaster, basalt, chalk, alabaster], 2);
+
+    expect(
+      screen.getByRole("dialog", { name: "Now playing: Basalt by Other Band" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Track 2 of 3")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Previous track" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Next track" }),
+    ).toBeInTheDocument();
+  });
+
+  it("resolves per-track cover, musician, and album title on navigation", () => {
+    renderQueue([alabaster, basalt, chalk], 2);
+
+    // Basalt has no cover and its own album metadata.
+    expect(screen.getByText("Dark Record")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "No album cover available" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+
+    expect(screen.getByText("White Record")).toBeInTheDocument();
+    expect(screen.getByText("Third Band")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Album cover for White Record" }),
+    ).toBeInTheDocument();
+
+    // Going back must restore Basalt's null cover instead of keeping Chalk's
+    // (a mapped-to-null cover is not the same as an unmapped track).
+    fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+
+    expect(screen.getByText("Dark Record")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "No album cover available" }),
+    ).toBeInTheDocument();
+  });
+
+  it("ignores a start track that is not in the list", () => {
+    renderQueue([alabaster], 999);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/test/audio-utils.test.ts
+++ b/web/src/test/audio-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { trimQueueHistory } from "@/lib/audio-utils";
+
+function makeTracks(count: number) {
+  return Array.from({ length: count }, (_, index) => ({ id: index + 1 }));
+}
+
+describe("trimQueueHistory", () => {
+  it("returns the queue unchanged while the current track is within the window", () => {
+    const tracks = makeTracks(10);
+
+    const result = trimQueueHistory(tracks, 4, 5);
+
+    expect(result.tracks).toBe(tracks);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it("returns the queue unchanged when there is no current track", () => {
+    const tracks = makeTracks(10);
+
+    expect(trimQueueHistory(tracks, null, 2).tracks).toBe(tracks);
+    expect(trimQueueHistory(tracks, 999, 2).tracks).toBe(tracks);
+  });
+
+  it("drops tracks beyond the window and reports them in order", () => {
+    const tracks = makeTracks(10);
+
+    // Current track id 8 sits at index 7; keeping 3 behind drops indexes 0-3.
+    const result = trimQueueHistory(tracks, 8, 3);
+
+    expect(result.dropped.map(track => track.id)).toEqual([1, 2, 3, 4]);
+    expect(result.tracks.map(track => track.id)).toEqual([
+      5, 6, 7, 8, 9, 10,
+    ]);
+  });
+
+  it("keeps exactly keepBehind tracks before the current one", () => {
+    const tracks = makeTracks(100);
+
+    const result = trimQueueHistory(tracks, 80, 50);
+
+    expect(result.tracks[0].id).toBe(30);
+    expect(result.tracks.indexOf(tracks[79])).toBe(50);
+    expect(result.dropped).toHaveLength(29);
+  });
+});

--- a/web/src/test/progress-bar.test.tsx
+++ b/web/src/test/progress-bar.test.tsx
@@ -175,4 +175,64 @@ describe("ProgressBar", () => {
     );
     expect(slider.value).toBe("102");
   });
+
+  it("clears the scrubbed position when the pointer is cancelled", () => {
+    const onSeek = vi.fn();
+
+    const { rerender } = render(
+      <ProgressBar
+        currentTime={50}
+        duration={200}
+        onSeek={onSeek}
+        variant="trailer"
+      />,
+    );
+
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: "100" } });
+    fireEvent.pointerCancel(slider);
+
+    rerender(
+      <ProgressBar
+        currentTime={51}
+        duration={200}
+        onSeek={onSeek}
+        variant="trailer"
+      />,
+    );
+    expect(slider.value).toBe("51");
+  });
+
+  it("drops a pending scrub value when resetKey changes", () => {
+    const onSeek = vi.fn();
+
+    const { rerender } = render(
+      <ProgressBar
+        currentTime={50}
+        duration={200}
+        onSeek={onSeek}
+        variant="expanded"
+        resetKey={1}
+      />,
+    );
+
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: "180" } });
+    expect(slider.value).toBe("180");
+
+    // Track auto-advances mid-drag: the new track must not inherit the old
+    // track's scrub position.
+    rerender(
+      <ProgressBar
+        currentTime={0}
+        duration={240}
+        onSeek={onSeek}
+        variant="expanded"
+        resetKey={2}
+      />,
+    );
+    expect(slider.value).toBe("0");
+  });
 });

--- a/web/src/test/progress-bar.test.tsx
+++ b/web/src/test/progress-bar.test.tsx
@@ -7,6 +7,9 @@ import {
 } from "@/lib/constants";
 
 describe("ProgressBar", () => {
+  // jsdom does not implement native range-input keyboard stepping, so this
+  // exercises the component's own keydown handler (which also overrides the
+  // native 1s step with friendlier increments in real browsers).
   it("seeks with keyboard controls", () => {
     const onSeek = vi.fn();
 
@@ -55,13 +58,10 @@ describe("ProgressBar", () => {
       const slider = screen.getByRole("slider");
 
       fireEvent.keyDown(slider, { key: "ArrowRight" });
-      fireEvent.pointerDown(slider, {
-        clientX: 50,
-        isPrimary: true,
-        pointerId: 1,
-      });
+      fireEvent.change(slider, { target: { value: "50" } });
 
       expect(slider).toHaveAttribute("aria-disabled", "true");
+      expect(slider).toHaveAttribute("tabindex", "-1");
       expect(onSeek).not.toHaveBeenCalled();
     },
   );
@@ -98,11 +98,12 @@ describe("ProgressBar", () => {
 
     const group = screen.getByRole("group");
     const slider = screen.getByRole("slider");
-    const fill = slider.firstElementChild;
+    const bar = slider.parentElement;
+    const fill = bar?.firstElementChild;
     const thumb = fill?.nextElementSibling;
 
     expect(group).toHaveClass("mb-4", "w-full");
-    expect(slider).toHaveClass("h-1.5", "focus:ring-ring");
+    expect(bar).toHaveClass("h-1.5", "focus-within:ring-ring");
     expect(fill).toHaveClass(
       "bg-primary",
       ...MOTION_PROGRESS_FILL_CLASS.split(" "),
@@ -110,12 +111,12 @@ describe("ProgressBar", () => {
     expect(thumb).toHaveClass(
       "size-3",
       "group-hover:opacity-100",
-      "group-focus:opacity-100",
+      "group-focus-within:opacity-100",
       ...MOTION_PROGRESS_THUMB_REVEAL_CLASS.split(" "),
     );
   });
 
-  it("seeks from pointer position", () => {
+  it("seeks when the range input value changes", () => {
     const onSeek = vi.fn();
 
     render(
@@ -128,24 +129,50 @@ describe("ProgressBar", () => {
     );
 
     const slider = screen.getByRole("slider");
-    vi.spyOn(slider, "getBoundingClientRect").mockReturnValue({
-      bottom: 10,
-      height: 10,
-      left: 20,
-      right: 220,
-      top: 0,
-      width: 200,
-      x: 20,
-      y: 0,
-      toJSON: () => ({}),
-    });
 
-    fireEvent.pointerDown(slider, {
-      clientX: 120,
-      isPrimary: true,
-      pointerId: 1,
-    });
+    fireEvent.change(slider, { target: { value: "100" } });
+    expect(onSeek).toHaveBeenLastCalledWith(100);
 
-    expect(onSeek).toHaveBeenCalledWith(100);
+    fireEvent.change(slider, { target: { value: "999" } });
+    expect(onSeek).toHaveBeenLastCalledWith(200);
+  });
+
+  it("keeps the scrubbed position until the pointer is released", () => {
+    const onSeek = vi.fn();
+
+    const { rerender } = render(
+      <ProgressBar
+        currentTime={50}
+        duration={200}
+        onSeek={onSeek}
+        variant="trailer"
+      />,
+    );
+
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+
+    fireEvent.change(slider, { target: { value: "100" } });
+
+    // A stale timeupdate re-render must not snap the thumb back mid-drag.
+    rerender(
+      <ProgressBar
+        currentTime={51}
+        duration={200}
+        onSeek={onSeek}
+        variant="trailer"
+      />,
+    );
+    expect(slider.value).toBe("100");
+
+    fireEvent.pointerUp(slider);
+    rerender(
+      <ProgressBar
+        currentTime={102}
+        duration={200}
+        onSeek={onSeek}
+        variant="trailer"
+      />,
+    );
+    expect(slider.value).toBe("102");
   });
 });

--- a/web/src/test/volume-control.test.tsx
+++ b/web/src/test/volume-control.test.tsx
@@ -91,8 +91,8 @@ describe("VolumeControl", () => {
 
     expect(screen.getByRole("button", { name: "Unmute" })).toBeVisible();
     expect(screen.getByRole("slider", { name: "Volume" })).toHaveAttribute(
-      "aria-valuenow",
-      "0",
+      "aria-valuetext",
+      "0% volume",
     );
     expect(screen.getByText("0%")).toBeVisible();
   });
@@ -112,7 +112,7 @@ describe("VolumeControl", () => {
 
     expect(media.volume).toBe(0.25);
     expect(media.muted).toBe(false);
-    expect(slider).toHaveAttribute("aria-valuenow", "25");
+    expect(slider).toHaveAttribute("aria-valuetext", "25% volume");
     expect(screen.getByRole("button", { name: "Mute" })).toBeVisible();
   });
 });

--- a/web/src/types/audio-player.ts
+++ b/web/src/types/audio-player.ts
@@ -22,6 +22,10 @@ export type PlayableTrackData = {
   musician_id: NullableInt64;
   album_cover: NullableString;
   musician_name: NullableString;
+
+  // Present on list/search rows; used to keep the player header accurate in
+  // mixed queues. The shuffle/play-all endpoints may omit it.
+  album_title?: NullableString;
 };
 
 // State for the global audio player
@@ -49,6 +53,13 @@ export type AudioPlayerActions = {
     track: TrackType,
     playlist: TrackType[],
     albumInfo: AlbumInfoType
+  ) => void;
+
+  // Play a track from a mixed list (search results, library tracks tab),
+  // queueing the whole list with per-track cover/musician metadata
+  playTrackFromList: (
+    rawTracks: PlayableTrackData[],
+    startTrackId: number
   ) => void;
 
   // Play an entire album from the beginning

--- a/web/src/types/audio-player.ts
+++ b/web/src/types/audio-player.ts
@@ -44,6 +44,10 @@ export type AudioPlayerState = {
 
   // Whether "play all" mode is enabled (plays through entire library)
   isPlayAllMode: boolean;
+
+  // How many played tracks were trimmed from the front of an endless
+  // shuffle/play-all queue; keeps the "Track N of M" counter monotonic
+  trimmedCount: number;
 };
 
 // Actions available for the audio player


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “play from a full list” for track rows and search results, preserving correct queue order even with duplicates.
  * Extended endless shuffle/play-all so the “Track N of M” counter remains monotonic as history trims.
* **Bug Fixes**
  * Fixed Previous-track behavior (restart near start, otherwise navigate).
  * Corrected mini-player spacing so content isn’t obscured.
* **Accessibility & UI**
  * Improved Media Session, keyboard focus guards, live announcements, and disabled semantics for Next/Previous.
  * Updated progress and volume accessibility behaviors; metadata is cleared when playback stops.
* **Tests**
  * Expanded queue, progress, media-session, keyboard-guard, and spacing test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->