### PR TITLE
Made some fixes to the sticky bar in the general settings page

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { useIsMiniPlayerVisible } from "@/hooks/useIsMiniPlayerVisible";
+import { MINI_PLAYER_CLEARANCE_PADDING_CLASS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 export default function AppShell({ children }: PropsWithChildren) {
@@ -48,7 +49,7 @@ export default function AppShell({ children }: PropsWithChildren) {
             // scroll container, or sticky elements inside pages stop sticking
             // to the window scroll.
             "flex min-h-0 min-w-0 flex-1 flex-col overflow-x-clip px-4 py-6 sm:px-6 lg:px-8",
-            isMiniPlayerVisible && "pb-28 sm:pb-24",
+            isMiniPlayerVisible && MINI_PLAYER_CLEARANCE_PADDING_CLASS,
           )}
         >
           {children}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -415,6 +415,15 @@ export const LIBRARY_TABS_LIST_CLASS =
   "grid! h-auto w-full max-w-full sm:w-fit sm:max-w-none";
 export const LIBRARY_TAB_TRIGGER_CLASS = "min-h-10 min-w-0 p-2 sm:px-4";
 
+/**
+ * Clearance for the fixed audio mini player (AudioPlayer.tsx). Both values
+ * encode the same player-bar height and must change together: the shell pads
+ * its content so pages scroll clear of the bar, and in-page sticky bottom
+ * elements offset above it.
+ */
+export const MINI_PLAYER_CLEARANCE_PADDING_CLASS = "pb-28 sm:pb-24";
+export const MINI_PLAYER_CLEARANCE_BOTTOM_CLASS = "bottom-28 sm:bottom-24";
+
 // Shared content fade transitions
 export const CONTENT_FADE_TRANSITION_MS = MOTION_DURATION_STANDARD_MS;
 export const CONTENT_FADE_ENTER_CLASS = MOTION_SECTION_ENTER_CLASS;

--- a/web/src/routes/_auth/settings/index.lazy.tsx
+++ b/web/src/routes/_auth/settings/index.lazy.tsx
@@ -39,6 +39,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useIsMiniPlayerVisible } from "@/hooks/useIsMiniPlayerVisible";
 import {
   GENERAL_SETTINGS_KEY,
+  MINI_PLAYER_CLEARANCE_BOTTOM_CLASS,
   MOTION_CONTROL_THUMB_TRANSFORM_CLASS,
   MOTION_SETTINGS_SURFACE_CLASS,
   PLAYBACK_SETTINGS_KEY,
@@ -440,7 +441,11 @@ function GeneralSettingsForm({ settings }: GeneralSettingsFormProps) {
     <form
       onSubmit={handleSubmit}
       noValidate
-      className="@container max-w-5xl space-y-6"
+      // scroll-mb on every focusable control: the sticky save bar overlays the
+      // bottom of the viewport, so keyboard-focus auto-scroll must clear it
+      // (bar height + its bottom offset, largest when stacked on mobile with
+      // the mini player visible).
+      className="@container max-w-5xl space-y-6 [&_:is(button,input,select)]:scroll-mb-72 sm:[&_:is(button,input,select)]:scroll-mb-44"
     >
       <Card
         className={cn(
@@ -688,7 +693,7 @@ function GeneralSettingsForm({ settings }: GeneralSettingsFormProps) {
       <div
         className={cn(
           "sticky z-10 rounded-lg border border-border/50 bg-card/95 p-4 shadow-lg shadow-black/10 backdrop-blur-md supports-backdrop-filter:bg-card/85 sm:flex sm:items-center sm:justify-between sm:gap-4",
-          isMiniPlayerVisible ? "bottom-28 sm:bottom-24" : "bottom-4",
+          isMiniPlayerVisible ? MINI_PLAYER_CLEARANCE_BOTTOM_CLASS : "bottom-4",
           MOTION_SETTINGS_SURFACE_CLASS,
         )}
       >
@@ -984,7 +989,7 @@ function GeneralSettingsLoading() {
 
   return (
     <div
-      className="@container max-w-5xl space-y-6"
+      className="max-w-5xl space-y-6"
       role="status"
       aria-labelledby={loadingId}
     >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page spacing and scrolling when the mini audio player is visible.
  * Adjusted the settings save bar to avoid overlapping with the mini player.
  * Improved focus behavior for controls near the bottom of the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->