### PR TITLE
Fix empty technical details runtime row

### DIFF
--- a/web/src/components/MovieChaptersSection.tsx
+++ b/web/src/components/MovieChaptersSection.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { formatTimeSeconds } from "@/lib/format";
+import { formatTimecode } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { MovieChaptersSectionProps } from "@/types";
 
@@ -50,7 +50,7 @@ export default function MovieChaptersSection({
             >
               <span className="leading-snug font-medium">{chapter.title}</span>
               <span className="mt-0.5 text-muted-foreground">
-                {formatTimeSeconds(chapter.start_time)}
+                {formatTimecode(chapter.start_time)}
               </span>
             </Link>
           </li>

--- a/web/src/components/MoviePlayerControls.tsx
+++ b/web/src/components/MoviePlayerControls.tsx
@@ -15,7 +15,7 @@ import {
   MOTION_PLAYER_CHROME_BUTTON_CLASS,
   MOTION_PLAYER_CHROME_PANEL_CLASS,
 } from "@/lib/constants";
-import { formatTimeSeconds } from "@/lib/format";
+import { formatTimecode } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { ChapterType } from "@/types";
 
@@ -85,11 +85,13 @@ export default function MoviePlayerControls({
         <div className="flex items-center justify-between">
           <div className="flex min-w-25 items-center gap-2">
             <span className="text-sm text-muted-foreground tabular-nums">
-              {formatTimeSeconds(currentTime)}
+              {formatTimecode(currentTime, {
+                forceHours: displayedDuration >= 3600,
+              })}
             </span>
             <span className="text-muted-foreground">/</span>
             <span className="text-sm text-muted-foreground tabular-nums">
-              {formatTimeSeconds(displayedDuration)}
+              {formatTimecode(displayedDuration)}
             </span>
           </div>
 

--- a/web/src/components/ProgressBar.tsx
+++ b/web/src/components/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { formatTimeSeconds } from "@/lib/format";
+import { formatSpokenTime, formatTimecode } from "@/lib/format";
 import {
   MOTION_PROGRESS_FILL_CLASS,
   MOTION_PROGRESS_THUMB_REVEAL_CLASS,
@@ -214,15 +214,18 @@ export default function ProgressBar({
         aria-disabled={!isSeekable}
         aria-valuetext={
           isSeekable
-            ? `${formatTimeSeconds(safeCurrentTime)} of ${formatTimeSeconds(safeDuration)}`
+            ? `${formatSpokenTime(safeCurrentTime)} of ${formatSpokenTime(safeDuration)}`
             : "Seek unavailable"
         }
       />
     </div>
   );
 
-  const currentTimeLabel = formatTimeSeconds(safeCurrentTime);
-  const durationLabel = formatTimeSeconds(safeDuration);
+  const showHours = safeDuration >= 3600;
+  const currentTimeLabel = formatTimecode(safeCurrentTime, {
+    forceHours: showHours,
+  });
+  const durationLabel = formatTimecode(safeDuration);
 
   if (styles.timesLayout === "inline") {
     return (

--- a/web/src/components/ResumeDialog.tsx
+++ b/web/src/components/ResumeDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
-import { formatTimeSeconds } from "@/lib/format";
+import { formatTimecode } from "@/lib/format";
 import { focusDialogRestoreTarget } from "@/hooks/useDialogFocusRestore";
 import { MOTION_MEDIA_DIALOG_SURFACE_CLASS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
@@ -58,7 +58,7 @@ export default function ResumeDialog({
           <DialogTitle className="text-foreground">Resume movie?</DialogTitle>
           <DialogDescription className="text-muted-foreground">
             {savedProgressSec !== null
-              ? `Resume from ${formatTimeSeconds(savedProgressSec)} or start from the beginning.`
+              ? `Resume from ${formatTimecode(savedProgressSec)} or start from the beginning.`
               : "Resume your saved progress or start from the beginning."}
           </DialogDescription>
         </DialogHeader>

--- a/web/src/components/SpotifyTrackPicker.tsx
+++ b/web/src/components/SpotifyTrackPicker.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { searchSpotifyTracks } from "@/lib/api";
+import { formatTrackDuration } from "@/lib/format";
 import { showActionFailed, showInfo } from "@/lib/toast-helpers";
 import { cn } from "@/lib/utils";
 import type {
@@ -22,17 +23,6 @@ type SpotifyTrackPickerProps = {
     body: SpotifyTrackSearchRequest,
   ) => Promise<ApiResponseType<{ results: SpotifyTrackSearchResultType[] }>>;
 };
-
-function formatTrackDuration(durationMs: number): string {
-  if (!Number.isFinite(durationMs) || durationMs <= 0) {
-    return "";
-  }
-
-  const totalSeconds = Math.round(durationMs / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-}
 
 export default function SpotifyTrackPicker({
   confirmLabel,

--- a/web/src/components/TechnicalDetailsDialog.tsx
+++ b/web/src/components/TechnicalDetailsDialog.tsx
@@ -225,6 +225,7 @@ export default function TechnicalDetailsDialog({
 
   const details = data?.data;
   const runTime = details ? unwrapInt(details.movie.run_time) : null;
+  const formattedRuntime = formatRuntimeMinutes(runTime);
   const durationSec = details ? unwrapFloat(details.movie.duration) : null;
 
   const handleOpenAutoFocus = (e: Event) => {
@@ -304,10 +305,10 @@ export default function TechnicalDetailsDialog({
                     label="Media type (MIME)"
                     value={details.movie.mime_type}
                   />
-                  {runTime != null && (
+                  {formattedRuntime && (
                     <DetailRow
                       label="Duration (rounded, for display)"
-                      value={formatRuntimeMinutes(runTime)}
+                      value={formattedRuntime}
                     />
                   )}
                   {durationSec != null && (

--- a/web/src/components/TechnicalDetailsDialog.tsx
+++ b/web/src/components/TechnicalDetailsDialog.tsx
@@ -2,7 +2,7 @@ import { useRef, type RefObject } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { movieTechnicalDetailsQueryOpts } from "@/lib/query-opts";
 import { unwrapString, unwrapInt, unwrapFloat } from "@/lib/nullable";
-import { formatBitRate } from "@/lib/format";
+import { formatBitRate, formatRuntimeMinutes } from "@/lib/format";
 import type {
   VideoStreamType,
   AudioStreamType,
@@ -24,12 +24,6 @@ function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024 * 1024)
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-function formatRuntime(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
 function SectionHeading({
@@ -313,7 +307,7 @@ export default function TechnicalDetailsDialog({
                   {runTime != null && (
                     <DetailRow
                       label="Duration (rounded, for display)"
-                      value={formatRuntime(runTime)}
+                      value={formatRuntimeMinutes(runTime)}
                     />
                   )}
                   {durationSec != null && (

--- a/web/src/components/watch-room/WatchRoomPage.tsx
+++ b/web/src/components/watch-room/WatchRoomPage.tsx
@@ -21,7 +21,7 @@ import {
   WATCH_ROOM_CLIENT_EVENT_TYPES,
   WATCH_ROOM_SEEK_STEP_SEC,
 } from "@/lib/constants";
-import { formatTimeSeconds } from "@/lib/format";
+import { formatTimecode } from "@/lib/format";
 import { buildTmdbImageUrl } from "@/lib/tmdb-image-url";
 import {
   movieTechnicalDetailsQueryOpts,
@@ -572,8 +572,10 @@ function WatchRoomPlayerPanel({
 
             <div className="flex items-center gap-4">
               <p className="text-sm font-medium text-muted-foreground">
-                {formatTimeSeconds(currentTime)} /{" "}
-                {formatTimeSeconds(duration)}
+                {formatTimecode(currentTime, {
+                  forceHours: duration >= 3600,
+                })}{" "}
+                / {formatTimecode(duration)}
               </p>
               <VolumeControl mediaRef={videoRef} />
               <button

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -48,7 +48,13 @@ export function formatDuration(ms: number) {
 }
 
 // takes in a duration in milliseconds and returns a formatted duration string
+// ("m:ss"); returns an empty string for missing or invalid durations so
+// callers can conditionally render it
 export function formatTrackDuration(ms: number) {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return "";
+  }
+
   const totalSeconds = Math.floor(ms / 1000);
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
@@ -61,22 +67,17 @@ export function formatBitRate(bitRate: number) {
   return `${Math.round(bitRate / 1000)} kbps`;
 }
 
-// Format seconds into mm:ss format (for audio player progress)
-// Handles edge cases like NaN and Infinity
-export function formatTimeSeconds(seconds: number) {
-  if (!isFinite(seconds) || isNaN(seconds)) return "0:00";
-
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
-}
-
-// Format seconds into a clock timecode, including the hours field only when
-// needed: "1:23" under an hour, "1:05:23" once it crosses an hour. Use this for
-// long-form content (movies, chapter markers) where mm:ss would overflow into
-// confusing values like "65:23".
-export function formatTimecode(seconds: number) {
+// Format seconds into a clock timecode for playback positions, including the
+// hours field only when needed: "1:23" under an hour, "1:05:23" once it
+// crosses an hour. Use this wherever mm:ss would overflow into confusing
+// values like "65:23". When rendering a current-time/duration pair, pass
+// `forceHours` on the current-time side (keyed on the duration) so the readout
+// keeps the duration's shape ("0:05:00 / 2:05:00") instead of changing width
+// when playback crosses the hour mark.
+export function formatTimecode(
+  seconds: number,
+  options?: { forceHours?: boolean },
+) {
   if (!isFinite(seconds) || isNaN(seconds) || seconds < 0) return "0:00";
 
   const total = Math.floor(seconds);
@@ -84,7 +85,7 @@ export function formatTimecode(seconds: number) {
   const mins = Math.floor((total % 3600) / 60);
   const secs = total % 60;
 
-  if (hours > 0) {
+  if (hours > 0 || options?.forceHours) {
     return `${hours}:${mins.toString().padStart(2, "0")}:${secs
       .toString()
       .padStart(2, "0")}`;

--- a/web/src/routes/_auth/trailer.lazy.tsx
+++ b/web/src/routes/_auth/trailer.lazy.tsx
@@ -29,7 +29,7 @@ import { movieDetailsQueryOpts } from "@/lib/query-opts";
 import { useYouTubePlayer } from "@/hooks/useYouTubePlayer";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
 import { toast } from "sonner";
-import { formatTimeSeconds } from "@/lib/format";
+import { formatTimecode } from "@/lib/format";
 import {
   MOVIE_SEEK_STEP_SEC,
   MOTION_MEDIA_OVERLAY_ENTER_CLASS,
@@ -478,11 +478,13 @@ function TrailerPage() {
           <div className="flex items-center justify-between">
             <div className="flex min-w-[100px] items-center gap-2">
               <span className="text-sm text-muted-foreground tabular-nums">
-                {formatTimeSeconds(currentTime)}
+                {formatTimecode(currentTime, {
+                  forceHours: duration >= 3600,
+                })}
               </span>
               <span className="text-muted-foreground">/</span>
               <span className="text-sm text-muted-foreground tabular-nums">
-                {formatTimeSeconds(duration)}
+                {formatTimecode(duration)}
               </span>
             </div>
 

--- a/web/src/test/format.test.ts
+++ b/web/src/test/format.test.ts
@@ -2,7 +2,74 @@ import { describe, expect, it } from "vitest";
 import {
   formatRuntimeMinutes,
   formatSpokenRuntimeMinutes,
+  formatSpokenTime,
+  formatTimecode,
+  formatTrackDuration,
 } from "@/lib/format";
+
+describe("formatTrackDuration", () => {
+  it("returns an empty string for missing or invalid durations", () => {
+    expect(formatTrackDuration(0)).toBe("");
+    expect(formatTrackDuration(-1)).toBe("");
+    expect(formatTrackDuration(Number.NaN)).toBe("");
+    expect(formatTrackDuration(Number.POSITIVE_INFINITY)).toBe("");
+  });
+
+  it("formats millisecond durations as m:ss", () => {
+    expect(formatTrackDuration(225000)).toBe("3:45");
+    expect(formatTrackDuration(61000)).toBe("1:01");
+  });
+
+  it("floors partial seconds", () => {
+    expect(formatTrackDuration(200700)).toBe("3:20");
+  });
+});
+
+describe("formatTimecode", () => {
+  it("returns 0:00 for non-finite or negative input", () => {
+    expect(formatTimecode(Number.NaN)).toBe("0:00");
+    expect(formatTimecode(Number.POSITIVE_INFINITY)).toBe("0:00");
+    expect(formatTimecode(-1)).toBe("0:00");
+    expect(formatTimecode(-1, { forceHours: true })).toBe("0:00");
+  });
+
+  it("formats sub-hour values as m:ss", () => {
+    expect(formatTimecode(0)).toBe("0:00");
+    expect(formatTimecode(83)).toBe("1:23");
+    expect(formatTimecode(3599)).toBe("59:59");
+  });
+
+  it("includes the hours field past one hour", () => {
+    expect(formatTimecode(3600)).toBe("1:00:00");
+    expect(formatTimecode(3923)).toBe("1:05:23");
+    expect(formatTimecode(7500)).toBe("2:05:00");
+  });
+
+  it("pads sub-hour values to h:mm:ss when forceHours is set", () => {
+    expect(formatTimecode(300, { forceHours: true })).toBe("0:05:00");
+    expect(formatTimecode(12, { forceHours: true })).toBe("0:00:12");
+    expect(formatTimecode(3923, { forceHours: true })).toBe("1:05:23");
+  });
+
+  it("floors fractional seconds", () => {
+    expect(formatTimecode(89.9)).toBe("1:29");
+  });
+});
+
+describe("formatSpokenTime", () => {
+  it("returns 0 seconds for non-finite, negative, or zero input", () => {
+    expect(formatSpokenTime(Number.NaN)).toBe("0 seconds");
+    expect(formatSpokenTime(-5)).toBe("0 seconds");
+    expect(formatSpokenTime(0)).toBe("0 seconds");
+  });
+
+  it("formats playback positions as words, dropping zero fields", () => {
+    expect(formatSpokenTime(1)).toBe("1 second");
+    expect(formatSpokenTime(330)).toBe("5 minutes 30 seconds");
+    expect(formatSpokenTime(3600)).toBe("1 hour");
+    expect(formatSpokenTime(3923)).toBe("1 hour 5 minutes 23 seconds");
+  });
+});
 
 describe("formatRuntimeMinutes", () => {
   it("returns null for empty, non-finite, or non-positive runtimes", () => {

--- a/web/src/test/movie-player-controls.test.tsx
+++ b/web/src/test/movie-player-controls.test.tsx
@@ -54,4 +54,32 @@ describe("MoviePlayerControls", () => {
       screen.getByRole("button", { name: "Adjust volume" }),
     ).toHaveClass(...MOTION_PLAYER_CHROME_BUTTON_CLASS.split(" "));
   });
+
+  it("pads the current time to h:mm:ss for movies over an hour", () => {
+    render(
+      <MoviePlayerControls
+        chromeFullscreenMode
+        controlsVisible
+        isFullscreen={false}
+        isImmersiveViewport
+        currentTime={12}
+        duration={7500}
+        displayedDuration={7500}
+        playing={false}
+        qualityLabel="Direct"
+        chapters={[]}
+        videoRef={createRef<HTMLVideoElement>()}
+        onSeek={vi.fn()}
+        onSeekBackward={vi.fn()}
+        onSeekForward={vi.fn()}
+        onTogglePlay={vi.fn()}
+        onToggleFullscreen={vi.fn()}
+        onSelectChapter={vi.fn()}
+      />,
+    );
+
+    // Rendered by both the chrome readout and the progress bar labels.
+    expect(screen.getAllByText("0:00:12").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2:05:00").length).toBeGreaterThan(0);
+  });
 });

--- a/web/src/test/progress-bar.test.tsx
+++ b/web/src/test/progress-bar.test.tsx
@@ -204,6 +204,26 @@ describe("ProgressBar", () => {
     expect(slider.value).toBe("51");
   });
 
+  it("shows hour-padded time labels and spoken value text past one hour", () => {
+    render(
+      <ProgressBar
+        currentTime={300}
+        duration={7500}
+        onSeek={vi.fn()}
+        variant="video"
+      />,
+    );
+
+    // Current time is padded to the duration's h:mm:ss shape so the readout
+    // width stays stable across the hour mark.
+    expect(screen.getByText("0:05:00")).toBeInTheDocument();
+    expect(screen.getByText("2:05:00")).toBeInTheDocument();
+    expect(screen.getByRole("slider")).toHaveAttribute(
+      "aria-valuetext",
+      "5 minutes of 2 hours 5 minutes",
+    );
+  });
+
   it("drops a pending scrub value when resetKey changes", () => {
     const onSeek = vi.fn();
 

--- a/web/src/test/technical-details-dialog.test.tsx
+++ b/web/src/test/technical-details-dialog.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import TechnicalDetailsDialog from "@/components/TechnicalDetailsDialog";
+import { MOVIE_TECHNICAL_DETAILS_KEY } from "@/lib/constants";
+import type {
+  ApiResponseType,
+  MovieTechnicalDetailsResponse,
+} from "@/types";
+
+function nullableInt64(value: number | null = null) {
+  return {
+    Int64: value ?? 0,
+    Valid: value != null,
+  };
+}
+
+function nullableFloat64(value: number | null = null) {
+  return {
+    Float64: value ?? 0,
+    Valid: value != null,
+  };
+}
+
+function technicalDetails(
+  runtimeMinutes: number | null,
+): ApiResponseType<MovieTechnicalDetailsResponse> {
+  return {
+    error: false,
+    data: {
+      movie: {
+        file_name: "arrival.mp4",
+        file_path: "/media/arrival.mp4",
+        size: 1000,
+        container: "mp4",
+        mime_type: "video/mp4",
+        run_time: nullableInt64(runtimeMinutes),
+        duration: nullableFloat64(6960),
+      },
+      video_streams: [],
+      audio_streams: [],
+      subtitles: [],
+      chapters: [],
+    },
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function renderDialog(runtimeMinutes: number | null) {
+  const queryClient = createQueryClient();
+  queryClient.setQueryData(
+    [MOVIE_TECHNICAL_DETAILS_KEY, 22],
+    technicalDetails(runtimeMinutes),
+  );
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TechnicalDetailsDialog
+        movieId={22}
+        open
+        onOpenChange={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("TechnicalDetailsDialog", () => {
+  it("does not render rounded duration when runtime formats to no value", () => {
+    renderDialog(0);
+
+    expect(
+      screen.queryByText("Duration (rounded, for display)"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Exact duration (ffprobe)")).toBeInTheDocument();
+    expect(screen.getByText("6960.00 s")).toBeInTheDocument();
+  });
+
+  it("renders rounded duration when runtime is displayable", () => {
+    renderDialog(116);
+
+    expect(
+      screen.getByText("Duration (rounded, for display)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 hr 56 min")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Gate the technical details rounded duration row on the formatted runtime value
- Add regression coverage for zero-runtime technical details data

## Tests
- bun run test -- src/test/technical-details-dialog.test.tsx src/test/format.test.ts
- bun run lint
- bun run build
- bun run test

## Notes
- Chrome DevTools/browser validation was not performed because the connector could not start a browser without an X server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized playback time displays across movie players, chapters, trailers, watch rooms, progress bars, and resume prompts.
  * Durations over one hour now consistently include hours in visible timecodes.
  * Improved accessible progress-bar time descriptions with spoken duration formatting.
  * Improved handling of unavailable or invalid track and runtime values.

* **Tests**
  * Added coverage for long-duration displays, accessibility labels, formatting behavior, and technical runtime details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->