### PR TITLE
Working on improving the musicians tab section in the music index page

### DIFF
--- a/web/e2e/music-index.spec.ts
+++ b/web/e2e/music-index.spec.ts
@@ -448,7 +448,7 @@ test("musicians tab renders accessible count text and URL-backed pagination", as
   await expect(musiciansTab).toHaveAttribute("aria-selected", "true");
 
   await expect(page.getByRole("link", { name: "Aurora Pines, 2 albums, 18 tracks" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Midnight Static, 1 albums, 9 tracks" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Midnight Static, 1 album, 9 tracks" })).toBeVisible();
 
   await page.getByRole("button", { name: "Go to next page" }).click();
 
@@ -466,6 +466,41 @@ test("musicians tab renders accessible count text and URL-backed pagination", as
     )
     .toBe(true);
   await expect(page.getByRole("link", { name: "Northern Signal, 3 albums, 27 tracks" })).toBeVisible();
+  assertMockSuiteClean(browserIssues, unexpectedApiRequests);
+});
+
+test("musicians tab shows an inline error with a working retry", async ({ page }) => {
+  const requestedMusicianRequests: string[] = [];
+  const browserIssues = trackBrowserIssues(page);
+
+  const unexpectedApiRequests = await mockMusicIndexApi(
+    page,
+    requestedMusicianRequests,
+  );
+
+  let failNextMusiciansRequest = true;
+  await page.route(/\/api\/music\/musicians\?/, async route => {
+    if (!failNextMusiciansRequest) {
+      await route.fallback();
+      return;
+    }
+
+    failNextMusiciansRequest = false;
+    await fulfillJSON(route, {
+      error: true,
+      message: "Music library is unavailable",
+    });
+  });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/music?tab=musicians");
+
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText("Music library is unavailable");
+
+  await alert.getByRole("button", { name: "Try again" }).click();
+
+  await expect(page.getByRole("link", { name: "Aurora Pines, 2 albums, 18 tracks" })).toBeVisible();
   assertMockSuiteClean(browserIssues, unexpectedApiRequests);
 });
 

--- a/web/e2e/music-tracks.spec.ts
+++ b/web/e2e/music-tracks.spec.ts
@@ -277,7 +277,7 @@ test("music library shell and URL-backed tabs render accessibly", async ({ page 
   await musiciansTab.click();
   await expect(page).toHaveURL(/tab=musicians/);
   await expect(musiciansTab).toHaveAttribute("aria-selected", "true");
-  await expect(page.getByRole("link", { name: "Mock Artist, 1 albums, 2267 tracks" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Mock Artist, 1 album, 2267 tracks" })).toBeVisible();
 
   await albumsTab.click();
   await expect(page).toHaveURL(/tab=albums/);

--- a/web/src/components/MusicianCard.tsx
+++ b/web/src/components/MusicianCard.tsx
@@ -39,7 +39,7 @@ export default function MusicianCard({ musician }: MusicianCardProps) {
       <Link
         to="/music/musician/$id"
         params={{ id: id.toString() }}
-        className="block rounded-xl outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        className="block rounded-xl outline-hidden"
         aria-label={`${name}, ${pluralize(album_count, "album")}, ${pluralize(track_count, "track")}`}
       >
         {/* Musician thumbnail - circular; fallback to User icon on load error */}

--- a/web/src/components/MusicianCard.tsx
+++ b/web/src/components/MusicianCard.tsx
@@ -1,7 +1,10 @@
-import { useState } from "react";
 import { Link } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { User } from "lucide-react";
+import { musicianDetailsQueryOpts } from "@/lib/query-opts";
+import { usePosterFallback } from "@/hooks/usePosterFallback";
 import {
+  CARD_FOCUS_WITHIN_RING_CLASS,
   CARD_MEDIA_HOVER_CLASS,
   CARD_SURFACE_CLASS,
 } from "@/lib/constants";
@@ -14,22 +17,30 @@ type MusicianCardProps = {
   musician: SimpleMusicianType;
 };
 
+const pluralize = (count: number, noun: string) =>
+  `${count} ${noun}${count === 1 ? "" : "s"}`;
+
 export default function MusicianCard({ musician }: MusicianCardProps) {
   const { id, name, thumb, album_count, track_count } = musician;
-  const thumbUrl = getMediaImageUrl(unwrapString(thumb));
-  const [failedThumbUrl, setFailedThumbUrl] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  const showThumb = thumbUrl && thumbUrl !== failedThumbUrl;
+  const thumbUrl = getMediaImageUrl(unwrapString(thumb)) ?? "";
+  const { showPoster: showThumb, onError } = usePosterFallback(thumbUrl);
+
+  const handlePrefetch = () =>
+    queryClient.prefetchQuery(musicianDetailsQueryOpts(id));
 
   return (
     <article
-      className={cn(CARD_SURFACE_CLASS, "p-4")}
+      className={cn(CARD_SURFACE_CLASS, CARD_FOCUS_WITHIN_RING_CLASS, "p-4")}
+      onMouseEnter={handlePrefetch}
+      onFocus={handlePrefetch}
     >
       <Link
         to="/music/musician/$id"
         params={{ id: id.toString() }}
-        className="block focus:ring-2 focus:ring-ring focus:outline-hidden focus:ring-inset"
-        aria-label={`${name}, ${album_count} albums, ${track_count} tracks`}
+        className="block rounded-xl outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        aria-label={`${name}, ${pluralize(album_count, "album")}, ${pluralize(track_count, "track")}`}
       >
         {/* Musician thumbnail - circular; fallback to User icon on load error */}
         <div className="relative mx-auto mb-3 aspect-square w-full max-w-32 overflow-hidden rounded-full bg-muted">
@@ -37,10 +48,14 @@ export default function MusicianCard({ musician }: MusicianCardProps) {
             <img
               src={thumbUrl}
               alt={`Photo of ${name}`}
+              width={256}
+              height={256}
               loading="lazy"
               decoding="async"
+              fetchPriority="low"
+              sizes="128px"
               className={cn("size-full object-cover", CARD_MEDIA_HOVER_CLASS)}
-              onError={() => setFailedThumbUrl(thumbUrl)}
+              onError={onError}
             />
           ) : (
             <div className="flex size-full items-center justify-center">
@@ -53,8 +68,7 @@ export default function MusicianCard({ musician }: MusicianCardProps) {
         <div className="text-center">
           <h3 className="truncate text-sm font-semibold text-foreground">{name}</h3>
           <p className="mt-0.5 text-xs text-muted-foreground">
-            {album_count} {album_count === 1 ? "album" : "albums"} ·{" "}
-            {track_count} {track_count === 1 ? "track" : "tracks"}
+            {pluralize(album_count, "album")} · {pluralize(track_count, "track")}
           </p>
         </div>
       </Link>

--- a/web/src/routes/_auth/music/index.tsx
+++ b/web/src/routes/_auth/music/index.tsx
@@ -35,6 +35,8 @@ import { useWindowScrollMargin } from "@/hooks/useWindowScrollMargin";
 import { showActionFailed, showSuccess } from "@/lib/toast-helpers";
 import { refreshMusicLibraryCache } from "@/lib/music-library-cache";
 import LiveAnnouncer from "@/components/LiveAnnouncer";
+import { MoviesLoadError } from "@/components/MoviesLoadError";
+import { isApiFailure } from "@/lib/is-api-failure";
 import { unwrapString, unwrapInt, unwrapStringOrUndefined } from "@/lib/nullable";
 import {
   albumsPaginatedQueryOpts,
@@ -425,12 +427,6 @@ type MusiciansTabContentProps = {
 function MusiciansTabSkeleton() {
   return (
     <div>
-      {/* Skeleton header */}
-      <div className="mb-6 flex items-center justify-between">
-        <div className={cn("h-4 w-24 rounded-sm bg-muted", MOTION_LOADING_STATE_CLASS)} />
-        <div className={cn("h-4 w-20 rounded-sm bg-muted", MOTION_LOADING_STATE_CLASS)} />
-      </div>
-
       {/* Skeleton grid - matches actual grid dimensions */}
       <div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
         {Array.from({ length: MUSICIANS_PER_PAGE }).map((_, i) => (
@@ -454,7 +450,7 @@ function MusiciansTabSkeleton() {
 function MusiciansTabContent({ currentPage }: MusiciansTabContentProps) {
   const navigate = Route.useNavigate();
 
-  const { data, isLoading } = useQuery(
+  const { data, isLoading, isError, refetch } = useQuery(
     musiciansPaginatedQueryOpts(currentPage, MUSICIANS_PER_PAGE),
   );
 
@@ -466,7 +462,7 @@ function MusiciansTabContent({ currentPage }: MusiciansTabContentProps) {
   const getAnnouncement = () => {
     if (isLoading) return undefined;
     if (musicians.length === 0) return "No musicians found";
-    return `Showing ${musicians.length} musicians, page ${currentPage} of ${totalPages}`;
+    return `Showing ${musicians.length} musician${musicians.length === 1 ? "" : "s"}, page ${currentPage} of ${totalPages}`;
   };
 
   const handlePageChange = (newPage: number) => {
@@ -486,9 +482,23 @@ function MusiciansTabContent({ currentPage }: MusiciansTabContentProps) {
     return <MusiciansTabSkeleton />;
   }
 
+  if (isError || isApiFailure(data)) {
+    return (
+      <MoviesLoadError
+        message={
+          isApiFailure(data)
+            ? data.message
+            : "Couldn’t load musicians. Check your connection and try again."
+        }
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
   if (musicians.length === 0) {
     return (
       <div className="py-12 text-center text-muted-foreground">
+        <LiveAnnouncer message={getAnnouncement()} />
         <Users className="mx-auto mb-4 size-10 opacity-50" aria-hidden="true" />
         <p>No musicians found in your library.</p>
       </div>
@@ -560,7 +570,7 @@ function AlbumsTabSkeleton() {
 function AlbumsTabContent({ currentPage, perPage }: AlbumsTabContentProps) {
   const navigate = Route.useNavigate();
 
-  const { data, isLoading } = useQuery(
+  const { data, isLoading, isError, refetch } = useQuery(
     albumsPaginatedQueryOpts(currentPage, perPage),
   );
 
@@ -572,7 +582,7 @@ function AlbumsTabContent({ currentPage, perPage }: AlbumsTabContentProps) {
   const getAnnouncement = () => {
     if (isLoading) return undefined;
     if (albums.length === 0) return "No albums found";
-    return `Showing ${albums.length} albums, page ${currentPage} of ${totalPages}`;
+    return `Showing ${albums.length} album${albums.length === 1 ? "" : "s"}, page ${currentPage} of ${totalPages}`;
   };
 
   const handlePageChange = (newPage: number) => {
@@ -592,9 +602,23 @@ function AlbumsTabContent({ currentPage, perPage }: AlbumsTabContentProps) {
     return <AlbumsTabSkeleton />;
   }
 
+  if (isError || isApiFailure(data)) {
+    return (
+      <MoviesLoadError
+        message={
+          isApiFailure(data)
+            ? data.message
+            : "Couldn’t load albums. Check your connection and try again."
+        }
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
   if (albums.length === 0) {
     return (
       <div className="py-12 text-center text-muted-foreground">
+        <LiveAnnouncer message={getAnnouncement()} />
         <Disc3 className="mx-auto mb-4 size-10 opacity-50" aria-hidden="true" />
         <p>No albums found in your library.</p>
       </div>

--- a/web/src/test/music-route.test.tsx
+++ b/web/src/test/music-route.test.tsx
@@ -87,10 +87,12 @@ function track(id: number, title: string) {
 
 type MockMusicFetchOptions = {
   spotifyAvailable?: boolean;
+  emptyMusicians?: boolean;
 };
 
 function mockMusicFetch(options: MockMusicFetchOptions = {}) {
   const spotifyAvailable = options.spotifyAvailable ?? true;
+  const emptyMusicians = options.emptyMusicians ?? false;
   const fetchMock = vi.fn((input: RequestInfo | URL) => {
     const url = requestURL(input);
 
@@ -153,6 +155,19 @@ function mockMusicFetch(options: MockMusicFetchOptions = {}) {
     }
 
     if (url === `/api/music/musicians?page=1&per_page=${MUSICIANS_PER_PAGE}`) {
+      if (emptyMusicians) {
+        return jsonResponse({
+          error: false,
+          data: {
+            musicians: [],
+            total: 0,
+            page: 1,
+            per_page: MUSICIANS_PER_PAGE,
+            total_pages: 0,
+          },
+        });
+      }
+
       return jsonResponse({
         error: false,
         data: {
@@ -323,6 +338,27 @@ describe("music route tab transitions", () => {
         ([, delay]) => delay === CONTENT_FADE_TRANSITION_MS,
       ),
     ).toBe(false);
+  });
+});
+
+describe("musicians tab empty state", () => {
+  it("renders and announces the empty musicians state", async () => {
+    setReducedMotionPreference(true);
+
+    await renderMusicRoute("/music/?tab=musicians", { emptyMusicians: true });
+
+    expect(
+      await screen.findByText("No musicians found in your library."),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      const statusRegions = screen.getAllByRole("status");
+      expect(
+        statusRegions.some(
+          region => region.textContent === "No musicians found",
+        ),
+      ).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer empty-state messaging and screen-reader announcements for Music Library tabs.
  * Added inline error alerts with a “Try again” option when musician or album data fails to load.
  * Improved musician image fallback behavior and keyboard focus styling.

* **Bug Fixes**
  * Corrected singular album wording, changing “1 albums” to “1 album.”
  * Improved loading and retry behavior for Music Library content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->