### PR TITLE
Fixed an issues found by codex on playback watch progress saving

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7433,7 +7433,9 @@
         "type": "object",
         "required": [
           "progress_sec",
-          "duration_sec"
+          "duration_sec",
+          "save_session_id",
+          "save_sequence"
         ],
         "properties": {
           "progress_sec": {
@@ -7443,6 +7445,15 @@
           "duration_sec": {
             "type": "number",
             "exclusiveMinimum": 0
+          },
+          "save_session_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "save_sequence": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 1
           }
         },
         "additionalProperties": false

--- a/server/cmd/api/watch_progress_handler.go
+++ b/server/cmd/api/watch_progress_handler.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"igloo/cmd/internal/database"
 	"igloo/cmd/internal/helpers"
@@ -16,8 +18,20 @@ import (
 const watchCompletionThreshold = 0.98
 
 type updateMovieWatchProgressRequest struct {
-	ProgressSec *float64 `json:"progress_sec"`
-	DurationSec *float64 `json:"duration_sec"`
+	ProgressSec   *float64 `json:"progress_sec"`
+	DurationSec   *float64 `json:"duration_sec"`
+	SaveSessionID *string  `json:"save_session_id"`
+	SaveSequence  *int64   `json:"save_sequence"`
+}
+
+func validUUID(value string) bool {
+	if len(value) != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-' {
+		return false
+	}
+
+	hexValue := strings.ReplaceAll(value, "-", "")
+	_, err := hex.DecodeString(hexValue)
+	return err == nil
 }
 
 type setMovieWatchedRequest struct {
@@ -175,6 +189,22 @@ func (app *Application) UpdateMovieWatchProgress(w http.ResponseWriter, r *http.
 		helpers.ErrorJSON(w, errors.New("duration_sec is required"), http.StatusBadRequest)
 		return
 	}
+	if req.SaveSessionID == nil {
+		helpers.ErrorJSON(w, errors.New("save_session_id is required"), http.StatusBadRequest)
+		return
+	}
+	if !validUUID(*req.SaveSessionID) {
+		helpers.ErrorJSON(w, errors.New("save_session_id must be a valid UUID"), http.StatusBadRequest)
+		return
+	}
+	if req.SaveSequence == nil {
+		helpers.ErrorJSON(w, errors.New("save_sequence is required"), http.StatusBadRequest)
+		return
+	}
+	if *req.SaveSequence <= 0 {
+		helpers.ErrorJSON(w, errors.New("save_sequence must be greater than 0"), http.StatusBadRequest)
+		return
+	}
 
 	progressVal := *req.ProgressSec
 	durationVal := *req.DurationSec
@@ -192,10 +222,13 @@ func (app *Application) UpdateMovieWatchProgress(w http.ResponseWriter, r *http.
 	durationSec := durationVal
 
 	if progressSec/durationSec >= watchCompletionThreshold {
-		if err := app.Queries.MarkMovieWatched(r.Context(), database.MarkMovieWatchedParams{
-			UserID:  userID,
-			MovieID: movieID,
-		}); err != nil {
+		err := app.Queries.MarkMovieWatchedFromProgress(r.Context(), database.MarkMovieWatchedFromProgressParams{
+			UserID:        userID,
+			MovieID:       movieID,
+			SaveSessionID: *req.SaveSessionID,
+			SaveSequence:  *req.SaveSequence,
+		})
+		if err != nil {
 			app.Logger.Error("failed to mark movie watched from progress update", "error", err, "movie_id", movieID, "user_id", userID)
 			helpers.ErrorJSON(w, errors.New("failed to update watch progress"))
 			return
@@ -210,12 +243,15 @@ func (app *Application) UpdateMovieWatchProgress(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if err := app.Queries.UpsertMovieWatchProgress(r.Context(), database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: progressSec,
-		DurationSec: durationSec,
-	}); err != nil {
+	err = app.Queries.UpsertMovieWatchProgress(r.Context(), database.UpsertMovieWatchProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   progressSec,
+		DurationSec:   durationSec,
+		SaveSessionID: *req.SaveSessionID,
+		SaveSequence:  *req.SaveSequence,
+	})
+	if err != nil {
 		app.Logger.Error("failed to upsert movie watch progress", "error", err, "movie_id", movieID, "user_id", userID)
 		helpers.ErrorJSON(w, errors.New("failed to update watch progress"))
 		return

--- a/server/cmd/api/watch_progress_handler_test.go
+++ b/server/cmd/api/watch_progress_handler_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+const testWatchProgressSaveSessionID = "11111111-1111-4111-8111-111111111111"
+
 func createTestUserAndMovie(t *testing.T, app *Application) (userID, movieID int64) {
 	t.Helper()
 	ctx := context.Background()
@@ -53,10 +55,12 @@ func TestWatchProgress_UpsertAndGet(t *testing.T) {
 	userID, movieID := createTestUserAndMovie(t, app)
 
 	err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 300.5,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   300.5,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("UpsertMovieWatchProgress failed: %v", err)
@@ -89,20 +93,24 @@ func TestWatchProgress_UpsertUpdatesExisting(t *testing.T) {
 	userID, movieID := createTestUserAndMovie(t, app)
 
 	err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 100.0,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   100.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("first upsert failed: %v", err)
 	}
 
 	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 500.0,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   500.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  2,
 	})
 	if err != nil {
 		t.Fatalf("second upsert failed: %v", err)
@@ -148,10 +156,12 @@ func TestWatchProgress_UpsertResetsWatchedFlag(t *testing.T) {
 	}
 
 	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 60.0,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   60.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("UpsertMovieWatchProgress failed: %v", err)
@@ -199,10 +209,12 @@ func TestWatchProgress_Delete(t *testing.T) {
 	userID, movieID := createTestUserAndMovie(t, app)
 
 	err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 300.0,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   300.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("UpsertMovieWatchProgress failed: %v", err)
@@ -280,10 +292,12 @@ func TestWatchProgress_MarkWatchedClearsExistingProgress(t *testing.T) {
 	userID, movieID := createTestUserAndMovie(t, app)
 
 	err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 3600.0,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   3600.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("UpsertMovieWatchProgress failed: %v", err)
@@ -416,20 +430,24 @@ func TestWatchProgress_PerUserIsolation(t *testing.T) {
 	}
 
 	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      user1.ID,
-		MovieID:     movie.ID,
-		ProgressSec: 600.0,
-		DurationSec: 7200.0,
+		UserID:        user1.ID,
+		MovieID:       movie.ID,
+		ProgressSec:   600.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("upsert for user1 failed: %v", err)
 	}
 
 	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      user2.ID,
-		MovieID:     movie.ID,
-		ProgressSec: 1800.0,
-		DurationSec: 7200.0,
+		UserID:        user2.ID,
+		MovieID:       movie.ID,
+		ProgressSec:   1800.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("upsert for user2 failed: %v", err)
@@ -508,10 +526,12 @@ func TestGetContinueWatchingMovies(t *testing.T) {
 
 	upsertProgress := func(userID, movieID int64, progressSec float64) {
 		err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-			UserID:      userID,
-			MovieID:     movieID,
-			ProgressSec: progressSec,
-			DurationSec: 7200.0,
+			UserID:        userID,
+			MovieID:       movieID,
+			ProgressSec:   progressSec,
+			DurationSec:   7200.0,
+			SaveSessionID: testWatchProgressSaveSessionID,
+			SaveSequence:  1,
 		})
 		if err != nil {
 			t.Fatalf("failed to upsert progress for movie %d: %v", movieID, err)
@@ -604,10 +624,12 @@ func TestWatchProgress_CascadeDeleteMovie(t *testing.T) {
 	userID, movieID := createTestUserAndMovie(t, app)
 
 	err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 300.0,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   300.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("UpsertMovieWatchProgress failed: %v", err)
@@ -635,10 +657,12 @@ func TestWatchProgress_CascadeDeleteUser(t *testing.T) {
 	userID, movieID := createTestUserAndMovie(t, app)
 
 	err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
-		UserID:      userID,
-		MovieID:     movieID,
-		ProgressSec: 300.0,
-		DurationSec: 7200.0,
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   300.0,
+		DurationSec:   7200.0,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
 	})
 	if err != nil {
 		t.Fatalf("UpsertMovieWatchProgress failed: %v", err)
@@ -682,6 +706,152 @@ func TestWatchProgress_CompletionThreshold(t *testing.T) {
 					tt.progressSec, tt.durationSec, ratio, isWatched, tt.wantWatched)
 			}
 		})
+	}
+}
+
+func TestWatchProgress_SaveOrdering(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+	ctx := context.Background()
+
+	userID, movieID := createTestUserAndMovie(t, app)
+	otherSessionID := "22222222-2222-4222-8222-222222222222"
+
+	err := app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   500,
+		DurationSec:   1000,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  2,
+	})
+	if err != nil {
+		t.Fatalf("save sequence 2: %v", err)
+	}
+
+	const preservedUpdatedAt = "2001-02-03 04:05:06"
+	_, err = app.DB.ExecContext(ctx,
+		"UPDATE movie_watch_progress SET updated_at = ? WHERE user_id = ? AND movie_id = ?",
+		preservedUpdatedAt, userID, movieID,
+	)
+	if err != nil {
+		t.Fatalf("set updated_at: %v", err)
+	}
+
+	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   100,
+		DurationSec:   1000,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  1,
+	})
+	if err != nil {
+		t.Fatalf("stale save: %v", err)
+	}
+
+	row, err := app.Queries.GetMovieWatchProgress(ctx, database.GetMovieWatchProgressParams{
+		UserID: userID, MovieID: movieID,
+	})
+	if err != nil {
+		t.Fatalf("get after stale save: %v", err)
+	}
+	if row.ProgressSec != 500 || row.SaveSequence != 2 || row.UpdatedAt != preservedUpdatedAt {
+		t.Fatalf("stale save changed row: %+v", row)
+	}
+
+	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   200,
+		DurationSec:   1000,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  2,
+	})
+	if err != nil {
+		t.Fatalf("equal-sequence save: %v", err)
+	}
+	row, err = app.Queries.GetMovieWatchProgress(ctx, database.GetMovieWatchProgressParams{
+		UserID: userID, MovieID: movieID,
+	})
+	if err != nil {
+		t.Fatalf("get after equal-sequence save: %v", err)
+	}
+	if row.ProgressSec != 500 || row.SaveSequence != 2 || row.UpdatedAt != preservedUpdatedAt {
+		t.Fatalf("equal-sequence save changed row: %+v", row)
+	}
+
+	err = app.Queries.MarkMovieWatchedFromProgress(ctx, database.MarkMovieWatchedFromProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  3,
+	})
+	if err != nil {
+		t.Fatalf("completion save: %v", err)
+	}
+
+	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   700,
+		DurationSec:   1000,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  2,
+	})
+	if err != nil {
+		t.Fatalf("stale save after completion: %v", err)
+	}
+	row, err = app.Queries.GetMovieWatchProgress(ctx, database.GetMovieWatchProgressParams{
+		UserID: userID, MovieID: movieID,
+	})
+	if err != nil {
+		t.Fatalf("get after stale completion overwrite: %v", err)
+	}
+	if !row.Watched || row.SaveSequence != 3 {
+		t.Fatalf("stale save overwrote completion: %+v", row)
+	}
+
+	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   60,
+		DurationSec:   1000,
+		SaveSessionID: testWatchProgressSaveSessionID,
+		SaveSequence:  4,
+	})
+	if err != nil {
+		t.Fatalf("higher-sequence rewind: %v", err)
+	}
+	row, err = app.Queries.GetMovieWatchProgress(ctx, database.GetMovieWatchProgressParams{
+		UserID: userID, MovieID: movieID,
+	})
+	if err != nil {
+		t.Fatalf("get after rewind: %v", err)
+	}
+	if row.Watched || row.ProgressSec != 60 {
+		t.Fatalf("higher-sequence rewind was not saved: %+v", row)
+	}
+
+	err = app.Queries.UpsertMovieWatchProgress(ctx, database.UpsertMovieWatchProgressParams{
+		UserID:        userID,
+		MovieID:       movieID,
+		ProgressSec:   250,
+		DurationSec:   1000,
+		SaveSessionID: otherSessionID,
+		SaveSequence:  1,
+	})
+	if err != nil {
+		t.Fatalf("different-session save: %v", err)
+	}
+	row, err = app.Queries.GetMovieWatchProgress(ctx, database.GetMovieWatchProgressParams{
+		UserID: userID, MovieID: movieID,
+	})
+	if err != nil {
+		t.Fatalf("get after different-session save: %v", err)
+	}
+	if row.ProgressSec != 250 || row.SaveSessionID != otherSessionID || row.SaveSequence != 1 {
+		t.Fatalf("different-session last write was not saved: %+v", row)
 	}
 }
 
@@ -783,8 +953,23 @@ func TestUpdateMovieWatchProgress_HTTPMissingFields(t *testing.T) {
 	t.Run("missing progress", func(t *testing.T) {
 		run(t, `{"duration_sec": 7200}`, http.StatusBadRequest)
 	})
+	t.Run("missing save session", func(t *testing.T) {
+		run(t, `{"progress_sec": 100, "duration_sec": 7200, "save_sequence": 1}`, http.StatusBadRequest)
+	})
+	t.Run("malformed save session", func(t *testing.T) {
+		run(t, `{"progress_sec": 100, "duration_sec": 7200, "save_session_id": "invalid", "save_sequence": 1}`, http.StatusBadRequest)
+	})
+	t.Run("missing save sequence", func(t *testing.T) {
+		run(t, `{"progress_sec": 100, "duration_sec": 7200, "save_session_id": "11111111-1111-4111-8111-111111111111"}`, http.StatusBadRequest)
+	})
+	t.Run("zero save sequence", func(t *testing.T) {
+		run(t, `{"progress_sec": 100, "duration_sec": 7200, "save_session_id": "11111111-1111-4111-8111-111111111111", "save_sequence": 0}`, http.StatusBadRequest)
+	})
+	t.Run("negative save sequence", func(t *testing.T) {
+		run(t, `{"progress_sec": 100, "duration_sec": 7200, "save_session_id": "11111111-1111-4111-8111-111111111111", "save_sequence": -1}`, http.StatusBadRequest)
+	})
 	t.Run("valid body", func(t *testing.T) {
-		run(t, `{"progress_sec": 100, "duration_sec": 7200}`, http.StatusOK)
+		run(t, `{"progress_sec": 100, "duration_sec": 7200, "save_session_id": "11111111-1111-4111-8111-111111111111", "save_sequence": 1}`, http.StatusOK)
 	})
 }
 
@@ -886,7 +1071,7 @@ func TestSetMovieWatched_HTTPMissingWatched(t *testing.T) {
 
 func TestReadJSON_WatchProgressRequest_DisallowUnknownFields(t *testing.T) {
 	var req updateMovieWatchProgressRequest
-	body := strings.NewReader(`{"progress_sec": 1, "duration_sec": 2, "extra": true}`)
+	body := strings.NewReader(`{"progress_sec": 1, "duration_sec": 2, "save_session_id": "11111111-1111-4111-8111-111111111111", "save_sequence": 1, "extra": true}`)
 	r := httptest.NewRequest(http.MethodPut, "/", body)
 	w := httptest.NewRecorder()
 	err := helpers.ReadJSON(w, r, &req, 1024)

--- a/server/cmd/internal/database/db.go
+++ b/server/cmd/internal/database/db.go
@@ -465,6 +465,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.markMovieWatchedStmt, err = db.PrepareContext(ctx, markMovieWatched); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkMovieWatched: %w", err)
 	}
+	if q.markMovieWatchedFromProgressStmt, err = db.PrepareContext(ctx, markMovieWatchedFromProgress); err != nil {
+		return nil, fmt.Errorf("error preparing query MarkMovieWatchedFromProgress: %w", err)
+	}
 	if q.markNotificationReadForUserStmt, err = db.PrepareContext(ctx, markNotificationReadForUser); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkNotificationReadForUser: %w", err)
 	}
@@ -1319,6 +1322,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing markMovieWatchedStmt: %w", cerr)
 		}
 	}
+	if q.markMovieWatchedFromProgressStmt != nil {
+		if cerr := q.markMovieWatchedFromProgressStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing markMovieWatchedFromProgressStmt: %w", cerr)
+		}
+	}
 	if q.markNotificationReadForUserStmt != nil {
 		if cerr := q.markNotificationReadForUserStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing markNotificationReadForUserStmt: %w", cerr)
@@ -1695,6 +1703,7 @@ type Queries struct {
 	markAllNotificationsReadForUserStmt         *sql.Stmt
 	markMovieUnwatchedStmt                      *sql.Stmt
 	markMovieWatchedStmt                        *sql.Stmt
+	markMovieWatchedFromProgressStmt            *sql.Stmt
 	markNotificationReadForUserStmt             *sql.Stmt
 	recordPlayEventStmt                         *sql.Stmt
 	removeCollaboratorStmt                      *sql.Stmt
@@ -1886,6 +1895,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		markAllNotificationsReadForUserStmt:         q.markAllNotificationsReadForUserStmt,
 		markMovieUnwatchedStmt:                      q.markMovieUnwatchedStmt,
 		markMovieWatchedStmt:                        q.markMovieWatchedStmt,
+		markMovieWatchedFromProgressStmt:            q.markMovieWatchedFromProgressStmt,
 		markNotificationReadForUserStmt:             q.markNotificationReadForUserStmt,
 		recordPlayEventStmt:                         q.recordPlayEventStmt,
 		removeCollaboratorStmt:                      q.removeCollaboratorStmt,

--- a/server/cmd/internal/database/models.go
+++ b/server/cmd/internal/database/models.go
@@ -137,12 +137,14 @@ type Movie struct {
 }
 
 type MovieWatchProgress struct {
-	UserID      int64   `json:"user_id"`
-	MovieID     int64   `json:"movie_id"`
-	ProgressSec float64 `json:"progress_sec"`
-	DurationSec float64 `json:"duration_sec"`
-	Watched     bool    `json:"watched"`
-	UpdatedAt   string  `json:"updated_at"`
+	UserID        int64   `json:"user_id"`
+	MovieID       int64   `json:"movie_id"`
+	ProgressSec   float64 `json:"progress_sec"`
+	DurationSec   float64 `json:"duration_sec"`
+	Watched       bool    `json:"watched"`
+	SaveSessionID string  `json:"save_session_id"`
+	SaveSequence  int64   `json:"save_sequence"`
+	UpdatedAt     string  `json:"updated_at"`
 }
 
 type MusicSpotifyMatch struct {

--- a/server/cmd/internal/database/movie_watch_progress.sql.go
+++ b/server/cmd/internal/database/movie_watch_progress.sql.go
@@ -93,6 +93,8 @@ SELECT
   progress_sec,
   duration_sec,
   watched,
+  save_session_id,
+  save_sequence,
   updated_at
 FROM movie_watch_progress
 WHERE user_id = ?
@@ -113,6 +115,8 @@ func (q *Queries) GetMovieWatchProgress(ctx context.Context, arg GetMovieWatchPr
 		&i.ProgressSec,
 		&i.DurationSec,
 		&i.Watched,
+		&i.SaveSessionID,
+		&i.SaveSequence,
 		&i.UpdatedAt,
 	)
 	return i, err
@@ -173,6 +177,47 @@ func (q *Queries) MarkMovieWatched(ctx context.Context, arg MarkMovieWatchedPara
 	return err
 }
 
+const markMovieWatchedFromProgress = `-- name: MarkMovieWatchedFromProgress :exec
+INSERT INTO movie_watch_progress (
+  user_id,
+  movie_id,
+  progress_sec,
+  duration_sec,
+  watched,
+  save_session_id,
+  save_sequence,
+  updated_at
+)
+VALUES
+  (?, ?, 0, 0, true, ?, ?, CURRENT_TIMESTAMP)
+ON CONFLICT (user_id, movie_id) DO UPDATE
+SET
+  progress_sec = 0,
+  watched = true,
+  save_session_id = excluded.save_session_id,
+  save_sequence = excluded.save_sequence,
+  updated_at = CURRENT_TIMESTAMP
+WHERE movie_watch_progress.save_session_id <> excluded.save_session_id
+   OR movie_watch_progress.save_sequence < excluded.save_sequence
+`
+
+type MarkMovieWatchedFromProgressParams struct {
+	UserID        int64  `json:"user_id"`
+	MovieID       int64  `json:"movie_id"`
+	SaveSessionID string `json:"save_session_id"`
+	SaveSequence  int64  `json:"save_sequence"`
+}
+
+func (q *Queries) MarkMovieWatchedFromProgress(ctx context.Context, arg MarkMovieWatchedFromProgressParams) error {
+	_, err := q.exec(ctx, q.markMovieWatchedFromProgressStmt, markMovieWatchedFromProgress,
+		arg.UserID,
+		arg.MovieID,
+		arg.SaveSessionID,
+		arg.SaveSequence,
+	)
+	return err
+}
+
 const upsertMovieWatchProgress = `-- name: UpsertMovieWatchProgress :exec
 INSERT INTO movie_watch_progress (
   user_id,
@@ -180,23 +225,31 @@ INSERT INTO movie_watch_progress (
   progress_sec,
   duration_sec,
   watched,
+  save_session_id,
+  save_sequence,
   updated_at
 )
 VALUES
-  (?, ?, ?, ?, false, CURRENT_TIMESTAMP)
+  (?, ?, ?, ?, false, ?, ?, CURRENT_TIMESTAMP)
 ON CONFLICT (user_id, movie_id) DO UPDATE
 SET
   progress_sec = excluded.progress_sec,
   duration_sec = excluded.duration_sec,
   watched = false,
+  save_session_id = excluded.save_session_id,
+  save_sequence = excluded.save_sequence,
   updated_at = CURRENT_TIMESTAMP
+WHERE movie_watch_progress.save_session_id <> excluded.save_session_id
+   OR movie_watch_progress.save_sequence < excluded.save_sequence
 `
 
 type UpsertMovieWatchProgressParams struct {
-	UserID      int64   `json:"user_id"`
-	MovieID     int64   `json:"movie_id"`
-	ProgressSec float64 `json:"progress_sec"`
-	DurationSec float64 `json:"duration_sec"`
+	UserID        int64   `json:"user_id"`
+	MovieID       int64   `json:"movie_id"`
+	ProgressSec   float64 `json:"progress_sec"`
+	DurationSec   float64 `json:"duration_sec"`
+	SaveSessionID string  `json:"save_session_id"`
+	SaveSequence  int64   `json:"save_sequence"`
 }
 
 func (q *Queries) UpsertMovieWatchProgress(ctx context.Context, arg UpsertMovieWatchProgressParams) error {
@@ -205,6 +258,8 @@ func (q *Queries) UpsertMovieWatchProgress(ctx context.Context, arg UpsertMovieW
 		arg.MovieID,
 		arg.ProgressSec,
 		arg.DurationSec,
+		arg.SaveSessionID,
+		arg.SaveSequence,
 	)
 	return err
 }

--- a/server/cmd/internal/database/querier.go
+++ b/server/cmd/internal/database/querier.go
@@ -208,6 +208,7 @@ type Querier interface {
 	MarkAllNotificationsReadForUser(ctx context.Context, arg MarkAllNotificationsReadForUserParams) error
 	MarkMovieUnwatched(ctx context.Context, arg MarkMovieUnwatchedParams) error
 	MarkMovieWatched(ctx context.Context, arg MarkMovieWatchedParams) error
+	MarkMovieWatchedFromProgress(ctx context.Context, arg MarkMovieWatchedFromProgressParams) error
 	// Idempotent and relevance-gated: only records a read when the notification is
 	// actually visible to the viewer.
 	MarkNotificationReadForUser(ctx context.Context, arg MarkNotificationReadForUserParams) error

--- a/server/sqlc/queries/movie_watch_progress.sql
+++ b/server/sqlc/queries/movie_watch_progress.sql
@@ -5,6 +5,8 @@ SELECT
   progress_sec,
   duration_sec,
   watched,
+  save_session_id,
+  save_sequence,
   updated_at
 FROM movie_watch_progress
 WHERE user_id = ?
@@ -17,16 +19,22 @@ INSERT INTO movie_watch_progress (
   progress_sec,
   duration_sec,
   watched,
+  save_session_id,
+  save_sequence,
   updated_at
 )
 VALUES
-  (?, ?, ?, ?, false, CURRENT_TIMESTAMP)
+  (?, ?, ?, ?, false, ?, ?, CURRENT_TIMESTAMP)
 ON CONFLICT (user_id, movie_id) DO UPDATE
 SET
   progress_sec = excluded.progress_sec,
   duration_sec = excluded.duration_sec,
   watched = false,
-  updated_at = CURRENT_TIMESTAMP;
+  save_session_id = excluded.save_session_id,
+  save_sequence = excluded.save_sequence,
+  updated_at = CURRENT_TIMESTAMP
+WHERE movie_watch_progress.save_session_id <> excluded.save_session_id
+   OR movie_watch_progress.save_sequence < excluded.save_sequence;
 
 -- name: DeleteMovieWatchProgress :exec
 DELETE FROM movie_watch_progress
@@ -49,6 +57,29 @@ SET
   progress_sec = 0,
   watched = true,
   updated_at = CURRENT_TIMESTAMP;
+
+-- name: MarkMovieWatchedFromProgress :exec
+INSERT INTO movie_watch_progress (
+  user_id,
+  movie_id,
+  progress_sec,
+  duration_sec,
+  watched,
+  save_session_id,
+  save_sequence,
+  updated_at
+)
+VALUES
+  (?, ?, 0, 0, true, ?, ?, CURRENT_TIMESTAMP)
+ON CONFLICT (user_id, movie_id) DO UPDATE
+SET
+  progress_sec = 0,
+  watched = true,
+  save_session_id = excluded.save_session_id,
+  save_sequence = excluded.save_sequence,
+  updated_at = CURRENT_TIMESTAMP
+WHERE movie_watch_progress.save_session_id <> excluded.save_session_id
+   OR movie_watch_progress.save_sequence < excluded.save_sequence;
 
 -- name: GetContinueWatchingMovies :many
 -- The 30-second floor must match the web client's

--- a/server/sqlc/schema.sql
+++ b/server/sqlc/schema.sql
@@ -511,6 +511,8 @@ CREATE TABLE
     progress_sec REAL NOT NULL DEFAULT 0,
     duration_sec REAL NOT NULL DEFAULT 0,
     watched BOOLEAN NOT NULL DEFAULT false,
+    save_session_id TEXT NOT NULL DEFAULT '',
+    save_sequence INTEGER NOT NULL DEFAULT 0,
     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (user_id, movie_id),
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/web/src/hooks/useMovieWatchProgressSaver.ts
+++ b/web/src/hooks/useMovieWatchProgressSaver.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { RefObject } from "react";
-import { persistMovieWatchProgress } from "@/lib/movie-playback";
+import {
+  createPlaybackSessionId,
+  persistMovieWatchProgress,
+} from "@/lib/movie-playback";
 import {
   MOVIE_WATCH_PROGRESS_KEEPALIVE_DEDUPE_MS,
   MOVIE_WATCH_PROGRESS_SAVE_INTERVAL_MS,
@@ -29,6 +32,12 @@ export function useMovieWatchProgressSaver({
 }: MovieWatchProgressSaverOptions) {
   const pendingSaveRef = useRef<Promise<void>>(Promise.resolve());
   const fallbackDurationRef = useRef(fallbackDurationSec ?? 0);
+  const saveSessionIdRef = useRef<string | null>(null);
+  const saveSequenceRef = useRef(0);
+
+  if (saveSessionIdRef.current === null) {
+    saveSessionIdRef.current = createPlaybackSessionId();
+  }
 
   useEffect(() => {
     fallbackDurationRef.current = fallbackDurationSec ?? 0;
@@ -41,8 +50,15 @@ export function useMovieWatchProgressSaver({
 
   const queueProgressSave = useCallback(
     (progressSec: number, durationSec: number) => {
+      const saveSequence = ++saveSequenceRef.current;
       const save = pendingSaveRef.current.then(() =>
-        persistMovieWatchProgress(movieId, progressSec, durationSec),
+        persistMovieWatchProgress(
+          movieId,
+          progressSec,
+          durationSec,
+          saveSessionIdRef.current!,
+          saveSequence,
+        ),
       );
       pendingSaveRef.current = save.catch(() => {});
       return save;
@@ -84,11 +100,14 @@ export function useMovieWatchProgressSaver({
 
       const atMs = Date.now();
       const durationSec = effectiveDurationSec();
+      const saveSequence = ++saveSequenceRef.current;
       lastKeepalive = { progressSec, atMs };
       void persistMovieWatchProgress(
         movieId,
         progressSec,
         durationSec,
+        saveSessionIdRef.current!,
+        saveSequence,
         { keepalive: true },
       );
     };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -431,10 +431,17 @@ export const updateMovieWatchProgress = (
   movieId: number,
   progressSec: number,
   durationSec: number,
+  saveSessionId: string,
+  saveSequence: number,
 ) =>
   apiRequest<{ watched: boolean }>(`/api/movies/${movieId}/watch-progress`, {
     method: "PUT",
-    body: { progress_sec: progressSec, duration_sec: durationSec },
+    body: {
+      progress_sec: progressSec,
+      duration_sec: durationSec,
+      save_session_id: saveSessionId,
+      save_sequence: saveSequence,
+    },
   });
 
 export const deleteMovieWatchProgress = (movieId: number) =>

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -134,9 +134,12 @@ export const TMDB_POSTER_SIZE = "w500";
 export const TMDB_PROFILE_SIZE = "w185";
 export const TMDB_LOGO_SIZE = "w92";
 
-// Virtual-list measurements in pixels. These keep virtualized rows stable.
-export const VIRTUAL_LIST_LETTER_HEIGHT = 52;
-export const VIRTUAL_LIST_TRACK_HEIGHT = 60;
+// Virtual-list measurements in pixels. These keep virtualized rows stable and
+// must match the rendered heights of TrackItem (p-3 row + two text lines) and
+// LetterHeader (py-3 + text-2xl + 1px border); an undersized estimate makes the
+// absolutely-positioned rows overlap their neighbors.
+export const VIRTUAL_LIST_LETTER_HEIGHT = 57;
+export const VIRTUAL_LIST_TRACK_HEIGHT = 68;
 
 // Shared surface for library and search track lists. Keeps list frames visually
 // identical: card radius plus standard surface and border tokens.

--- a/web/src/lib/movie-playback.ts
+++ b/web/src/lib/movie-playback.ts
@@ -72,7 +72,7 @@ export function getOrCreateMovieHlsPlaybackSessionId(
   movieId: number,
   storage: HlsPlaybackSessionStorage | null = browserSessionStorage(),
 ): string {
-  const create = () => createHlsPlaybackSessionId();
+  const create = () => createPlaybackSessionId();
   if (!Number.isFinite(movieId) || movieId <= 0 || !storage) return create();
 
   const key = movieHlsPlaybackSessionStorageKey(movieId);
@@ -138,7 +138,7 @@ export function deriveMoviePlaybackStatus(
   return { kind: "ready" };
 }
 
-function createHlsPlaybackSessionId(): string {
+export function createPlaybackSessionId(): string {
   if (globalThis.crypto?.randomUUID) {
     return globalThis.crypto.randomUUID();
   }
@@ -331,6 +331,8 @@ export async function persistMovieWatchProgress(
   movieId: number,
   progressSec: number,
   durationSec: number,
+  saveSessionId: string,
+  saveSequence: number,
   options?: { keepalive?: boolean },
 ) {
   if (!(durationSec > 0)) return;
@@ -350,6 +352,8 @@ export async function persistMovieWatchProgress(
         body: JSON.stringify({
           progress_sec: clampedProgress,
           duration_sec: durationSec,
+          save_session_id: saveSessionId,
+          save_sequence: saveSequence,
         }),
       });
     } catch {
@@ -362,6 +366,8 @@ export async function persistMovieWatchProgress(
     movieId,
     clampedProgress,
     durationSec,
+    saveSessionId,
+    saveSequence,
   );
   if (res.error) {
     throw new Error(res.message);

--- a/web/src/routes/_auth/music/index.tsx
+++ b/web/src/routes/_auth/music/index.tsx
@@ -685,8 +685,15 @@ function TracksListSkeleton() {
 }
 
 function TracksTabContent() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useInfiniteQuery(tracksInfiniteQueryOpts());
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    refetch,
+  } = useInfiniteQuery(tracksInfiniteQueryOpts());
 
   const { data: likedIdsData } = useQuery(likedTrackIdsQueryOpts());
   const likedSet = new Set<number>(
@@ -718,9 +725,19 @@ function TracksTabContent() {
     return <TracksListSkeleton />;
   }
 
+  if (isError) {
+    return (
+      <MoviesLoadError
+        message="Couldn’t load tracks. Check your connection and try again."
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
   if (allTracks.length === 0) {
     return (
       <div className="py-12 text-center text-muted-foreground">
+        <LiveAnnouncer message={getAnnouncement()} />
         <Music className="mx-auto mb-4 size-10 opacity-50" aria-hidden="true" />
         <p>No tracks found in your library.</p>
       </div>
@@ -821,7 +838,10 @@ function VirtualizedTracksList({
       role="list"
       aria-label="Tracks"
     >
+      {/* Presentational spacer: keeps the list -> listitem ownership intact so
+          the intervening positioning wrapper doesn't strip the list semantics. */}
       <div
+        role="presentation"
         style={{
           height: `${virtualizer.getTotalSize()}px`,
           width: "100%",
@@ -836,7 +856,7 @@ function VirtualizedTracksList({
           return (
             <div
               key={virtualRow.key}
-              role={item.type === "track" ? "listitem" : undefined}
+              role={item.type === "track" ? "listitem" : "presentation"}
               aria-posinset={item.type === "track" ? item.trackIndex : undefined}
               aria-setsize={item.type === "track" ? totalTracks : undefined}
               style={{
@@ -944,14 +964,12 @@ function ShuffleButton() {
 
 function LetterHeader({ letter }: { letter: string }) {
   return (
-    <div
-      className="border-b border-primary/20 bg-muted/50 px-4 py-3"
-      role="heading"
-      aria-level={3}
+    <h3
+      className="border-b border-primary/20 bg-muted/50 px-4 py-3 text-2xl font-bold text-primary"
       aria-label={`Tracks starting with ${letter}`}
     >
-      <span className="text-2xl font-bold text-primary">{letter}</span>
-    </div>
+      {letter}
+    </h3>
   );
 }
 

--- a/web/src/routes/_auth/music/index.tsx
+++ b/web/src/routes/_auth/music/index.tsx
@@ -699,6 +699,8 @@ function TracksTabContent() {
   const likedSet = new Set<number>(
     likedIdsData?.error === false ? (likedIdsData.data.liked_track_ids ?? []) : [],
   );
+  const firstPage = data?.pages[0];
+  const firstPageFailed = isApiFailure(firstPage);
 
   // Get total tracks count from first page
   const totalTracks =
@@ -725,10 +727,14 @@ function TracksTabContent() {
     return <TracksListSkeleton />;
   }
 
-  if (isError) {
+  if (isError || firstPageFailed) {
     return (
       <MoviesLoadError
-        message="Couldn’t load tracks. Check your connection and try again."
+        message={
+          firstPageFailed
+            ? firstPage.message
+            : "Couldn’t load tracks. Check your connection and try again."
+        }
         onRetry={() => void refetch()}
       />
     );

--- a/web/src/test/movies/movie-watch-progress-saver.test.tsx
+++ b/web/src/test/movies/movie-watch-progress-saver.test.tsx
@@ -16,6 +16,11 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+function requestBody(fetchMock: ReturnType<typeof vi.fn>) {
+  const options = fetchMock.mock.calls[0]?.[1] as RequestInit;
+  return JSON.parse(options.body as string) as Record<string, unknown>;
+}
+
 const successfulUpdate = {
   error: false as const,
   data: { watched: false },
@@ -62,8 +67,24 @@ describe("movie watch progress saver", () => {
     );
     await exitSave;
 
-    expect(updateMovieWatchProgress).toHaveBeenNthCalledWith(1, 7, 300, 1000);
-    expect(updateMovieWatchProgress).toHaveBeenNthCalledWith(2, 7, 450, 1000);
+    const saveSessionId = updateMovieWatchProgress.mock.calls[0]?.[3];
+    expect(saveSessionId).toEqual(expect.any(String));
+    expect(updateMovieWatchProgress).toHaveBeenNthCalledWith(
+      1,
+      7,
+      300,
+      1000,
+      saveSessionId,
+      1,
+    );
+    expect(updateMovieWatchProgress).toHaveBeenNthCalledWith(
+      2,
+      7,
+      450,
+      1000,
+      saveSessionId,
+      2,
+    );
   });
 
   it("uses a keepalive request on pagehide without saving again on unmount", async () => {
@@ -90,10 +111,15 @@ describe("movie watch progress saver", () => {
         expect.objectContaining({
           method: "PUT",
           keepalive: true,
-          body: JSON.stringify({ progress_sec: 300, duration_sec: 1000 }),
         }),
       ),
     );
+    expect(requestBody(fetchMock)).toEqual({
+      progress_sec: 300,
+      duration_sec: 1000,
+      save_session_id: expect.any(String),
+      save_sequence: 1,
+    });
 
     unmount();
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -128,10 +154,15 @@ describe("movie watch progress saver", () => {
         expect.objectContaining({
           method: "PUT",
           keepalive: true,
-          body: JSON.stringify({ progress_sec: 300, duration_sec: 1000 }),
         }),
       ),
     );
+    expect(requestBody(fetchMock)).toEqual({
+      progress_sec: 300,
+      duration_sec: 1000,
+      save_session_id: expect.any(String),
+      save_sequence: 1,
+    });
   });
 
   it("dedupes hidden-then-pagehide into a single keepalive save", async () => {
@@ -185,10 +216,15 @@ describe("movie watch progress saver", () => {
         expect.objectContaining({
           method: "PUT",
           keepalive: true,
-          body: JSON.stringify({ progress_sec: 300, duration_sec: 5400 }),
         }),
       ),
     );
+    expect(requestBody(fetchMock)).toEqual({
+      progress_sec: 300,
+      duration_sec: 5400,
+      save_session_id: expect.any(String),
+      save_sequence: 1,
+    });
   });
 
   it("dispatches a captured lifecycle snapshot while an ordinary save is unresolved", async () => {
@@ -223,9 +259,22 @@ describe("movie watch progress saver", () => {
       "/api/movies/7/watch-progress",
       expect.objectContaining({
         keepalive: true,
-        body: JSON.stringify({ progress_sec: 450, duration_sec: 1000 }),
       }),
     );
+    const saveSessionId = updateMovieWatchProgress.mock.calls[0]?.[3];
+    expect(updateMovieWatchProgress).toHaveBeenCalledWith(
+      7,
+      300,
+      1000,
+      saveSessionId,
+      1,
+    );
+    expect(requestBody(fetchMock)).toEqual({
+      progress_sec: 450,
+      duration_sec: 1000,
+      save_session_id: saveSessionId,
+      save_sequence: 2,
+    });
 
     firstSave.resolve(successfulUpdate);
     await pauseSave;
@@ -248,6 +297,12 @@ describe("movie watch progress saver", () => {
       await result.current.handlePauseSave();
     });
 
-    expect(updateMovieWatchProgress).toHaveBeenCalledWith(7, 45, 1000);
+    expect(updateMovieWatchProgress).toHaveBeenCalledWith(
+      7,
+      45,
+      1000,
+      expect.any(String),
+      1,
+    );
   });
 });

--- a/web/src/test/music/music-route.test.tsx
+++ b/web/src/test/music/music-route.test.tsx
@@ -88,11 +88,13 @@ function track(id: number, title: string) {
 type MockMusicFetchOptions = {
   spotifyAvailable?: boolean;
   emptyMusicians?: boolean;
+  failFirstTracksRequest?: boolean;
 };
 
 function mockMusicFetch(options: MockMusicFetchOptions = {}) {
   const spotifyAvailable = options.spotifyAvailable ?? true;
   const emptyMusicians = options.emptyMusicians ?? false;
+  let tracksRequestCount = 0;
   const fetchMock = vi.fn((input: RequestInfo | URL) => {
     const url = requestURL(input);
 
@@ -190,6 +192,15 @@ function mockMusicFetch(options: MockMusicFetchOptions = {}) {
     }
 
     if (url === `/api/music/tracks?limit=${TRACKS_INFINITE_PAGE_SIZE}&offset=0`) {
+      tracksRequestCount += 1;
+
+      if (options.failFirstTracksRequest && tracksRequestCount === 1) {
+        return jsonResponse({
+          error: true,
+          message: "The tracks library is temporarily unavailable.",
+        });
+      }
+
       return jsonResponse({
         error: false,
         data: {
@@ -425,6 +436,27 @@ describe("music route more menu", () => {
 });
 
 describe("music route tracks tab", () => {
+  it("shows an API failure and loads tracks after retrying", async () => {
+    const user = userEvent.setup();
+
+    await renderMusicRoute("/music/?tab=tracks", {
+      failFirstTracksRequest: true,
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "The tracks library is temporarily unavailable.",
+    );
+    expect(
+      screen.queryByText("No tracks found in your library."),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByRole("list", { name: "Tracks" })).toBeInTheDocument();
+    expect(screen.getByText("Alabaster")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("labels the virtualized track list and track action menus", async () => {
     await renderMusicRoute("/music/?tab=tracks");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watch progress updates now include playback-session identifiers and ordered save sequencing to prevent stale updates from overwriting newer progress.
  * Requests are validated to require valid save session data; completion now records watched status with the same save metadata.
* **Bug Fixes**
  * Watch-progress persistence now carries the new save metadata across periodic, keepalive, and lifecycle saves.
  * Improved virtualized tracks loading behavior (initial failure handling) and accessibility semantics for music list rows/headings.
* **Tests**
  * Added coverage for save ordering semantics and expanded request validation assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->