### PR TITLE
fix(web): improve audio player accessibility

### DIFF
--- a/docs/audio-player-followups.md
+++ b/docs/audio-player-followups.md
@@ -1,0 +1,88 @@
+# Audio Player Review — Follow-up Issues (2026-07-19)
+
+Issues observed during the audio-player UI/UX review on `fix/audio-player-ui`
+that were deliberately **not** fixed there, to keep that change focused. The
+review itself fixed: the mixed focus-ring recipes (now `FOCUS_VISIBLE_RING_CLASS`
+via `PLAYER_ICON_BUTTON_CLASS` / `PLAYER_PRIMARY_BUTTON_CLASS`), `disabled` on
+play/pause (now `aria-disabled` + guard), raw `bg-white` progress thumbs (now
+`bg-foreground`), the duplicated play/toggle/seek logic, the per-page
+current-track wiring (now `useTrackPlaybackMatcher`), and global shortcuts
+being dead while the player's own sliders had focus.
+
+Everything below is pre-existing and reproducible on `main`.
+
+## 1. Movie player: duplicate "Playback progress" group + doubled time readouts
+
+`MoviePlayerControls.tsx:76` wraps `ProgressBar` in its own
+`role="group" aria-label="Playback progress"`, but `ProgressBar` already
+renders an identically-labelled group internally
+(`ProgressBar.tsx:101` default `groupLabel`). Screen-reader users hear two
+nested "Playback progress" groups. The footer also renders its own
+`0:01:24 / 2:04:34` readout while the `video` variant of `ProgressBar` shows
+the same times below the bar — two visible time displays for one position.
+
+Fix ideas: drop the wrapper `div`'s group role (keep it purely for layout),
+and either pass `showTimes`-off styling for the video variant or remove the
+footer's separate readout.
+
+**Caution:** this is playback chrome — per `docs/ffmpeg.md` / design-system
+§3.5 it needs the full playback test pass (direct stream, HLS, fullscreen
+idle-hide, watch rooms use the same bar via `WatchRoomPage`).
+
+## 2. Movie player announces its seek slider as "Seek through track"
+
+`MoviePlayerControls` does not override `ProgressBar`'s default
+`ariaLabel = "Seek through track"` (`ProgressBar.tsx:100`), so on a *movie*
+the slider is announced with music wording. Pass
+`ariaLabel="Seek through movie"` (and review the watch-room usage) when
+touching item 1.
+
+## 3. Playlist drag-and-drop still threads current-track props manually
+
+The playlist page passes `currentTrackId` / `isPlaying` down through
+`DraggableTrackList` → `SortableTrackItem` instead of using the new
+`useTrackPlaybackMatcher` hook (`web/src/hooks/useTrackPlaybackMatcher.ts`)
+that the other four lists now share. Left alone because adopting the hook
+changes the DnD components' public props, their tests would need an
+`AudioPlayerProvider` wrapper, and the drag overlay intentionally renders
+`isCurrentTrack={false}` (`DraggableTrackList.tsx:187`) — that special case
+must survive any refactor.
+
+## 4. No e2e coverage of actual audio playback
+
+No Playwright spec ever clicks through to a playing `<audio>` element — the
+music specs assert that Play buttons exist and stop there.
+`web/e2e/mock-api-server.ts` has no handler for
+`GET /api/music/tracks/{id}/stream` (only the movie stream is stubbed), so
+streaming audio is currently untestable in the mocked harness. A future spec
+should stub the stream route (a stalled response is enough — the movie play
+spec proves seek/transport assertions work at `readyState 0`) and drive:
+play from an album → fullscreen dialog → minimize → mini-bar transport →
+current-row highlight.
+
+## 5. Dev database is never migrated (`make dev` startup failure)
+
+The embedded startup schema only creates missing tables. After
+`server/sqlc/schema.sql` gains a column, an existing `db/igloo.db` (repo
+root) makes the server die at boot:
+`failed to prepare database queries: … no such column: save_session_id`
+(hit 2026-07-19; fixed by `ALTER TABLE movie_watch_progress ADD COLUMN …`
+matching the schema's type/default — don't delete the db, it holds the
+scanned library). Pre-production "no migrations" is policy, but a dev-only
+mitigation (a `make db-reset` target, or a startup log line naming the
+mismatched table) would save the next person the diagnosis.
+
+## 6. Dev-only console warning: Inter preload unused
+
+Every page in dev logs
+`The resource /fonts/InterVariable.woff2 was preloaded using link preload
+but not used within a few seconds…` (often repeated, and again after each
+HMR update). The preload markup itself is correct — `index.html:29` has
+`as="font" type="font/woff2" crossorigin`, which matches the anonymous-mode
+fetch the `@font-face` in `boot.css:4` performs — so the usual
+crossorigin-mismatch cause is ruled out. The likely culprit is dev-mode
+serving: Vite injects `boot.css` via JS, so the `@font-face` registers (and
+the font request fires) later than the browser's grace window. Verify
+whether the warning appears on a production build (`make build`, served by
+the Go binary); if prod is clean this is pure dev noise and just needs a
+note wherever "console must be clean" audits are run, not a code change.

--- a/web/src/components/playback/AudioPlayer.tsx
+++ b/web/src/components/playback/AudioPlayer.tsx
@@ -433,6 +433,13 @@ export default function AudioPlayer({
     };
   }, [audioRef, track]);
 
+  const handleTogglePlay = () => {
+    // While loading the button is aria-disabled (never `disabled`, which
+    // would drop it from the VoiceOver focus order) — guard here instead.
+    if (isLoading) return;
+    toggleMediaPlayback(audioRef.current);
+  };
+
   const handleGlobalKeyDown = useEffectEvent((event: KeyboardEvent) => {
     const audio = audioRef.current;
 
@@ -479,15 +486,15 @@ export default function AudioPlayer({
 
       const interactive = target.closest(INTERACTIVE_SELECTOR);
       if (interactive) {
-        // Space must activate the focused control everywhere, and arrow keys
-        // belong to widgets like tabs and radios — except inside the player's
-        // own chrome, where arrows keep seeking and adjusting volume.
+        // Space must activate the focused control everywhere, and navigation
+        // keys belong to widgets like tabs and radios — except inside the
+        // player's own chrome, where they keep controlling playback.
         if (event.key === " ") {
           return;
         }
 
         if (
-          ARROW_KEYS.has(event.key) &&
+          (ARROW_KEYS.has(event.key) || event.key === "Home") &&
           !interactive.closest("[data-audio-player]")
         ) {
           return;
@@ -498,7 +505,7 @@ export default function AudioPlayer({
     switch (event.key) {
       case " ":
         event.preventDefault();
-        toggleMediaPlayback(audio);
+        handleTogglePlay();
         break;
       case "ArrowLeft":
         event.preventDefault();
@@ -549,13 +556,6 @@ export default function AudioPlayer({
 
     return () => window.removeEventListener("keydown", handleGlobalKeyDown);
   }, []);
-
-  const handleTogglePlay = () => {
-    // While loading the button is aria-disabled (never `disabled`, which
-    // would drop it from the VoiceOver focus order) — guard here instead.
-    if (isLoading) return;
-    toggleMediaPlayback(audioRef.current);
-  };
 
   const playNext = () => {
     if (hasNext) {

--- a/web/src/components/playback/AudioPlayer.tsx
+++ b/web/src/components/playback/AudioPlayer.tsx
@@ -21,10 +21,16 @@ import ProgressBar from "@/components/playback/ProgressBar";
 import VolumeControl from "@/components/playback/VolumeControl";
 import {
   AUDIO_SEEK_STEP_SECONDS,
+  AUDIO_VOLUME_STEP,
+  FOCUS_VISIBLE_RING_CLASS,
   MOTION_MEDIA_OVERLAY_ENTER_CLASS,
   MOTION_PLAYER_CHROME_BUTTON_CLASS,
   MOTION_PLAYER_CHROME_ENTER_CLASS,
+  PLAYER_ICON_BUTTON_CLASS,
+  PLAYER_PRIMARY_BUTTON_CLASS,
+  PLAYER_TRANSPORT_INERT_CLASS,
 } from "@/lib/constants";
+import { playMediaElement, toggleMediaPlayback } from "@/lib/audio-utils";
 import { cn } from "@/lib/utils";
 
 type AudioPlayerProps = {
@@ -52,7 +58,6 @@ type AudioPlayerProps = {
 // has passed this many seconds.
 const RESTART_THRESHOLD_SECONDS = 3;
 const PREVIOUS_TRACK_ARIA_LABEL = "Previous track";
-const AUDIO_VOLUME_STEP = 0.1;
 
 // Controls whose native keyboard interaction must win over the global
 // playback shortcuts.
@@ -156,15 +161,16 @@ export default function AudioPlayer({
   const playPauseAriaLabel = isPlaying ? "Pause" : "Play";
   const streamUrl = track ? `/api/music/tracks/${track.id}/stream` : null;
 
-  const playAudio = async () => {
+  // Seek relative to the current position, clamped to the track bounds.
+  const seekBy = (offsetSeconds: number) => {
     const audio = audioRef.current;
     if (!audio) return;
 
-    try {
-      await audio.play();
-    } catch {
-      // Autoplay can still be blocked by the browser in some cases.
-    }
+    const totalDuration = audio.duration || duration;
+    audio.currentTime = Math.min(
+      totalDuration,
+      Math.max(0, audio.currentTime + offsetSeconds),
+    );
   };
 
   // Spotify-style previous: within the first few seconds go to the previous
@@ -221,10 +227,10 @@ export default function AudioPlayer({
       return;
     }
 
+    // MediaMetadata artwork wants absolute URLs; new URL() leaves already
+    // absolute covers untouched and resolves /api paths against the origin.
     const artworkUrl = albumCover
-      ? albumCover.startsWith("http")
-        ? albumCover
-        : `${window.location.origin}${albumCover}`
+      ? new URL(albumCover, window.location.origin).toString()
       : null;
 
     navigator.mediaSession.metadata = new MediaMetadata({
@@ -246,7 +252,7 @@ export default function AudioPlayer({
   }, [isPlaying, track]);
 
   const handleMediaSessionPlay = useEffectEvent(() => {
-    void playAudio();
+    void playMediaElement(audioRef.current);
   });
 
   const handleMediaSessionPause = useEffectEvent(() => {
@@ -269,26 +275,13 @@ export default function AudioPlayer({
 
   const handleMediaSessionSeekBackward = useEffectEvent(
     ({ seekOffset }: { seekOffset?: number }) => {
-      const audio = audioRef.current;
-      if (!audio) return;
-
-      audio.currentTime = Math.max(
-        0,
-        audio.currentTime - (seekOffset ?? AUDIO_SEEK_STEP_SECONDS),
-      );
+      seekBy(-(seekOffset ?? AUDIO_SEEK_STEP_SECONDS));
     },
   );
 
   const handleMediaSessionSeekForward = useEffectEvent(
     ({ seekOffset }: { seekOffset?: number }) => {
-      const audio = audioRef.current;
-      if (!audio) return;
-
-      const totalDuration = audio.duration || duration;
-      audio.currentTime = Math.min(
-        totalDuration,
-        audio.currentTime + (seekOffset ?? AUDIO_SEEK_STEP_SECONDS),
-      );
+      seekBy(seekOffset ?? AUDIO_SEEK_STEP_SECONDS);
     },
   );
 
@@ -449,11 +442,28 @@ export default function AudioPlayer({
 
     const target = event.target instanceof HTMLElement ? event.target : null;
 
+    // The player's own sliders (seek, volume) stay eligible for the global
+    // shortcuts — they never take text input — but their range navigation keys
+    // belong to the native slider. Anything else that takes typing suppresses
+    // shortcuts.
+    const isPlayerRangeInput =
+      target instanceof HTMLInputElement &&
+      target.type === "range" &&
+      target.closest("[data-audio-player]") !== null;
+
     if (
       target &&
+      !isPlayerRangeInput &&
       (target.tagName === "INPUT" ||
         target.tagName === "TEXTAREA" ||
         target.isContentEditable)
+    ) {
+      return;
+    }
+
+    if (
+      isPlayerRangeInput &&
+      (ARROW_KEYS.has(event.key) || event.key === "Home")
     ) {
       return;
     }
@@ -488,28 +498,16 @@ export default function AudioPlayer({
     switch (event.key) {
       case " ":
         event.preventDefault();
-        if (audio.paused) {
-          void playAudio();
-        } else {
-          audio.pause();
-        }
+        toggleMediaPlayback(audio);
         break;
       case "ArrowLeft":
         event.preventDefault();
-        audio.currentTime = Math.max(
-          0,
-          audio.currentTime - AUDIO_SEEK_STEP_SECONDS,
-        );
+        seekBy(-AUDIO_SEEK_STEP_SECONDS);
         break;
-      case "ArrowRight": {
+      case "ArrowRight":
         event.preventDefault();
-        const totalDuration = audio.duration || duration;
-        audio.currentTime = Math.min(
-          totalDuration,
-          audio.currentTime + AUDIO_SEEK_STEP_SECONDS,
-        );
+        seekBy(AUDIO_SEEK_STEP_SECONDS);
         break;
-      }
       case "ArrowUp":
         event.preventDefault();
         audio.volume = Math.min(1, audio.volume + AUDIO_VOLUME_STEP);
@@ -553,14 +551,10 @@ export default function AudioPlayer({
   }, []);
 
   const handleTogglePlay = () => {
-    const audio = audioRef.current;
-    if (!audio) return;
-
-    if (audio.paused) {
-      void playAudio();
-    } else {
-      audio.pause();
-    }
+    // While loading the button is aria-disabled (never `disabled`, which
+    // would drop it from the VoiceOver focus order) — guard here instead.
+    if (isLoading) return;
+    toggleMediaPlayback(audioRef.current);
   };
 
   const playNext = () => {
@@ -580,17 +574,8 @@ export default function AudioPlayer({
     if (!audioRef.current || !streamUrl) return;
 
     const audio = audioRef.current;
-
-    const loadTrack = async () => {
-      audio.load();
-      try {
-        await audio.play();
-      } catch {
-        // Autoplay can still be blocked by the browser in some cases.
-      }
-    };
-
-    void loadTrack();
+    audio.load();
+    void playMediaElement(audio);
   }, [audioRef, streamUrl]);
 
   if (!track) return null;
@@ -644,8 +629,8 @@ export default function AudioPlayer({
                 type="button"
                 onClick={handleMinimize}
                 className={cn(
-                  MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                  "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden",
+                  PLAYER_ICON_BUTTON_CLASS,
+                  "size-10 hover:bg-accent/50",
                 )}
                 aria-label="Minimize player (Escape)"
               >
@@ -662,8 +647,8 @@ export default function AudioPlayer({
                   type="button"
                   onClick={onClose}
                   className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden",
+                    PLAYER_ICON_BUTTON_CLASS,
+                    "size-10 hover:bg-accent/50",
                   )}
                   aria-label="Stop playback and close player"
                 >
@@ -720,8 +705,8 @@ export default function AudioPlayer({
                   type="button"
                   onClick={playPrevious}
                   className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-14 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden",
+                    PLAYER_ICON_BUTTON_CLASS,
+                    "size-14 hover:bg-accent/50",
                   )}
                   aria-label={previousAriaLabel}
                 >
@@ -732,10 +717,11 @@ export default function AudioPlayer({
                   type="button"
                   ref={playPauseButtonRef}
                   onClick={handleTogglePlay}
-                  disabled={isLoading}
+                  aria-disabled={isLoading || undefined}
+                  aria-busy={isLoading || undefined}
                   className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-20 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-xl shadow-primary/30 hover:bg-primary/90 focus:ring-4 focus:ring-ring/50 focus:outline-hidden disabled:opacity-50",
+                    PLAYER_PRIMARY_BUTTON_CLASS,
+                    "size-20 shadow-xl shadow-primary/30",
                   )}
                   aria-label={isLoading ? "Loading" : playPauseAriaLabel}
                 >
@@ -753,8 +739,9 @@ export default function AudioPlayer({
                   onClick={playNext}
                   aria-disabled={!hasNext}
                   className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-14 items-center justify-center rounded-full text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden aria-disabled:cursor-not-allowed aria-disabled:opacity-30",
+                    PLAYER_ICON_BUTTON_CLASS,
+                    PLAYER_TRANSPORT_INERT_CLASS,
+                    "size-14 hover:bg-accent/50",
                   )}
                   aria-label={nextAriaLabel}
                 >
@@ -796,7 +783,8 @@ export default function AudioPlayer({
                 onClick={onExpand}
                 className={cn(
                   MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                  "flex min-w-0 flex-1 items-center gap-3 rounded-lg text-left hover:opacity-80 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden",
+                  FOCUS_VISIBLE_RING_CLASS,
+                  "flex min-w-0 flex-1 items-center gap-3 rounded-lg text-left hover:opacity-80",
                 )}
                 aria-label={`Expand player. Now playing: ${track.title} by ${artist}`}
               >
@@ -833,10 +821,7 @@ export default function AudioPlayer({
                 <button
                   type="button"
                   onClick={playPrevious}
-                  className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden",
-                  )}
+                  className={cn(PLAYER_ICON_BUTTON_CLASS, "size-10 hover:bg-accent")}
                   aria-label={previousAriaLabel}
                 >
                   <SkipBack className="size-4" aria-hidden="true" />
@@ -845,10 +830,11 @@ export default function AudioPlayer({
                 <button
                   type="button"
                   onClick={handleTogglePlay}
-                  disabled={isLoading}
+                  aria-disabled={isLoading || undefined}
+                  aria-busy={isLoading || undefined}
                   className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden disabled:opacity-50",
+                    PLAYER_PRIMARY_BUTTON_CLASS,
+                    "size-12 shadow-lg shadow-primary/20",
                   )}
                   aria-label={isLoading ? "Loading" : playPauseAriaLabel}
                 >
@@ -866,8 +852,9 @@ export default function AudioPlayer({
                   onClick={playNext}
                   aria-disabled={!hasNext}
                   className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden aria-disabled:cursor-not-allowed aria-disabled:opacity-30",
+                    PLAYER_ICON_BUTTON_CLASS,
+                    PLAYER_TRANSPORT_INERT_CLASS,
+                    "size-10 hover:bg-accent",
                   )}
                   aria-label={nextAriaLabel}
                 >
@@ -894,8 +881,8 @@ export default function AudioPlayer({
                 type="button"
                 onClick={onExpand}
                 className={cn(
-                  MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                  "hidden size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden sm:flex",
+                  PLAYER_ICON_BUTTON_CLASS,
+                  "hidden size-8 hover:bg-accent sm:flex",
                 )}
                 aria-label="Expand to fullscreen player"
               >
@@ -906,10 +893,7 @@ export default function AudioPlayer({
                 <button
                   type="button"
                   onClick={onClose}
-                  className={cn(
-                    MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                    "flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden",
-                  )}
+                  className={cn(PLAYER_ICON_BUTTON_CLASS, "size-8 hover:bg-accent")}
                   aria-label="Stop playback and close player"
                 >
                   <X className="size-4" aria-hidden="true" />

--- a/web/src/components/playback/ProgressBar.tsx
+++ b/web/src/components/playback/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { formatSpokenTime, formatTimecode } from "@/lib/format";
 import {
+  CARD_FOCUS_WITHIN_RING_CLASS,
   MOTION_PROGRESS_FILL_CLASS,
   MOTION_PROGRESS_THUMB_REVEAL_CLASS,
 } from "@/lib/constants";
@@ -34,52 +35,54 @@ const variantStyles: Record<
     showTimes: boolean;
     timesLayout: "below" | "inline";
   }
-> = {
-  expanded: {
+> = (() => {
+  // Shared pieces the variants compose. All bars carry the whole-group
+  // focus-within variant of the single ring recipe (design-system §1.7);
+  // thumbs are bg-foreground — every variant sits on a themed panel, so the
+  // over-media white/black exception (§1.2) does not apply here.
+  const barBase = cn("relative rounded-full bg-muted", CARD_FOCUS_WITHIN_RING_CLASS);
+  const thumbBase =
+    "absolute top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground opacity-0 group-hover:opacity-100 group-focus-within:opacity-100";
+  const timeTextBase = "text-muted-foreground tabular-nums";
+
+  const expanded = {
     container: "mb-6 w-full max-w-md",
-    bar: "group relative h-2 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
-    thumb:
-      "absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100",
-    timeText: "text-sm text-muted-foreground tabular-nums",
+    bar: cn("group h-2", barBase),
+    thumb: cn("size-4 shadow-lg", thumbBase),
+    timeText: cn("text-sm", timeTextBase),
     showTimes: true,
-    timesLayout: "below",
-  },
-  minimized: {
-    container: "hidden max-w-md flex-1 items-center gap-3 sm:flex",
-    bar: "group relative h-1.5 flex-1 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring",
-    thumb:
-      "absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-md group-hover:opacity-100 group-focus-within:opacity-100",
-    timeText: "w-10 text-xs text-muted-foreground tabular-nums",
-    showTimes: true,
-    timesLayout: "inline",
-  },
-  mobile: {
-    container: "mt-2 sm:hidden",
-    bar: "relative h-1 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring",
-    thumb: "", // No thumb on mobile for cleaner look
-    timeText: "text-xs text-muted-foreground tabular-nums",
-    showTimes: true,
-    timesLayout: "below",
-  },
-  video: {
-    container: "mb-4 w-full",
-    bar: "group relative h-2 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background",
-    thumb:
-      "absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100",
-    timeText: "text-sm text-muted-foreground tabular-nums",
-    showTimes: true,
-    timesLayout: "below",
-  },
-  trailer: {
-    container: "mb-4 w-full",
-    bar: "group relative h-1.5 rounded-full bg-muted focus-within:ring-2 focus-within:ring-ring",
-    thumb:
-      "absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-md group-hover:opacity-100 group-focus-within:opacity-100",
-    timeText: "text-sm text-muted-foreground tabular-nums",
-    showTimes: false,
-    timesLayout: "below",
-  },
-};
+    timesLayout: "below" as const,
+  };
+
+  return {
+    expanded,
+    minimized: {
+      container: "hidden max-w-md flex-1 items-center gap-3 sm:flex",
+      bar: cn("group h-1.5 flex-1", barBase),
+      thumb: cn("size-3 shadow-md", thumbBase),
+      timeText: cn("w-10 text-xs", timeTextBase),
+      showTimes: true,
+      timesLayout: "inline",
+    },
+    mobile: {
+      container: "mt-2 sm:hidden",
+      bar: cn("h-1", barBase),
+      thumb: "", // No thumb on mobile for cleaner look
+      timeText: cn("text-xs", timeTextBase),
+      showTimes: true,
+      timesLayout: "below",
+    },
+    video: { ...expanded, container: "mb-4 w-full" },
+    trailer: {
+      container: "mb-4 w-full",
+      bar: cn("group h-1.5", barBase),
+      thumb: cn("size-3 shadow-md", thumbBase),
+      timeText: cn("text-sm", timeTextBase),
+      showTimes: false,
+      timesLayout: "below",
+    },
+  };
+})();
 
 function clampToRange(value: number, min: number, max: number) {
   if (!Number.isFinite(value)) {

--- a/web/src/components/playback/VolumeControl.tsx
+++ b/web/src/components/playback/VolumeControl.tsx
@@ -8,8 +8,8 @@ import {
 } from "react";
 import { Volume, Volume1, Volume2, VolumeX } from "lucide-react";
 import {
-  MOTION_PLAYER_CHROME_BUTTON_CLASS,
   MOTION_PLAYER_CHROME_PANEL_CLASS,
+  PLAYER_ICON_BUTTON_CLASS,
 } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -192,10 +192,7 @@ export default function VolumeControl({
         <button
           type="button"
           onClick={toggleMute}
-          className={cn(
-            MOTION_PLAYER_CHROME_BUTTON_CLASS,
-            "flex size-10 items-center justify-center rounded-full text-muted-foreground hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden",
-          )}
+          className={cn(PLAYER_ICON_BUTTON_CLASS, "size-10")}
           aria-label={isMuted ? "Unmute (M)" : "Mute (M)"}
         >
           {getVolumeIcon()}
@@ -218,8 +215,8 @@ export default function VolumeControl({
         type="button"
         onClick={() => setIsMinimizedPanelOpen(open => !open)}
         className={cn(
-          MOTION_PLAYER_CHROME_BUTTON_CLASS,
-          "flex size-11 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden",
+          PLAYER_ICON_BUTTON_CLASS,
+          "size-11 hover:bg-accent",
           isMinimizedPanelOpen && "bg-accent text-foreground",
         )}
         aria-label="Adjust volume"
@@ -244,10 +241,7 @@ export default function VolumeControl({
               ref={minimizedMuteButtonRef}
               type="button"
               onClick={toggleMute}
-              className={cn(
-                MOTION_PLAYER_CHROME_BUTTON_CLASS,
-                "flex size-11 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden",
-              )}
+              className={cn(PLAYER_ICON_BUTTON_CLASS, "size-11 hover:bg-accent")}
               aria-label={isMuted ? "Unmute (M)" : "Mute (M)"}
             >
               {getVolumeIcon()}

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -20,6 +20,7 @@ import {
   convertToAudioTrack,
   extractTrackMetadata,
   shuffleArray,
+  toggleMediaPlayback,
   trimQueueHistory,
 } from "@/lib/audio-utils";
 import {
@@ -133,17 +134,6 @@ export function AudioPlayerProvider({
     trackAlbumTitlesRef.current?.clear();
     playAllOffsetRef.current = 0;
     playAllTotalRef.current = 0;
-  };
-
-  const playAudio = async () => {
-    const audio = audioRef.current;
-    if (!audio) return;
-
-    try {
-      await audio.play();
-    } catch {
-      // Playback can still be blocked by the browser in some cases.
-    }
   };
 
   const currentTrackIndex = queueState.currentTrack
@@ -504,15 +494,7 @@ export function AudioPlayerProvider({
   };
 
   const togglePlay = () => {
-    const audio = audioRef.current;
-    if (!audio) return;
-
-    if (audio.paused) {
-      void playAudio();
-      return;
-    }
-
-    audio.pause();
+    toggleMediaPlayback(audioRef.current);
   };
 
   const suspendKeyboard = () => {

--- a/web/src/hooks/useTrackPlaybackMatcher.ts
+++ b/web/src/hooks/useTrackPlaybackMatcher.ts
@@ -1,0 +1,16 @@
+import { useAudioPlayerState } from "@/hooks/useAudioPlayerState";
+
+// Shared "is this row the current track" wiring for track lists — every list
+// renders TrackItem with the same two props derived from the player state.
+export function useTrackPlaybackMatcher() {
+  const { currentTrack, isPlaying } = useAudioPlayerState();
+
+  return (trackId: number) => {
+    const isCurrentTrack = currentTrack?.id === trackId;
+
+    return {
+      isCurrentTrack,
+      isPlaying: isCurrentTrack && isPlaying,
+    };
+  };
+}

--- a/web/src/lib/audio-utils.ts
+++ b/web/src/lib/audio-utils.ts
@@ -1,5 +1,27 @@
 import type { PlayableTrackData } from "@/types";
 
+// Start playback, swallowing the rejection browsers throw when autoplay is
+// blocked — the UI simply stays paused in that case.
+export async function playMediaElement(media: HTMLMediaElement | null) {
+  if (!media) return;
+
+  try {
+    await media.play();
+  } catch {
+    // Autoplay can still be blocked by the browser in some cases.
+  }
+}
+
+export function toggleMediaPlayback(media: HTMLMediaElement | null) {
+  if (!media) return;
+
+  if (media.paused) {
+    void playMediaElement(media);
+  } else {
+    media.pause();
+  }
+}
+
 // Convert minimal track data to a full TrackType for the audio player
 // Fills in default values for fields not needed for playback
 export function convertToAudioTrack(track: PlayableTrackData) {

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -212,6 +212,7 @@ export const HLS_PLAYBACK_SESSION_QUERY_PARAM = "playback_session";
 export const MOVIE_SEEK_STEP_SEC = 10;
 export const AUDIO_SEEK_STEP_SECONDS = 10;
 export const MOVIE_VOLUME_STEP = 0.1;
+export const AUDIO_VOLUME_STEP = 0.1;
 export const MOVIE_CONTROLS_IDLE_MS = 3000;
 export const MOVIE_WATCH_PROGRESS_SAVE_INTERVAL_MS = 15_000;
 /** Window in which visibilitychange(hidden) + pagehide keepalive saves at the same position collapse into one PUT. */
@@ -500,6 +501,23 @@ export const HOME_ALBUM_GRID_CLASS =
  */
 export const FOCUS_VISIBLE_RING_CLASS =
   "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-hidden";
+
+/**
+ * Circular icon button in the audio player chrome (design-system §1.7, §2.3).
+ * Call sites add the size (`size-10`, `size-14`, …) and hover surface
+ * (`hover:bg-accent/50` in the expanded dialog, `hover:bg-accent` in the mini
+ * bar and volume panel).
+ */
+export const PLAYER_ICON_BUTTON_CLASS = `${MOTION_PLAYER_CHROME_BUTTON_CLASS} flex items-center justify-center rounded-full text-muted-foreground hover:text-foreground ${FOCUS_VISIBLE_RING_CLASS}`;
+/**
+ * Primary play/pause transport button. Dimming while loading comes from
+ * `aria-disabled` — never `disabled`, which breaks VoiceOver focus on media
+ * transport controls (design-system §1.7). Call sites add size + shadow.
+ */
+export const PLAYER_PRIMARY_BUTTON_CLASS = `${MOTION_PLAYER_CHROME_BUTTON_CLASS} flex items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 aria-disabled:opacity-50 ${FOCUS_VISIBLE_RING_CLASS}`;
+/** Inert-but-focusable transport control (e.g. next on the last track). */
+export const PLAYER_TRANSPORT_INERT_CLASS =
+  "aria-disabled:cursor-not-allowed aria-disabled:opacity-30";
 
 /**
  * Layout-only shell for the full-width library/settings tab bars (movies /

--- a/web/src/routes/_auth/music/album.$id.tsx
+++ b/web/src/routes/_auth/music/album.$id.tsx
@@ -32,7 +32,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
-import { useAudioPlayerState } from "@/hooks/useAudioPlayerState";
+import { useTrackPlaybackMatcher } from "@/hooks/useTrackPlaybackMatcher";
 import TrackItem from "@/components/music/TrackItem";
 import ConfirmDialog from "@/components/shared/ConfirmDialog";
 import { formatDate, formatDuration } from "@/lib/format";
@@ -189,7 +189,7 @@ function AlbumDetailsContent({
   total_duration,
 }: AlbumDetailsResponseType) {
   const audioPlayer = useAudioPlayerActions();
-  const audioPlayerState = useAudioPlayerState();
+  const matchTrackPlayback = useTrackPlaybackMatcher();
   const navigate = Route.useNavigate();
   const queryClient = useQueryClient();
 
@@ -330,17 +330,9 @@ function AlbumDetailsContent({
   const pageAnnouncement = `${album.title}${musicianName ? ` by ${musicianName}` : ""}. ${tracks.length} ${tracks.length === 1 ? "track" : "tracks"}. Total duration: ${formatDuration(total_duration)}.${album_genres.length > 0 ? ` Genres: ${album_genres.join(", ")}.` : ""}`;
   const pageAnnouncementId = `album-${album.id}-summary`;
 
-  // Check if a specific track is currently playing
-  const isTrackPlaying = (track: TrackType) => {
-    return (
-      audioPlayerState.currentTrack?.id === track.id &&
-      audioPlayerState.isPlaying
-    );
-  };
-
   // Handle playing/pausing a track
   const handleToggleTrack = (track: TrackType) => {
-    if (audioPlayerState.currentTrack?.id === track.id) {
+    if (matchTrackPlayback(track.id).isCurrentTrack) {
       // Toggle play/pause for the current track
       audioPlayer.togglePlay();
     } else {
@@ -678,8 +670,7 @@ function AlbumDetailsContent({
                         genres={trackGenreMap.get(track.id) || []}
                         variant="album"
                         isLiked={likedSet.has(track.id)}
-                        isPlaying={isTrackPlaying(track)}
-                        isCurrentTrack={audioPlayerState.currentTrack?.id === track.id}
+                        {...matchTrackPlayback(track.id)}
                         onPlay={() => handleToggleTrack(track)}
                       />
                     ))}

--- a/web/src/routes/_auth/music/index.tsx
+++ b/web/src/routes/_auth/music/index.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/lib/query-opts";
 import { convertToAudioTrack } from "@/lib/audio-utils";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
-import { useAudioPlayerState } from "@/hooks/useAudioPlayerState";
+import { useTrackPlaybackMatcher } from "@/hooks/useTrackPlaybackMatcher";
 import {
   ALBUMS_PER_PAGE,
   CONTENT_FADE_ENTER_CLASS,
@@ -996,7 +996,7 @@ const TrackListItem = memo(function TrackListItem({
   queueRef: React.RefObject<TrackListItemType[]>;
 }) {
   const audioPlayer = useAudioPlayerActions();
-  const playerState = useAudioPlayerState();
+  const matchTrackPlayback = useTrackPlaybackMatcher();
 
   const handlePlay = () => {
     audioPlayer.playTrackFromList(queueRef.current, track.id);
@@ -1013,8 +1013,7 @@ const TrackListItem = memo(function TrackListItem({
       musicianId={unwrapInt(track.musician_id)}
       musicianName={unwrapStringOrUndefined(track.musician_name)}
       variant="library"
-      isPlaying={playerState.currentTrack?.id === track.id && playerState.isPlaying}
-      isCurrentTrack={playerState.currentTrack?.id === track.id}
+      {...matchTrackPlayback(track.id)}
       isLiked={isLiked}
       onPlay={handlePlay}
       showActionsMenu
@@ -1166,7 +1165,7 @@ type LikedTracksInPlaylistsTabProps = {
 function LikedTracksInPlaylistsTab({ likedTracksPage, onExit }: LikedTracksInPlaylistsTabProps) {
   const navigate = Route.useNavigate();
   const audioPlayer = useAudioPlayerActions();
-  const audioPlayerState = useAudioPlayerState();
+  const matchTrackPlayback = useTrackPlaybackMatcher();
 
   const { data, isLoading } = useQuery(likedTracksQueryOpts(likedTracksPage));
 
@@ -1260,11 +1259,7 @@ function LikedTracksInPlaylistsTab({ likedTracksPage, onExit }: LikedTracksInPla
               musicianName={unwrapStringOrUndefined(track.musician_name)}
               variant="library"
               isLiked
-              isPlaying={
-                audioPlayerState.currentTrack?.id === track.id &&
-                audioPlayerState.isPlaying
-              }
-              isCurrentTrack={audioPlayerState.currentTrack?.id === track.id}
+              {...matchTrackPlayback(track.id)}
               onPlay={() => handlePlayTrack(track)}
               showActionsMenu
             />

--- a/web/src/routes/_auth/music/musician.$id.tsx
+++ b/web/src/routes/_auth/music/musician.$id.tsx
@@ -27,7 +27,7 @@ import {
   SpotifyPopularityMeter,
 } from "@/components/music/SpotifyPopularity";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
-import { useAudioPlayerState } from "@/hooks/useAudioPlayerState";
+import { useTrackPlaybackMatcher } from "@/hooks/useTrackPlaybackMatcher";
 import TrackItem from "@/components/music/TrackItem";
 import { formatDuration } from "@/lib/format";
 import { convertToAudioTrack } from "@/lib/audio-utils";
@@ -198,7 +198,7 @@ function MusicianDetailsContent({
   total_duration,
 }: MusicianDetailsResponseType) {
   const audioPlayer = useAudioPlayerActions();
-  const audioPlayerState = useAudioPlayerState();
+  const matchTrackPlayback = useTrackPlaybackMatcher();
 
   const [thumbFailed, setThumbFailed] = useState(false);
 
@@ -286,13 +286,6 @@ function MusicianDetailsContent({
       title: musician.name,
       musician: musician.name,
     });
-  };
-
-  const isTrackPlaying = (track: MusicianTrackType) => {
-    return (
-      audioPlayerState.currentTrack?.id === track.id &&
-      audioPlayerState.isPlaying
-    );
   };
 
   // Screen reader announcement summarizing the page
@@ -571,10 +564,7 @@ function MusicianDetailsContent({
                       albumId={unwrapInt(track.album_id)}
                       variant="musician"
                       isLiked={likedSet.has(track.id)}
-                      isPlaying={isTrackPlaying(track)}
-                      isCurrentTrack={
-                        audioPlayerState.currentTrack?.id === track.id
-                      }
+                      {...matchTrackPlayback(track.id)}
                       onPlay={() => handlePlayTrack(track)}
                     />
                   ))}

--- a/web/src/routes/_auth/search/index.lazy.tsx
+++ b/web/src/routes/_auth/search/index.lazy.tsx
@@ -10,7 +10,7 @@ import MusicianCard from "@/components/music/MusicianCard";
 import TrackItem from "@/components/music/TrackItem";
 import { useContentFadeTransition } from "@/hooks/useContentFadeTransition";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
-import { useAudioPlayerState } from "@/hooks/useAudioPlayerState";
+import { useTrackPlaybackMatcher } from "@/hooks/useTrackPlaybackMatcher";
 import {
   unwrapInt,
   unwrapString,
@@ -609,7 +609,7 @@ function SearchTrackItem({
   queue: TrackListItemType[];
 }) {
   const audioPlayer = useAudioPlayerActions();
-  const playerState = useAudioPlayerState();
+  const matchTrackPlayback = useTrackPlaybackMatcher();
 
   const handlePlay = () => {
     audioPlayer.playTrackFromList(queue, track.id);
@@ -626,10 +626,7 @@ function SearchTrackItem({
       musicianId={unwrapInt(track.musician_id)}
       musicianName={unwrapStringOrUndefined(track.musician_name)}
       variant="library"
-      isPlaying={
-        playerState.currentTrack?.id === track.id && playerState.isPlaying
-      }
-      isCurrentTrack={playerState.currentTrack?.id === track.id}
+      {...matchTrackPlayback(track.id)}
       onPlay={handlePlay}
       showActionsMenu
     />

--- a/web/src/routes/_auth/trailer.lazy.tsx
+++ b/web/src/routes/_auth/trailer.lazy.tsx
@@ -472,7 +472,6 @@ function TrailerPage() {
             duration={duration}
             onSeek={seekTo}
             ariaLabel="Seek through trailer"
-            groupLabel="Playback progress"
           />
 
           <div className="flex items-center justify-between">

--- a/web/src/test/lib/audio-utils.test.ts
+++ b/web/src/test/lib/audio-utils.test.ts
@@ -1,9 +1,45 @@
-import { describe, expect, it } from "vitest";
-import { trimQueueHistory } from "@/lib/audio-utils";
+import { describe, expect, it, vi } from "vitest";
+import {
+  playMediaElement,
+  toggleMediaPlayback,
+  trimQueueHistory,
+} from "@/lib/audio-utils";
 
 function makeTracks(count: number) {
   return Array.from({ length: count }, (_, index) => ({ id: index + 1 }));
 }
+
+describe("playMediaElement", () => {
+  it("swallows the rejection when the browser blocks playback", async () => {
+    const media = {
+      play: vi.fn().mockRejectedValue(new Error("NotAllowedError")),
+    } as unknown as HTMLMediaElement;
+
+    await expect(playMediaElement(media)).resolves.toBeUndefined();
+    expect(media.play).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a missing element", async () => {
+    await expect(playMediaElement(null)).resolves.toBeUndefined();
+  });
+});
+
+describe("toggleMediaPlayback", () => {
+  it("plays when paused and pauses when playing", () => {
+    const media = {
+      paused: true,
+      play: vi.fn().mockResolvedValue(undefined),
+      pause: vi.fn(),
+    } as unknown as HTMLMediaElement;
+
+    toggleMediaPlayback(media);
+    expect(media.play).toHaveBeenCalledOnce();
+
+    (media as unknown as { paused: boolean }).paused = false;
+    toggleMediaPlayback(media);
+    expect(media.pause).toHaveBeenCalledOnce();
+  });
+});
 
 describe("trimQueueHistory", () => {
   it("returns the queue unchanged while the current track is within the window", () => {

--- a/web/src/test/lib/constants-contracts.test.ts
+++ b/web/src/test/lib/constants-contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ALBUMS_PAGINATED_KEY,
   ALBUMS_PER_PAGE,
+  AUDIO_VOLUME_STEP,
   FOCUS_VISIBLE_RING_CLASS,
   HOME_ALBUM_GRID_CLASS,
   HOME_POSTER_GRID_CLASS,
@@ -10,10 +11,15 @@ import {
   MOVIES_BY_GENRE_KEY,
   MOVIES_LIBRARY_KEY,
   MOVIES_LIKED_KEY,
+  MOVIE_VOLUME_STEP,
   MOVIES_PER_PAGE,
+  MOTION_PLAYER_CHROME_BUTTON_CLASS,
   MUSICIANS_PAGINATED_KEY,
   MUSICIANS_PER_PAGE,
   NOTIFICATION_TITLES,
+  PLAYER_ICON_BUTTON_CLASS,
+  PLAYER_PRIMARY_BUTTON_CLASS,
+  PLAYER_TRANSPORT_INERT_CLASS,
   PLAYLIST_TRACKS_KEY,
   PLAYLIST_TRACKS_PAGE_SIZE,
   SEARCH_MOVIES_KEY,
@@ -42,6 +48,26 @@ describe("constants contracts", () => {
     expect(FOCUS_VISIBLE_RING_CLASS).toBe(
       "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-hidden",
     );
+  });
+
+  it("keeps player chrome buttons on the single ring recipe and shared motion (design-system §1.7, §3.5)", () => {
+    for (const constant of [
+      PLAYER_ICON_BUTTON_CLASS,
+      PLAYER_PRIMARY_BUTTON_CLASS,
+    ]) {
+      expect(constant).toContain(FOCUS_VISIBLE_RING_CLASS);
+      expect(constant).toContain(MOTION_PLAYER_CHROME_BUTTON_CLASS);
+      // No plain `focus:` variants — rings are keyboard-only (focus-visible).
+      expect(constant).not.toMatch(/(^|[^-])focus:/);
+    }
+    // Loading/inert transport controls stay focusable: aria-disabled, never disabled.
+    expect(PLAYER_PRIMARY_BUTTON_CLASS).toContain("aria-disabled:opacity-50");
+    expect(PLAYER_PRIMARY_BUTTON_CLASS).not.toMatch(/(^|\s)disabled:/);
+    expect(PLAYER_TRANSPORT_INERT_CLASS).toBe(
+      "aria-disabled:cursor-not-allowed aria-disabled:opacity-30",
+    );
+    expect(AUDIO_VOLUME_STEP).toBe(0.1);
+    expect(AUDIO_VOLUME_STEP).toBe(MOVIE_VOLUME_STEP);
   });
 
   it("keeps home grids on auto-fill so sparse sections don't stretch (design-system §3.2)", () => {

--- a/web/src/test/music/audio-player-media-session.test.tsx
+++ b/web/src/test/music/audio-player-media-session.test.tsx
@@ -11,6 +11,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AudioPlayer from "@/components/playback/AudioPlayer";
 import {
+  FOCUS_VISIBLE_RING_CLASS,
   MOTION_MEDIA_OVERLAY_ENTER_CLASS,
   MOTION_PLAYER_CHROME_BUTTON_CLASS,
   MOTION_PLAYER_CHROME_ENTER_CLASS,
@@ -438,6 +439,47 @@ describe("AudioPlayer Media Session", () => {
     );
   });
 
+  it("keeps transport controls on the single focus-visible ring recipe (design-system §1.7)", () => {
+    renderAudioPlayer({ onClose: vi.fn() });
+
+    for (const name of [
+      "Restart track",
+      "Play",
+      "No next track",
+      "Stop playback and close player",
+    ]) {
+      expect(screen.getByRole("button", { name })).toHaveClass(
+        ...FOCUS_VISIBLE_RING_CLASS.split(" "),
+      );
+    }
+  });
+
+  it("keeps play/pause focusable while loading via aria-disabled, and ignores clicks", () => {
+    const { audio } = renderAudioPlayer({ onClose: vi.fn() });
+
+    const playButton = screen.getByRole("button", { name: "Play" });
+    expect(playButton).not.toHaveAttribute("disabled");
+    expect(playButton).not.toHaveAttribute("aria-disabled");
+
+    fireEvent(audio, new Event("loadstart"));
+
+    const loadingButton = screen.getByRole("button", { name: "Loading" });
+    expect(loadingButton).not.toHaveAttribute("disabled");
+    expect(loadingButton).toHaveAttribute("aria-disabled", "true");
+    expect(loadingButton).toHaveAttribute("aria-busy", "true");
+
+    // The click guard replaces `disabled`: no play/pause while loading.
+    (HTMLMediaElement.prototype.play as ReturnType<typeof vi.fn>).mockClear();
+    fireEvent.click(loadingButton);
+    expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
+    expect(HTMLMediaElement.prototype.pause).not.toHaveBeenCalled();
+
+    fireEvent(audio, new Event("canplay"));
+    expect(
+      screen.getByRole("button", { name: "Play" }),
+    ).not.toHaveAttribute("aria-disabled");
+  });
+
   it("focuses playback controls when the expanded player opens", async () => {
     renderAudioPlayer({ isExpanded: true, onClose: vi.fn() });
 
@@ -687,6 +729,72 @@ describe("AudioPlayer Media Session", () => {
       fireEvent.keyDown(document.body, { key: "ArrowRight" });
 
       expect(setCurrentTime).toHaveBeenCalledWith(40);
+    });
+
+    it("restarts the track with Home from a non-range target", () => {
+      const { audio } = renderAudioPlayer();
+      const setCurrentTime = observeAudioCurrentTime(audio, 30);
+
+      const defaultNotPrevented = fireEvent.keyDown(document.body, {
+        key: "Home",
+      });
+
+      expect(defaultNotPrevented).toBe(false);
+      expect(setCurrentTime).toHaveBeenCalledWith(0);
+    });
+
+    it("leaves Home on the expanded volume slider to the native control", () => {
+      const { audio } = renderAudioPlayer({ isExpanded: true });
+      const setCurrentTime = observeAudioCurrentTime(audio, 30);
+      const volumeSlider = screen.getByRole("slider", { name: "Volume" });
+      volumeSlider.focus();
+
+      // jsdom does not perform the range input's native Home action, so the
+      // global guard must leave the event unprevented for a browser to do it.
+      const defaultNotPrevented = fireEvent.keyDown(volumeSlider, {
+        key: "Home",
+      });
+
+      expect(defaultNotPrevented).toBe(true);
+      expect(setCurrentTime).not.toHaveBeenCalled();
+    });
+
+    it("keeps letter shortcuts working from the player's own sliders, leaving arrows to the slider", () => {
+      const { audio } = renderAudioPlayer();
+      setAudioNumber(audio, "duration", 120);
+      const setCurrentTime = observeAudioCurrentTime(audio, 30);
+      // Sync the component's displayed position/duration with the element.
+      fireEvent(audio, new Event("durationchange"));
+      fireEvent(audio, new Event("timeupdate"));
+
+      // The mini bar renders the sm+ strip and the mobile strip; either works.
+      const [seekSlider] = screen.getAllByRole("slider", {
+        name: "Seek through track",
+      });
+      seekSlider.focus();
+
+      // m must reach the global shortcut even with the slider focused…
+      fireEvent.keyDown(seekSlider, { key: "m" });
+      expect(audio.muted).toBe(true);
+
+      // …while the global arrow handler stays out of the slider's way
+      // (the slider's own handler seeks ±5; the global one would add ±10).
+      fireEvent.keyDown(seekSlider, { key: "ArrowRight" });
+      expect(setCurrentTime).toHaveBeenCalledTimes(1);
+      expect(setCurrentTime).toHaveBeenCalledWith(35);
+    });
+
+    it("suppresses shortcuts from text inputs", () => {
+      const { audio } = renderAudioPlayer({
+        siblings: <input type="text" aria-label="Search stub" />,
+      });
+      setAudioNumber(audio, "duration", 120);
+
+      const textInput = screen.getByRole("textbox", { name: "Search stub" });
+      textInput.focus();
+      fireEvent.keyDown(textInput, { key: "m" });
+
+      expect(audio.muted).toBe(false);
     });
   });
 

--- a/web/src/test/music/audio-player-media-session.test.tsx
+++ b/web/src/test/music/audio-player-media-session.test.tsx
@@ -743,6 +743,22 @@ describe("AudioPlayer Media Session", () => {
       expect(setCurrentTime).toHaveBeenCalledWith(0);
     });
 
+    it("leaves Home on an external tab control unhandled", () => {
+      const { audio } = renderAudioPlayer({
+        siblings: <button role="tab" type="button">Outside tab</button>,
+      });
+      const setCurrentTime = observeAudioCurrentTime(audio, 30);
+      const outsideTab = screen.getByRole("tab", { name: "Outside tab" });
+
+      outsideTab.focus();
+      const defaultNotPrevented = fireEvent.keyDown(outsideTab, {
+        key: "Home",
+      });
+
+      expect(defaultNotPrevented).toBe(true);
+      expect(setCurrentTime).not.toHaveBeenCalled();
+    });
+
     it("leaves Home on the expanded volume slider to the native control", () => {
       const { audio } = renderAudioPlayer({ isExpanded: true });
       const setCurrentTime = observeAudioCurrentTime(audio, 30);
@@ -757,6 +773,22 @@ describe("AudioPlayer Media Session", () => {
 
       expect(defaultNotPrevented).toBe(true);
       expect(setCurrentTime).not.toHaveBeenCalled();
+    });
+
+    it("prevents Space without toggling playback while audio is loading", () => {
+      const { audio } = renderAudioPlayer();
+      const playMock = HTMLMediaElement.prototype.play as ReturnType<
+        typeof vi.fn
+      >;
+
+      fireEvent(audio, new Event("loadstart"));
+      playMock.mockClear();
+
+      const defaultNotPrevented = fireEvent.keyDown(document.body, { key: " " });
+
+      expect(defaultNotPrevented).toBe(false);
+      expect(playMock).not.toHaveBeenCalled();
+      expect(HTMLMediaElement.prototype.pause).not.toHaveBeenCalled();
     });
 
     it("keeps letter shortcuts working from the player's own sliders, leaving arrows to the slider", () => {

--- a/web/src/test/playback/progress-bar.test.tsx
+++ b/web/src/test/playback/progress-bar.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import ProgressBar from "@/components/playback/ProgressBar";
 import {
+  CARD_FOCUS_WITHIN_RING_CLASS,
   MOTION_PROGRESS_FILL_CLASS,
   MOTION_PROGRESS_THUMB_REVEAL_CLASS,
 } from "@/lib/constants";
@@ -115,6 +116,30 @@ describe("ProgressBar", () => {
       ...MOTION_PROGRESS_THUMB_REVEAL_CLASS.split(" "),
     );
   });
+
+  it.each(["expanded", "minimized", "video", "trailer"] as const)(
+    "uses a semantic thumb and the whole-group focus ring on the %s variant",
+    variant => {
+      render(
+        <ProgressBar
+          currentTime={30}
+          duration={120}
+          onSeek={vi.fn()}
+          variant={variant}
+        />,
+      );
+
+      const slider = screen.getByRole("slider");
+      const bar = slider.parentElement;
+      const thumb = bar?.firstElementChild?.nextElementSibling;
+
+      // Every variant sits on a themed panel, so the thumb is bg-foreground —
+      // the over-media white exception (design-system §1.2) does not apply.
+      expect(thumb).toHaveClass("bg-foreground");
+      expect(thumb).not.toHaveClass("bg-white");
+      expect(bar).toHaveClass(...CARD_FOCUS_WITHIN_RING_CLASS.split(" "));
+    },
+  );
 
   it("seeks when the range input value changes", () => {
     const onSeek = vi.fn();

--- a/web/src/test/playback/volume-control.test.tsx
+++ b/web/src/test/playback/volume-control.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import VolumeControl from "@/components/playback/VolumeControl";
+import { PLAYER_ICON_BUTTON_CLASS } from "@/lib/constants";
 
 function renderVolumeControl() {
   const media = document.createElement("audio");
@@ -19,6 +20,14 @@ function renderVolumeControl() {
 }
 
 describe("VolumeControl", () => {
+  it("keeps the trigger on the shared player chrome recipe (design-system §1.7)", () => {
+    renderVolumeControl();
+
+    expect(
+      screen.getByRole("button", { name: "Adjust volume" }),
+    ).toHaveClass(...PLAYER_ICON_BUTTON_CLASS.split(" "));
+  });
+
   it("opens the minimized panel as a non-modal control group", async () => {
     const user = userEvent.setup();
     renderVolumeControl();


### PR DESCRIPTION
## Summary

- unify audio-player controls on the shared focus-visible styling and keep loading transport controls focusable
- consolidate media play/toggle behavior and current-track matching across music lists
- preserve native range navigation for player sliders, including Volume Home, while retaining global shortcuts elsewhere
- standardize progress-bar focus and thumb styling and document deferred follow-up issues

## Testing

- `bun run test -- src/test/music/audio-player-media-session.test.tsx src/test/playback/volume-control.test.tsx src/test/playback/progress-bar.test.tsx`
- `bun run lint`
- `bun run test`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio playback controls, including reliable play/pause toggling and relative seeking.
  * Enhanced keyboard navigation for player sliders and transport controls.
  * Improved artwork handling for lock-screen and system media controls.
  * Track rows now display current-track and playing states more consistently.

* **Bug Fixes**
  * Removed the duplicate playback progress label from trailers.
  * Improved loading-state behavior and accessibility announcements for playback controls.
  * Standardized focus styling across player controls and progress bars.

* **Documentation**
  * Added documentation covering known audio-player follow-up issues.

* **Tests**
  * Expanded coverage for playback utilities, keyboard interactions, accessibility states, and player styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->