### PR TITLE
Audit HLS playback and fix the blocking findings

### DIFF
--- a/docs/ffmpeg.md
+++ b/docs/ffmpeg.md
@@ -371,6 +371,8 @@ The poll interval is deliberately short. A segment that lands just after a check
 
 Segments and whole media files are served through the kernel's `sendfile(2)` path. The session middleware wraps the response writer in a type that does not implement `io.ReaderFrom`, which would silently force every byte through a userspace copy, so `restoreSendfile` re-exposes the capability for the whole router. See §4.4 of `docs/web-direct-playback-audit.md`.
 
+Initialization files and media segments for both personal and watch-room HLS sessions support HTTP byte ranges. A complete asset response uses `200 OK`; a satisfiable `Range` request uses `206 Partial Content` with `Accept-Ranges: bytes` and `Content-Range`; and an unsatisfiable range returns `416 Requested Range Not Satisfiable`.
+
 FFmpeg stderr is not streamed to clients. The HLS runner keeps the last 20 stderr lines and passes them to the session exit handler for logging. That gives enough context for server-side troubleshooting without storing unbounded FFmpeg output.
 
 ## Seeking and Resume Behavior

--- a/docs/ffmpeg.md
+++ b/docs/ffmpeg.md
@@ -110,7 +110,7 @@ The generated files match the HTTP handlers:
 
 fMP4 HLS is used because modern browser players handle it well and it works naturally with copied H.264 video, transcoded H.264 video, and AAC audio. A short 4-second target segment gives acceptable startup and seek behavior while keeping the number of segment files manageable. FFmpeg also receives `movflags=+frag_discont` for fMP4 segment output so independent fragments tolerate discontinuities across rebased sessions and copy-video boundaries.
 
-FFmpeg writes an event playlist while encoding. Igloo exposes a VOD-style playlist to clients. During encoding, Igloo generates a complete VOD playlist from the known movie duration so hls.js sees a seekable on-demand asset instead of a live/event stream. Generated VOD playlists use a target duration of 8 seconds for transcodes and 30 seconds for copy-video sessions, because copied video can only split on source keyframe boundaries. After FFmpeg exits successfully, Igloo finalizes the FFmpeg playlist by switching it to VOD and appending `#EXT-X-ENDLIST` when needed.
+FFmpeg writes an event playlist while encoding. For transcode sessions, Igloo generates a complete VOD playlist from the known movie duration during encoding so hls.js sees a seekable on-demand asset instead of a live/event stream; generated playlists use a target duration of 8 seconds. Copy-video sessions are served FFmpeg's own playlist instead, as described below. After FFmpeg exits successfully, Igloo finalizes the FFmpeg playlist by switching it to VOD and appending `#EXT-X-ENDLIST` when needed.
 
 Which playlist a client receives depends on whether the session copies video, because only one of the two can be described arithmetically:
 

--- a/docs/ffmpeg.md
+++ b/docs/ffmpeg.md
@@ -112,6 +112,15 @@ fMP4 HLS is used because modern browser players handle it well and it works natu
 
 FFmpeg writes an event playlist while encoding. Igloo exposes a VOD-style playlist to clients. During encoding, Igloo generates a complete VOD playlist from the known movie duration so hls.js sees a seekable on-demand asset instead of a live/event stream. Generated VOD playlists use a target duration of 8 seconds for transcodes and 30 seconds for copy-video sessions, because copied video can only split on source keyframe boundaries. After FFmpeg exits successfully, Igloo finalizes the FFmpeg playlist by switching it to VOD and appending `#EXT-X-ENDLIST` when needed.
 
+Which playlist a client receives depends on whether the session copies video, because only one of the two can be described arithmetically:
+
+- **Transcode sessions** get the synthesized playlist described above: `ceil(duration / 4)` entries each declared as 4 seconds. This is exact, because `-force_key_frames` pins every segment boundary to a 4-second mark (measured drift over 300 seconds of output: 8 ms). The whole movie is listed from the first request, so the asset is seekable end to end immediately.
+- **Copy-video (`remux`) sessions** are served FFmpeg's own playlist instead, with only the asset URLs rewritten. Copied segments can split only at source keyframes, so their durations are whatever the source encode dictates — 5.40 s mean (range 1.0–10.0) on one 1080p H.264 source, 9.24 s mean (range 1.2–12.4) on another. Synthesizing a playlist for these advertised durations FFmpeg never produced and segments that would never exist, and the surplus entries returned `404 segment does not exist` once the session finished, breaking playback near the end of the film (audit findings H1 and H2).
+
+While a copy-video session is still encoding, its playlist is served as `#EXT-X-PLAYLIST-TYPE:EVENT` with no `#EXT-X-ENDLIST`, so players may reload it and pick up new segments as FFmpeg publishes them. Once FFmpeg exits cleanly the finalized VOD playlist is served as before. A manifest request for a copy-video session that has not published its first segment yet waits briefly and then returns `503` with a short `Retry-After` rather than falling back to a synthesized playlist.
+
+The practical cost is that a copy-video session is seekable only across what FFmpeg has produced. During steady playback the encoder runs several times faster than realtime, and the web client rebases the session for any seek more than 120 seconds ahead, so this is narrower than it sounds.
+
 The manifest handler rewrites playlist asset URLs so each `init.mp4` and `segment_N.m4s` URL includes the selected audio track and session query parameters. The rewritten `start` is the effective normalized start used by the cache key and FFmpeg, not an out-of-range value from the original request. This keeps HLS asset requests tied to the same session configuration that created the manifest.
 
 HLS responses use `Cache-Control: no-store`. Transcode output is session-scoped, temporary, and can vary by profile, audio track, start time, and playback context. Browser or proxy caching would make stale segment and playlist behavior harder to reason about.
@@ -366,7 +375,13 @@ FFmpeg stderr is not streamed to clients. The HLS runner keeps the last 20 stder
 
 ## Seeking and Resume Behavior
 
-The HLS manifest accepts a `start` query parameter. When `start` is greater than zero, FFmpeg starts from that source offset with `-ss`. A raw API start offset at or past the movie's duration — stale saved progress after a re-scan, or rounding at the very end — is clamped to five seconds before the end instead of failing (or to zero when the movie is shorter than five seconds). That effective start drives the singleflight/cache key, FFmpeg parameters, generated asset URLs, and subsequent segment lookup.
+The HLS manifest accepts a `start` query parameter. When `start` is greater than zero, FFmpeg starts from that source offset with `-ss`, placed before `-i`. Input seeking lands on the source keyframe at or before the requested time. When re-encoding, FFmpeg then discards frames up to the requested offset, so a transcode starts exactly where it was asked to; stream copy cannot discard frames, so a copy-video session really begins at that earlier keyframe — measured at 8.83 s early for a request at 600 s on one source. The output is rebased to start at zero either way by `-avoid_negative_ts make_zero`.
+
+For copy-video sessions Igloo measures where the media actually begins, with a bounded ffprobe keyframe lookup that runs alongside FFmpeg so it adds no startup latency, and publishes it as the `X-Igloo-Actual-Start` response header on the manifest. The client maps session time back to absolute movie time from that value, so the displayed clock and saved watch progress follow the picture rather than the request. The measurement is advisory: if it fails the header is omitted and the client falls back to the requested start.
+
+The manifest also carries `X-Igloo-Effective-Profile`, naming the profile FFmpeg actually ran. A `remux` request that fails the safety gate is still served from the `/hls/remux/` path, so without this the client cannot tell a stream copy from the full transcode it was silently given.
+
+Subtitles are rebased to match. The WebVTT endpoint stores cues with absolute source timestamps, and its `start` query parameter shifts them onto the requesting session's timeline when it is served. The cache stays keyed on movie and stream index alone, so shifting costs no extra extraction and no extra cache entries. A raw API start offset at or past the movie's duration — stale saved progress after a re-scan, or rounding at the very end — is clamped to five seconds before the end instead of failing (or to zero when the movie is shorter than five seconds). That effective start drives the singleflight/cache key, FFmpeg parameters, generated asset URLs, and subsequent segment lookup.
 
 When the web client knows the movie duration, it first clamps the requested absolute playback target to that duration. For HLS it then applies the 10-second resume rewind to the clamped target and uses the result consistently for the manifest URL, session-window key, local playback offset, and absolute-time mapping. Direct playback initialization uses the same clamped absolute target.
 
@@ -406,6 +421,8 @@ ffmpeg -v error -i <source> -map 0:<stream_index> -c:s webvtt -f webvtt pipe:1
 
 The output is returned directly from stdout and cached for one hour by movie ID and stream index. The request has a 60-second timeout so a difficult subtitle track cannot tie up a request indefinitely.
 
+The endpoint accepts an optional `start` query parameter giving the HLS session offset the cues will be played against. Cues are extracted and cached with absolute source timestamps; `start` shifts them at serve time so they line up with a rebased session's media timeline. Cues ending before the session start are dropped and a cue straddling it is clamped to zero. Direct play and sessions starting at zero omit the parameter and get the absolute cues unchanged.
+
 Bitmap subtitle codecs are rejected before FFmpeg runs:
 
 - `hdmv_pgs_subtitle`
@@ -421,7 +438,7 @@ After conversion, Igloo replaces escaped `\h` sequences with spaces. This handle
 For binary deployments:
 
 - `TRANSCODE_DIR` seeds the Settings transcode directory on first launch; after that, edit it from Settings.
-- HLS temp output is written below the Settings transcode directory.
+- HLS temp output is written below the Settings transcode directory. A session generates the whole remaining movie ahead of the playhead, so Igloo refuses to start one when that filesystem has less than 2 GB free, returning `503` rather than failing mid-stream. A filesystem it cannot measure is not treated as full.
 - `HLS_MAX_CPU_TRANSCODES` is read at startup and limits concurrent HLS transcode sessions; copy-video (remux) sessions are not counted. It is not stored in Settings.
 - `HLS_MAX_SESSIONS_PER_USER` is read at startup and limits cached plus in-flight personal HLS sessions per user; remux and transcode sessions are both counted. The default is 3. It is not stored in Settings.
 - Configured media directories should be readable by the Igloo process. Igloo does not need write access to media libraries.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2178,6 +2178,9 @@
             "$ref": "#/components/parameters/HLSFilenamePath"
           },
           {
+            "$ref": "#/components/parameters/RangeHeader"
+          },
+          {
             "$ref": "#/components/parameters/AudioTrackQuery"
           },
           {
@@ -2194,6 +2197,9 @@
           "200": {
             "$ref": "#/components/responses/HLSSegmentResponse"
           },
+          "206": {
+            "$ref": "#/components/responses/PartialHLSSegmentResponse"
+          },
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
@@ -2202,6 +2208,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          },
+          "416": {
+            "$ref": "#/components/responses/RangeNotSatisfiable"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -2987,11 +2996,17 @@
           },
           {
             "$ref": "#/components/parameters/HLSFilenamePath"
+          },
+          {
+            "$ref": "#/components/parameters/RangeHeader"
           }
         ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/HLSSegmentResponse"
+          },
+          "206": {
+            "$ref": "#/components/responses/PartialHLSSegmentResponse"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -3004,6 +3019,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          },
+          "416": {
+            "$ref": "#/components/responses/RangeNotSatisfiable"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -5444,6 +5462,37 @@
             "schema": {
               "type": "string",
               "const": "no-store"
+            }
+          }
+        },
+        "content": {
+          "video/mp4": {
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "PartialHLSSegmentResponse": {
+        "description": "Partial fragmented MP4 initialization file or media segment for a byte range.",
+        "headers": {
+          "Accept-Ranges": {
+            "schema": {
+              "type": "string",
+              "const": "bytes"
+            }
+          },
+          "Cache-Control": {
+            "schema": {
+              "type": "string",
+              "const": "no-store"
+            }
+          },
+          "Content-Range": {
+            "schema": {
+              "type": "string",
+              "example": "bytes 0-1048575/4194304"
             }
           }
         },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2151,6 +2151,9 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "503": {
             "$ref": "#/components/responses/ServiceUnavailable"
           }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2307,6 +2307,9 @@
           },
           {
             "$ref": "#/components/parameters/TrackIndexPath"
+          },
+          {
+            "$ref": "#/components/parameters/SubtitleStartQuery"
           }
         ],
         "responses": {
@@ -4566,6 +4569,16 @@
         "schema": {
           "type": "string"
         }
+      },
+      "SubtitleStartQuery": {
+        "name": "start",
+        "in": "query",
+        "required": false,
+        "description": "HLS session start in seconds. Cues are extracted with absolute source timestamps, so they are shifted by this value to match a rebased session's media timeline. Omit for direct play and sessions starting at zero.",
+        "schema": {
+          "type": "number",
+          "minimum": 0
+        }
       }
     },
     "requestBodies": {
@@ -5397,6 +5410,19 @@
             "schema": {
               "type": "string",
               "const": "no-store"
+            }
+          },
+          "X-Igloo-Effective-Profile": {
+            "description": "Profile FFmpeg actually ran. This differs from the requested profile in the path whenever the remux safety gate forces a transcode, so a `remux` request can be answered with a transcode profile here.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "X-Igloo-Actual-Start": {
+            "description": "Seconds into the movie where the session's media really begins. Stream copy cannot cut mid-GOP, so a copy-video session starts at the source keyframe at or before the requested start. Omitted when it has not been measured.",
+            "schema": {
+              "type": "number",
+              "minimum": 0
             }
           }
         },

--- a/docs/web-hls-playback-audit.md
+++ b/docs/web-hls-playback-audit.md
@@ -1364,8 +1364,9 @@ scan against the copy — expected, and confined to the copy.
 the §HLS Output Format and §Seeking and Resume Behavior sections stated the generated VOD
 playlist and `-ss` behaviour without noting that copy-video segment durations and counts
 are synthetic and diverge from the real output, or that `-ss` snaps backwards to a
-keyframe. Both now say what the code does, each cross-referencing the finding here. These
-notes should be revised again when H1/H2/H5 are fixed.
+keyframe. Both now say what the code does, each cross-referencing the finding here. Those
+notes were revised again alongside the H1/H2/H5 fixes (§23) and now describe the shipped
+behavior.
 
 ---
 

--- a/docs/web-hls-playback-audit.md
+++ b/docs/web-hls-playback-audit.md
@@ -42,10 +42,13 @@ absent features as broken ones.
    variant. There is no `#EXT-X-MEDIA:TYPE=AUDIO`, no `GROUP-ID`, no `CHANNELS`
    attribute. Changing audio track creates a new session rather than switching rendition.
 
-A consequence worth stating up front: because the delivered playlist is a plain VOD media
-playlist with `#EXT-X-ENDLIST`, **clients must not reload it** (RFC 8216 §6.2.1). Anything
-wrong in the first manifest a client receives stays wrong for the whole session. This is
-load-bearing for H1 and H2.
+A consequence worth stating up front: at the time of the audit the delivered playlist was
+always a plain VOD media playlist with `#EXT-X-ENDLIST`, so **clients must not reload it**
+(RFC 8216 §6.2.1) and anything wrong in the first manifest a client received stayed wrong
+for the whole session. This was load-bearing for H1 and H2. (Pre-remediation: since the
+H1/H2 fix in §23, a copy-video session still encoding serves an `EVENT` playlist that
+clients do reload; the VOD-with-`ENDLIST` description still holds for transcode sessions
+and finalized copy-video sessions.)
 
 ### 1.3 Method and evidence quality
 
@@ -125,9 +128,11 @@ to FFmpeg as I/O errors rather than hangs.
 5. **Process start.** `startHLSSession` (`:550`) creates `igloo-hls-*` under the transcode
    dir, acquires a CPU permit for non-copy sessions, and calls `RunHLS`
    (`ffmpeg_hls.go:333`) on `context.Background()` so FFmpeg outlives the request.
-6. **Playlist body.** `buildHLSPlaylistBody` (`hls_handler.go:144`) serves
-   `rewritePlaylistURLs(FinalPlaylist)` once FFmpeg has exited cleanly, otherwise
-   `generateVODPlaylist` (`hls_playlist.go:84`).
+6. **Playlist body.** At audit time, `buildHLSPlaylistBody` (`hls_handler.go:144`) served
+   `rewritePlaylistURLs(FinalPlaylist)` once FFmpeg had exited cleanly, otherwise
+   `generateVODPlaylist` (`hls_playlist.go:84`), for every session. (Pre-remediation: the
+   §23 fix keeps this shape for transcode sessions only; copy-video sessions now serve
+   FFmpeg's own playlist — `EVENT` while encoding, finalized VOD after a clean exit.)
 7. **Segments.** `HLSSegment` (`:102`) re-derives the cache key, checks ownership
    (`canAccessPersonalHLSSession`), refreshes the TTL, and calls `serveReadyHLSSegment`
    (`:156`), which polls `segmentComplete` (`:321`) every 25 ms up to 120 s.
@@ -1324,8 +1329,9 @@ cap and eviction behave correctly.
 
 ## 21. Diagnostic changes
 
-No production code was modified. `git status` shows only this new document plus the
-`docs/ffmpeg.md` corrections listed below.
+The audit experiments themselves modified no production code — their footprint was this
+document plus the `docs/ffmpeg.md` corrections listed below. The remediation that followed
+(§23) did change production code; those changes ship in the same branch as this document.
 
 **Repository side effects:**
 
@@ -1443,7 +1449,7 @@ P0 and P1 were fixed in the same session that produced this audit. P2 and P3 rem
 | **H1, H2** | Copy-video sessions now serve **FFmpeg's own playlist** (URLs rewritten, `EVENT` while encoding, finalized `VOD` after a clean exit) instead of a playlist synthesized from the movie duration. Transcodes keep the synthesized VOD playlist, which is exact for them. A manifest request for a copy-video session that has not published a segment yet waits, then returns `503` + `Retry-After: 1` — it never falls back to synthesizing. | `hls_handler.go` (`buildHLSPlaylistBody`, `readLiveHLSPlaylist`, `hasPlayableSegment`) |
 | **H3** | Two-part. The client no longer offers `remux` for video the server will refuse to copy — `getAvailableModes` now applies `isBrowserSafeH264` to the remux branch, closing the common 10-bit case at source. For the remaining dynamic-preflight case the manifest carries `X-Igloo-Effective-Profile`, read via hls.js `MANIFEST_LOADED` and shown in the player badge through `effectiveModeLabel`. | `lib/playback.ts`, `VideoPlayer.tsx`, `play.tsx`, `hls_handler.go`, `hls_session.go` |
 | **H4** | The WebVTT endpoint accepts `start` and shifts cue timings at serve time. The cache still holds one absolute-timestamp payload per (movie, stream), so there is no extra extraction and no cache multiplication. The client appends the session start to the subtitle URL. | `helpers/subtitle_shift.go`, `subtitle_handler.go`, `lib/movie-playback.ts` |
-| **H5** | Copy-video sessions with a non-zero start measure where the media really begins, with a bounded ffprobe keyframe lookup running alongside FFmpeg, published as `X-Igloo-Actual-Start`. Advisory: on failure the header is omitted. Transcodes are unaffected — input seek is frame-accurate when re-encoding. | `ffprobe_keyframes.go`, `hls_session.go`, `hls_handler.go` |
+| **H5** | Copy-video sessions with a non-zero start measure where the media really begins, with a bounded ffprobe keyframe lookup running alongside FFmpeg, published as `X-Igloo-Actual-Start`. Advisory: on failure the header is omitted. Transcodes are unaffected — the input seek still lands on a keyframe at or before the offset, but re-encoding discards the pre-roll frames, so the output timeline starts exactly where asked. | `ffprobe_keyframes.go`, `hls_session.go`, `hls_handler.go` |
 | **H8** | A session is refused with `503` when the transcode filesystem has under 2 GB free. A filesystem that cannot be measured is not treated as full. | `disk_space.go`, `hls_session.go` |
 | **H9** | The watch-room player is wired to `useHlsSessionRecovery`, `useHlsCapacityRetry` and `useHlsSessionKeepalive`, with a reload key that rebuilds the player; WebSocket sync then restores the host position. The keepalive also closes H17. | `WatchRoomPage.tsx`, `lib/watch-room.ts` |
 | **H11** | An unsupported browser now gets an explicit error instead of a blank player. | `VideoPlayer.tsx` |
@@ -1488,8 +1494,9 @@ Copy-video sessions are now seekable only across what FFmpeg has produced, becau
 playlist no longer claims segments that do not exist. In practice the encoder runs several
 times faster than realtime and any seek more than 120 s ahead already rebases the session
 (`shouldRebaseHlsMovieSession`), so the exposure is a forward seek inside the no-rebase
-window during a session's first seconds — where the previous behaviour was a blocking wait
-followed by a `503`.
+window during a session's first seconds — where the previous behaviour was a request that
+blocked while the segment was generated, ending in a `503` only if it never arrived within
+the deadline.
 
 ### 23.4 Still open
 

--- a/docs/web-hls-playback-audit.md
+++ b/docs/web-hls-playback-audit.md
@@ -1,0 +1,1501 @@
+# Igloo Web HLS Playback Audit
+
+Date: 2026-07-28. Branch `fix/hls-playback` at `31ea3b0b`.
+
+Companion to `docs/web-direct-playback-audit.md`, which explicitly excluded everything
+audited here (its §1, "What was not audited": HLS manifest and segment generation, FFmpeg
+encoding, hardware acceleration, HLS session cleanup, FFmpeg process management, and
+hls.js lifecycle/recovery internals).
+
+---
+
+## 1. Scope and methodology
+
+### 1.1 What was audited
+
+The HLS delivery path end to end: pipeline selection, FFmpeg argument construction,
+manifest and segment generation, segment readiness and seeking, session and process
+lifecycle, watch-room HLS, hardware-acceleration resolution, the hls.js integration, and
+the HLS-specific parts of the player UI.
+
+Direct playback appears only where it decides whether HLS is used, hands off to it, or
+reports the resulting mode. The direct-playback audit is treated as context, not as
+evidence; every HLS-relevant claim it makes was re-verified here (§6.4, §12.1).
+
+### 1.2 Three architectural facts that reshape this report
+
+These are not defects. They are stated once so later sections do not repeatedly report
+absent features as broken ones.
+
+1. **There is no ABR ladder and no master playlist.** Every session serves a single media
+   playlist; the requested profile is a path segment (`/hls/{profile}/playlist.m3u8`).
+   `#EXT-X-STREAM-INF`, `BANDWIDTH`, `AVERAGE-BANDWIDTH`, `CODECS`, `RESOLUTION`,
+   `FRAME-RATE` and `CLOSED-CAPTIONS` do not exist anywhere in the codebase. Quality is
+   chosen before playback and changing it creates a new session.
+2. **Subtitles are never part of HLS output.** `buildHLSArgs`
+   (`server/cmd/internal/ffmpeg/ffmpeg_hls.go:68`) emits no `-c:s`, no `-map 0:s`, no
+   `subtitles=`/`ass=` filter and no burn-in, under any profile. Subtitles are a sidecar
+   `<track>` element pointing at `/api/movies/{id}/subtitles/{i}/web.vtt`. There is no
+   `#EXT-X-MEDIA:TYPE=SUBTITLES` rendition, no `FORCED` attribute, and no subtitle group.
+   §10 therefore audits the sidecar path *as it interacts with HLS*.
+3. **Audio renditions do not exist either.** Exactly one audio stream is muxed into the
+   variant. There is no `#EXT-X-MEDIA:TYPE=AUDIO`, no `GROUP-ID`, no `CHANNELS`
+   attribute. Changing audio track creates a new session rather than switching rendition.
+
+A consequence worth stating up front: because the delivered playlist is a plain VOD media
+playlist with `#EXT-X-ENDLIST`, **clients must not reload it** (RFC 8216 §6.2.1). Anything
+wrong in the first manifest a client receives stays wrong for the whole session. This is
+load-bearing for H1 and H2.
+
+### 1.3 Method and evidence quality
+
+Findings are graded:
+
+- **Confirmed** — reproduced against this repository, with the artifact named.
+- **Likely** — follows necessarily from code that was read, but the user-visible
+  consequence was not itself reproduced.
+- **Hypothesis** — plausible, not established; the settling experiment is named.
+
+Empirical work used two arms, both isolated from the user's real data:
+
+- **Offline arm.** The embedded release binary
+  (`server/cmd/internal/ffmpeg/ffmpeg_linux_amd64`, `7.1.4-Jellyfin`) run directly against
+  library files with the argv reconstructed from `buildHLSArgs`, bounded by `-t`.
+- **Live arm.** A throwaway build (`go build -tags "externalbin sqlite_fts5"`) on port
+  8099 against a **copy** of `db/igloo.db` in the scratchpad, with `transcode_dir` pointed
+  at the scratchpad and a default admin seeded into the copy. The real database, the real
+  `./transcode`, and the user's account were never written.
+
+The reconstruction was validated rather than assumed: the argv captured from
+`/proc/<pid>/cmdline` of a live session is byte-identical to the offline argv apart from
+the `-t` bound (§7.1, artifact `C1-real-argv.txt`). Every offline measurement is therefore
+a statement about production behaviour.
+
+**Browsers were deliberately excluded from this audit's scope.** Findings whose
+user-visible consequence depends on hls.js or MSE internals are graded **Likely** and
+carry the exact browser experiment needed to settle them (§20.3).
+
+Note on binaries: dev and test builds use the `externalbin` tag and resolve `ffmpeg` from
+`PATH` (here Ubuntu 6.1.1); release builds embed Jellyfin 7.1.4. Offline work used the
+**embedded** binary, so it reflects release behaviour. Both builds were checked for every
+option the code emits and both support all of them (§8.1, artifact `A1-caps.txt`).
+
+### 1.4 Library composition (constrains what is reachable)
+
+Measured from the movie library:
+
+| Property | Count | Consequence |
+| --- | ---: | --- |
+| HEVC Main 10, `smpte2084` | 146 | Always full transcode + software tone-map |
+| HEVC Main 10, bt709/null | 94 | Always full transcode |
+| H.264 High 8-bit `yuv420p` | 159 | The only remux-eligible sources |
+| H.264 at ≥1440p | **0** | Remux is unreachable above 1080p |
+| AAC streams with profile `LC` | 200 | Safe to copy |
+| AAC streams with **no profile recorded** | 35 | Copied blind — could be HE-AAC (H15) |
+| AAC streams with ≥6 channels | 104 | The live `-c:a copy` multichannel case |
+
+The library is mounted over CIFS (Tailscale) at roughly 3.1 MB/s. Sustained read of a 4K
+source at 40 Mbps needs ~5 MB/s just to keep 1× realtime, so `-readrate 4` is never the
+binding constraint for 4K and the mount is. The mount is `soft`, so read timeouts surface
+to FFmpeg as I/O errors rather than hangs.
+
+---
+
+## 2. Current HLS architecture
+
+### 2.1 Lifecycle, personal playback
+
+1. **Mode selection is client-side.** `getAvailableModes` (`web/src/lib/playback.ts:195`)
+   filters `STREAM_MODES`; `resolvePlaybackSettings` (`:258`) picks the effective mode from
+   user preferences, the bandwidth-derived `recommendedProfileId`, and deep-link search
+   params. `resolveModeForAudioTrack` (`:231`) upgrades `direct` → `remux` whenever a
+   non-first audio track is selected. `isHlsPlayback = resolvedMode !== "direct"`
+   (`useMoviePlaybackData.ts:130`).
+2. **URL construction.** `buildMovieStreamUrl` (`web/src/lib/movie-playback.ts:169`) emits
+   `/api/movies/{id}/hls/{mode}/playlist.m3u8?playback_session=<uuid>&start=<sec>[&audio_track=<n>][&reload=<n>]`.
+   The UUID comes from `getOrCreateMovieHlsPlaybackSessionId` (`:52`), persisted per movie
+   in `sessionStorage`.
+3. **Manifest handler.** `HLSManifest` (`server/cmd/api/hls_handler.go:52`) →
+   `parseHLSParams` (`:258`) → `GetOrCreateHLSSession` (`hls_session.go:704`), singleflight
+   per key, personal-session reservation, then `createHLSSession` (`:929`).
+4. **Profile decision.** `createHLSSession` loads stream rows, picks `primaryVideoStream`,
+   resolves the `audio_track` ordinal to an absolute ffprobe index, computes
+   `requestedProfile` / `effectiveProfile` / `fallbackProfile`, and applies the remux gate
+   (§3).
+5. **Process start.** `startHLSSession` (`:550`) creates `igloo-hls-*` under the transcode
+   dir, acquires a CPU permit for non-copy sessions, and calls `RunHLS`
+   (`ffmpeg_hls.go:333`) on `context.Background()` so FFmpeg outlives the request.
+6. **Playlist body.** `buildHLSPlaylistBody` (`hls_handler.go:144`) serves
+   `rewritePlaylistURLs(FinalPlaylist)` once FFmpeg has exited cleanly, otherwise
+   `generateVODPlaylist` (`hls_playlist.go:84`).
+7. **Segments.** `HLSSegment` (`:102`) re-derives the cache key, checks ownership
+   (`canAccessPersonalHLSSession`), refreshes the TTL, and calls `serveReadyHLSSegment`
+   (`:156`), which polls `segmentComplete` (`:321`) every 25 ms up to 120 s.
+8. **Client playback.** `VideoPlayer.tsx:169-250` dynamically imports `hls.js/light`,
+   constructs `Hls`, calls `loadSource` then `attachMedia`.
+9. **Teardown.** `pagehide` and effect cleanup in `play.tsx:289-324` call
+   `stopMovieHlsPlaybackSession`; otherwise TTL expiry drives `OnEvicted` →
+   `cleanupHLSSession` (`hls_session.go:480`).
+
+### 2.2 Watch-room lifecycle (differences only)
+
+Cache key `room:<id>` (`RoomHLSSessionKey`, `hls_session.go:163`), 30-minute TTL, warmed at
+room creation from `startSec=0` with an empty `playbackSession`
+(`GetOrCreateRoomHLSSession:822`). `watchRoomStreamUrl` (`web/src/lib/watch-room.ts:4`)
+emits `/api/watch-rooms/{id}/hls/playlist.m3u8` — **no profile, no start, no
+playback_session, no reload**. All participants share one FFmpeg process and one temp dir;
+synchronisation is client-side over the WebSocket hub.
+
+### 2.3 Component inventory
+
+| Layer | Location |
+| --- | --- |
+| Routes | `server/cmd/api/routes.go:172-177` (personal), `:219-222` (room) |
+| Handlers | `hls_handler.go`, `watch_room_media_handler.go` |
+| Session manager | `hls_session.go` (cache, keys, admission, profile decision, lifecycle) |
+| Playlist builder | `hls_playlist.go` |
+| Remux safety | `hls_remux_safety.go`, `ffmpeg/remux_validator.go` |
+| Limiter | `hls_limiter.go` |
+| Arg builder / runner | `ffmpeg/ffmpeg_hls.go` |
+| Capability probes | `ffmpeg/capabilities.go` |
+| FFprobe parse / persist | `ffprobe/ffprobe_metadata.go`, `movies_scanner.go:917` |
+| Player | `web/src/components/playback/VideoPlayer.tsx` (sole hls.js site) |
+| Orchestration | `web/src/routes/_auth/movies/$id/play.tsx` |
+| HLS hooks | `useHlsCapacityRetry.ts`, `useHlsSessionKeepalive.ts`, `useHlsSessionRecovery.ts` |
+| Watch room | `WatchRoomPage.tsx`, `useWatchRoomConnection.ts` |
+
+---
+
+## 3. HLS pipeline-selection assessment
+
+### 3.1 The available pipelines
+
+| Pipeline | Reached when | Args |
+| --- | --- | --- |
+| Copy video + copy audio | `remux` requested, gate passes, audio codec is `aac` | `-c:v copy -c:a copy` |
+| Copy video + transcode audio | `remux`, gate passes, audio ≠ `aac` | `-c:v copy -c:a aac -ac 2 -b:a 320k` |
+| Transcode video + copy audio | any non-remux profile **and** audio codec is `aac` | encoder + `-c:a copy` |
+| Full transcode | any non-remux profile and audio ≠ `aac` | encoder + `-c:a aac -ac 2 -b:a 320k` |
+| Subtitle conversion | never in HLS (sidecar endpoint) | — |
+| Subtitle burn-in | not implemented | — |
+| Rejection | no playable video stream (`createHLSSession:946`) | — |
+
+All five reachable combinations are genuinely distinct: `startHLSSession:557` sets
+`copyAudio = audioCodec == "aac"` independently of the video decision, and
+`buildHLSArgs:202` honours `CopyAudio` in every branch. So "HLS" spans everything from a
+pure stream copy to a full re-encode, and a transcode profile on an AAC source correctly
+copies the audio rather than needlessly re-encoding it.
+
+### 3.2 What the decision considers
+
+Considered: container (client-side only, for `direct`), video codec name, codec profile
+string, bit depth, pixel format, source height (fallback selection), HDR `color_transfer`,
+audio codec name, selected tracks, user-selected quality, encoder availability and
+hardware runtime probes, CPU permit availability, per-user session capacity.
+
+**Not considered:** video level, chroma subsampling other than via the pixel-format
+allowlist, frame rate (except for GOP sizing), audio profile (§9.1), channel count for the
+copy decision (§9.1), sample rate, subtitle codec (irrelevant — no subtitles in HLS), and
+native-HLS support (the server has no idea whether the client is Safari).
+
+### 3.3 The remux gate
+
+Two layers, both in `createHLSSession:977-1016`:
+
+- **Static:** `isBrowserSafeH264RemuxCandidate` (`hls_session.go:88`) rejects non-H.264
+  codec names, `bit_depth > 8`, pixel formats outside the allowlist
+  `{yuv420p, yuvj420p, nv12, nv21}`, and profile strings containing `10`/`4:2:2`/`422`/
+  `4:4:4`/`444`. Rejection caches an unsafe verdict for 24 h and falls back.
+- **Dynamic:** on cache miss, FFmpeg is started in remux mode, `waitForRemuxPreflight`
+  blocks for `init.mp4` plus 4 complete segments (≤30 s), and `ValidateRemuxSafety` parses
+  the fMP4 boxes asserting sync samples begin with IDR NALs. Failure to *validate* caches
+  unsafe; failure to *wait* falls back without caching, correctly treating timeouts as
+  transient.
+
+This is a well-designed gate and it works. Verified: `remux safety validated … checked_segments=4
+checked_sync_samples=4` for movie 57, and independently every segment of the offline
+remux output begins with a keyframe (§5.4).
+
+### 3.4 The unnecessary-transcode question
+
+- **Video transcoded when only audio is incompatible?** No. Remux copies video and
+  transcodes only audio.
+- **Audio transcoded unnecessarily?** Yes, in one case: any non-AAC audio is re-encoded
+  even when the container/codec pair would be fine, and it is always downmixed to stereo
+  (§9.2).
+- **Subtitles forcing video transcode?** No — subtitles never touch the HLS pipeline.
+- **Requested remux silently becoming a full transcode?** **Yes, and invisibly** — see H3.
+
+### 3.5 H3 — the effective profile is never exposed (Confirmed, High)
+
+`effectiveProfile` exists only as a local in `createHLSSession`, a field on the internal
+`hlsSessionStartParams` (`hls_session.go:70`), and a structured-log key. It is **not** a
+field on `HLSSession`, **not** in `docs/openapi.json`, and **not referenced anywhere in
+`web/src`**.
+
+Reproduced against the live sandbox (artifact `C6-headers.txt`, `C6-hevc-remux.m3u8`):
+
+```
+GET /api/movies/120/hls/remux/playlist.m3u8?...   → HTTP 200
+Cache-Control: no-store
+Content-Type: application/vnd.apple.mpegurl
+(no header naming the effective profile)
+
+first segment URL: /api/movies/120/hls/remux/segment_0.m4s?...
+
+server log: level=WARN msg="remux safety fallback engaged" movie_id=120
+            requested_profile=remux effective_profile=2160p_16mbps
+            validation_result=unsafe
+            fallback_reason="requested remux is not supported for codec \"hevc\""
+```
+
+The client asked for a cheap stream copy and received a **2160p 16 Mbps libx264
+transcode**. The response is a 200, the asset URLs still say `/hls/remux/`, and the player
+badge — `modeLabel`, rendered at `MoviePlayerControls.tsx:143-146` from the *client-side*
+resolved mode — still reads "Remux". The only observable difference is
+`#EXT-X-TARGETDURATION:8` instead of `30`, which no client interprets as a mode signal.
+
+This is precisely the mode-reporting defect that finding D9 of the direct-playback audit
+fixed for direct play, left unfixed on the HLS side.
+
+Severity is amplified by resource cost: on this machine a 1040p→720p CPU transcode ran at
+4.38× realtime (§8.3); a 2160p→2160p 16 Mbps transcode over a 3.1 MB/s mount will not
+sustain realtime, so the user experiences unexplained stalling on a mode they believed was
+a stream copy.
+
+### 3.6 Repeated recreation of a failing pipeline
+
+The cache key uses the **requested** profile (`HLSSessionKey`, `hls_session.go:157`), so a
+fallen-back session is cached under `…:remux:…` and reused — the fallback is computed once
+per session, not per request. The 24 h `remuxSafetyVerdict` cache prevents re-running
+preflight. Static rejections cache immediately. No recreation loop was found at the server
+layer.
+
+The client layer is different: see H2, where a 404 tail drives
+`useHlsSessionRecovery` through three recreate-and-fail cycles.
+
+---
+
+## 4. Frontend and hls.js assessment
+
+`hls.js` `^1.6.16`, imported as `hls.js/light` via a dynamic `import()`
+(`VideoPlayer.tsx:44`). One instantiation site in the whole application.
+
+### 4.1 Initialization and lifecycle
+
+Correct: dynamic import keeps hls.js out of the main bundle; `xhrSetup` sets
+`withCredentials`; `backBufferLength: 120` bounds memory; the `cancelled` flag plus
+`disposeHls` closure handles React 19 Strict Mode double-invocation; `destroy()` runs on
+unmount, source change, and `startSec` change. `startSec` is deliberately in the dependency
+array so a resume-target change rebuilds the instance (locked by the test
+`"rebuilds the hls.js instance when startSec changes on the same URL"`,
+`src/test/playback/video-player.test.tsx:232`).
+
+`loadSource()` is called before `attachMedia()` (`:199-200`), the inverse of the hls.js
+documentation example. Both orders are supported; no defect.
+
+**H10 (Likely, Low) — a late cleanup can null a live instance ref.** `hlsRef.current` is
+assigned unconditionally at `:193` and set to `null` unconditionally at `:196`. If
+instance A's cleanup runs after instance B was created (possible when the dynamic import
+of the second effect run resolves before the first run's cleanup), the ref holding B is
+nulled. The ref is only read by the start-seek effect (`:273`, `if (hlsRef.current) return`),
+so the observable consequence is that the native seek path can compete with hls.js's
+`startPosition`. Narrow, but the fix is a one-line identity check.
+
+**H11 (Confirmed, Medium) — unsupported browsers get a blank player.** At `:180`,
+`if (cancelled || !Hls.isSupported()) return;` exits silently: no `onError`, no message,
+no fallback. The user sees a video element that never loads. Every browser that supports
+neither MSE nor native HLS lands here.
+
+### 4.2 Native HLS
+
+`supportsNativeHLS` (`web/src/lib/playback.ts:42`) is a module-load IIFE testing
+`canPlayType` for `application/vnd.apple.mpegurl` and `application/x-mpegURL`. When true,
+HLS is handed to the native element via `video.src` (`VideoPlayer.tsx:256-266`).
+
+Consequences not currently handled:
+
+- On native HLS (Safari, iOS) **none of the hls.js error routing exists**. There is no
+  session-lost detection, no 503 capacity handling, no `recoverMediaError`. A 404 tail
+  (H2) surfaces as a generic media error.
+- The server never learns the client is native, so profile decisions cannot account for
+  Safari's codec support (e.g. HEVC in fMP4, which Safari could play directly and which
+  Igloo always transcodes).
+
+Both are graded **Confirmed** as code facts; their user impact on Safari was not exercised.
+
+### 4.3 State synchronisation
+
+The UI reflects the **requested** mode only. `modeLabel` derives from the client's resolved
+mode; nothing consumes an effective profile because none is published (H3). Quality level,
+available levels, current audio rendition and current subtitle rendition are not read from
+hls.js at all — there is nothing to read, since the manifest is single-variant with no
+renditions (§1.2). Buffering state comes from media-element events
+(`VideoPlayer.tsx:72-99`), not from hls.js. Capacity state is surfaced (`play.tsx:701-715`
+with a polite `LiveAnnouncer`). Recovery attempts are not surfaced at all.
+
+No cross-movie state leakage was found: `sessionWindowKey`
+(`useMoviePlaybackData.ts:171`) includes movie, mode, audio track, playback-session UUID
+and floored start, and all three HLS hooks reset their counters when it changes.
+
+### 4.4 Error handling
+
+`VideoPlayer.tsx:209-238` routes: `FRAG_LOAD_ERROR` + HTTP 404 → `onSessionLost`;
+fatal `MANIFEST_LOAD_ERROR`/`LEVEL_LOAD_ERROR` + HTTP 503 → `onCapacityBusy` with
+`Retry-After`; fatal media error → one `recoverMediaError()`; everything else fatal →
+`onError`. Non-fatal errors are left to hls.js. Budgets live in the hooks:
+`HLS_SESSION_LOST_MAX_ATTEMPTS = 3` with a 2 s minimum interval,
+`HLS_CAPACITY_RETRY_MAX_ATTEMPTS = 6`.
+
+This is a sound structure and it matches hls.js 1.6 (no deprecated patterns;
+`recoverMediaError` and `ErrorDetails` are current). Three gaps:
+
+- **Error types are string-cast rather than taken from the enum** (`:48-49`,
+  `const HLS_NETWORK_ERROR = "networkError" as ErrorData["type"]`). This compiles even if
+  the upstream enum values change, and would silently stop matching. Use
+  `Hls.ErrorTypes.NETWORK_ERROR`, which is already available in the closure.
+- **`recoverMediaError` is budgeted per instance, not per window**, and there is no
+  `swapAudioCodec` second-stage recovery. One attempt then a terminal error.
+- **A 404 on a *segment* is unconditionally interpreted as "session lost"** even when it
+  actually means "this segment never existed" (H2). The client's response — recreate the
+  session — cannot help, and burns the budget.
+
+### 4.5 Keepalive and recovery
+
+`useHlsSessionKeepalive` refetches the manifest every 120 s while playback is ready
+(server idle TTL is 300 s), swallowing errors. Because the keepalive hits `HLSManifest`,
+which calls `GetOrCreateHLSSession`, it does not merely refresh a TTL — **it will recreate
+an evicted session**, which is a deliberate and effective transparent-recovery mechanism.
+
+`useHlsSessionRecovery` rate-limits to one attempt per 2 s and 3 per window, calling
+`navigateToPlaybackPosition(t, { forceReload: true })`.
+
+---
+
+## 5. Manifest and rendition assessment
+
+### 5.1 What is emitted
+
+`generateVODPlaylist` (`hls_playlist.go:84`) synthesises, before FFmpeg has produced
+anything:
+
+```
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:8   (30 when session.CopyVideo)
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-MAP:URI="<base>init.mp4<query>"
+#EXTINF:4.000000,
+<base>segment_0.m4s<query>
+… ceil(duration/4) entries, all 4.000000 except a clamped last one …
+#EXT-X-ENDLIST
+```
+
+Tag correctness: `#EXTM3U`, `#EXT-X-VERSION:7` (appropriate for fMP4 + `EXT-X-MAP`),
+`MEDIA-SEQUENCE`, `PLAYLIST-TYPE`, `EXT-X-MAP` and `ENDLIST` are all well-formed and
+correctly ordered. `#EXT-X-INDEPENDENT-SEGMENTS` is absent (see §5.5). No master-playlist
+tags exist (§1.2).
+
+### 5.2 H1 — synthesized segment durations are fiction for copy-video (Confirmed, Critical)
+
+The playlist is generated from movie duration alone. For transcodes this is exact, because
+`-force_key_frames:0 expr:gte(t,n_forced*4)` pins every keyframe to a 4 s boundary. For
+**copy-video** the output can only split at *source* keyframes, which are wherever the
+original encoder put them.
+
+Measured with the production argv (artifacts `B1-extinf-drift.tsv`,
+`B2-extinf-drift.tsv`):
+
+| Source | Mode | Content | Real segs | Advertised | Mean `EXTINF` | Min–Max | Cumulative drift |
+| --- | --- | ---: | ---: | ---: | ---: | --- | ---: |
+| Movie 57 (h264 1040p 23.976) | remux | 600 s | 94 | 150 | **5.403 s** | 1.001–10.010 | **+131.9 s** |
+| Movie 191 (h264 768p 29.97) | remux | 300 s | 74 | 75 | 4.055 s | 0.834–8.976 | ≈ 0 |
+| Movie 131 (h264 752p) | remux | 120 s | **13** | 30 | **9.240 s** | 1.168–12.429 | large |
+| Movie 57 | 720p transcode | 300 s | **75** | 75 | **4.000 s** | 3.962–4.004 | **+0.008 s** |
+
+The transcode row is the control: the mechanism is sound, and the defect is **specific to
+copy-video**. Its magnitude is entirely a property of the source's keyframe spacing, so it
+ranges from harmless (movie 191) to severe (movie 131, where 13 real segments are
+advertised as 30).
+
+One deviation to record: the transcode control was run with `-c:a aac -ac 2 -b:a 320k`,
+whereas the server would emit `-c:a copy` for this source (its audio is AAC, §3.1). HLS
+segment boundaries are chosen at video keyframes, so the audio codec does not affect the
+durations being measured; the remux rows, which carry the finding, used the argv verified
+identical to production (§7.1).
+
+Two consequences follow, and they differ in how certain they are:
+
+- **Playlist timing is objectively wrong** (Confirmed). At segment 10 of movie 57 the
+  playlist says content starts at 40.000 s; the fragment's own timestamp says 70.070 s
+  (§5.4). A player that trusts `EXTINF` maps seek targets to the wrong segment.
+- **Whether the *user* mis-seeks depends on hls.js** (Likely, not Confirmed). hls.js
+  re-derives fragment start times from parsed fragment PTS after loading, so it may
+  self-correct. Settling this needs the browser experiment in §20.3-B6. Note the
+  correction cannot help the *first* seek into an unloaded region, which is precisely the
+  common case.
+
+### 5.3 H2 — the playlist advertises segments that will never exist (Confirmed, Critical)
+
+Because the segment *count* is `ceil(duration/4)` while real segments are longer, FFmpeg
+produces fewer files than the playlist lists. For movie 57 the live server emitted a
+playlist with **1458** `#EXTINF` entries (artifact `C1-playlist-remux.m3u8`); at the
+measured 5.403 s mean, FFmpeg will produce roughly **1079** — about 379 phantom entries.
+
+Reproduced decisively on a short tail session (artifact `C5-tail.m3u8`):
+
+```
+GET /api/movies/57/hls/remux/playlist.m3u8?start=5800  → 8 #EXTINF entries
+server log: msg="hls session finished" movie_id=57 elapsed=15s   (clean exit)
+segments actually written to the temp dir: 1
+GET segment_0 → 200
+GET segment_1..7 → 404 404 404 404 404 404 404
+```
+
+FFmpeg's own playlist for that session contains exactly 1 `#EXTINF`. The server advertised
+eight 4 s segments where the source's keyframe spacing produced a single 28 s one.
+
+The 404 comes from `serveReadyHLSSegment` (`hls_handler.go:176-183`): the session has
+exited cleanly and the file does not exist, so it returns `404 segment does not exist`.
+
+**The client turns this into a recovery loop rather than a clean end.**
+`VideoPlayer.tsx:210-217` classifies any `FRAG_LOAD_ERROR` with `response.code === 404` as
+session-lost, so `useHlsSessionRecovery` recreates the session up to three times; each
+recreation produces the same too-long playlist and the same 404. The user sees playback
+fail near the end of the movie with a session error.
+
+Crucially, **the corrected playlist never reaches the client.** Once FFmpeg exits cleanly
+the server does serve `FinalPlaylist` with true durations (`buildHLSPlaylistBody:149`) —
+but the client is holding a `VOD` + `ENDLIST` playlist, which RFC 8216 forbids reloading,
+and hls.js does not reload it. The keepalive refetch (`useHlsSessionKeepalive`) is a bare
+`fetch()` whose body is discarded. So the accurate playlist is generated and thrown away.
+
+### 5.4 Fragment-level correctness (verified good)
+
+Per-fragment probing of the offline remux output (embedded 7.1.4 binary):
+
+| Segment | First video PTS | Keyframe? | Playlist cumulative start |
+| --- | ---: | --- | ---: |
+| 0 | 0.083 | yes | 0.000 |
+| 1 | 8.550 | yes | 8.467 |
+| 2 | 14.556 | yes | 14.473 |
+| 3 | 24.566 | yes | 24.483 |
+| 10 | 70.070 | yes | 69.987 |
+
+Timestamps are continuous and monotonic across fragments, and **every segment begins on a
+keyframe** — `movflags=+frag_discont` does not reset `baseMediaDecodeTime`. The output is
+structurally sound; the defect is in the *description* of it, not the media.
+
+(An earlier "non-monotonically increasing dts" signal was an artifact of naively
+concatenating `init.mp4` with all segments and remuxing; it appears identically in the
+known-good transcode output and is not a defect.)
+
+### 5.5 Minor manifest gaps
+
+- **`#EXT-X-INDEPENDENT-SEGMENTS` is not emitted** even though it is true for transcodes
+  (every segment starts on a forced IDR) and verified true for the copy-video output
+  above. Declaring it lets players start decoding at any segment without extra probing.
+- **`#EXT-X-TARGETDURATION:30` for copy-video is a blunt instrument.** It is legal (it
+  must be ≥ the largest rounded `EXTINF`, and the largest measured was 12.429 s), but it
+  is a workaround for H1 rather than a fix, and it inflates the buffering hints players
+  derive from it.
+- **No `#EXT-X-START`**, so a rebased session gives players no hint that it represents a
+  window rather than the whole asset.
+
+### 5.6 Renditions
+
+Not applicable — no audio, subtitle, or video renditions exist (§1.2). The audit brief's
+rendition checklist (`GROUP-ID`, `DEFAULT`, `AUTOSELECT`, `FORCED`, `CHANNELS`,
+duplicate-language handling, commentary and audio-description tracks) describes a feature
+set Igloo has not implemented. Whether it *should* is addressed in §18.2.
+
+---
+
+## 6. FFprobe metadata assessment
+
+### 6.1 What is captured
+
+`ffprobe -v quiet -print_format json -show_streams -show_format -show_chapters`
+(`ffprobe_metadata.go:186`), parsed into `Stream` (`:21`) with `index, codec_name, profile,
+level, width, height, coded_*, display_aspect_ratio, avg_frame_rate, r_frame_rate,
+bits_per_raw_sample, pix_fmt, color_range, color_transfer, color_primaries, color_space,
+channels, channel_layout, sample_rate, bit_rate`, plus full `StreamDisposition` (`:51`:
+`attached_pic, default, forced, comment, dub, original, hearing_impaired, visual_impaired`)
+and tag-key normalisation (`StreamTags.UnmarshalJSON:70`, lowercasing, separator stripping,
+`lang` → `language`).
+
+Persisted by `processMovieStreams` (`movies_scanner.go:917`), which deletes and re-inserts
+all stream rows and skips `attached_pic` and cover-art video codecs.
+
+### 6.2 Sufficiency for HLS
+
+Sufficient for what the HLS path actually does: pipeline choice reads `codec`,
+`codec_profile`, `bit_depth`, `pixel_format`, `color_transfer`, `height`, `frame_rate`;
+mapping reads `stream_index`; audio copy reads `codec`.
+
+Not captured or not used, and needed for improvements recommended later: **`codec_level`
+is stored but never read by the HLS path** (it is used only for the direct-play
+`canPlayType` string), and audio `profile` is stored but not consulted for the copy
+decision (§9.1). There is no stored keyframe index, which is the root enabler for fixing
+H1/H2 properly (§18.1).
+
+### 6.3 H14 — stream ordinals are not stable across re-scans (Confirmed, Medium)
+
+`audio_track` is an ordinal into `stream_index`-ordered audio rows, resolved server-side
+(`createHLSSession:966-968`). `processMovieStreams` deletes and re-inserts every stream row
+on each scan, and there is no `UNIQUE(movie_id, stream_index)` constraint on
+`video_streams`, `audio_streams`, or `subtitles` (only non-unique indices). A re-scan that
+changes stream order silently repoints:
+
+- a user's saved `preferred_audio_language`-derived selection,
+- a deep link carrying `audio_track=N`,
+- **a watch room's stored `audio_track`**, which is validated once at creation and never
+  re-validated.
+
+The direct-playback audit flagged this as a structural risk (its §6.2); it is confirmed
+here as unmitigated on the HLS path. Note the ordinal is *also* the subtitle track index in
+`/subtitles/{trackIndex}/web.vtt`, so the same drift silently changes which subtitle plays.
+
+### 6.4 Verification of direct-audit claims
+
+- "the `audio_track` API parameter is an ordinal … resolved to the absolute ffprobe index
+  server-side" — **verified**: the live argv is `-map 0:0 -map 0:1` with indices taken from
+  `stream_index`, not from ordinal position (§7.1).
+- "`primaryVideoStream` is used by both watch-room creation and `createHLSSession`" —
+  **verified** (`hls_session.go:945`, `watch_room_handler.go:413-438`).
+- `hlsSegmentPoll = 25ms` and `hlsRemuxPreflightPoll = 250ms` split — **verified**
+  (`hls_handler.go:26`, `:31`).
+
+---
+
+## 7. FFmpeg stream-mapping and command assessment
+
+### 7.1 Fidelity of the reconstruction
+
+Live capture from `/proc/<pid>/cmdline` for `GET /api/movies/57/hls/remux/playlist.m3u8`
+(artifact `C1-real-argv.txt`):
+
+```
+/usr/bin/ffmpeg -y -fflags +genpts -analyzeduration 5000000 -probesize 5000000
+  -readrate 4 -readrate_initial_burst 60
+  -i /home/…/The.Santa.Clause.1994.mp4
+  -map 0:0 -map 0:1 -map_metadata -1 -map_chapters -1
+  -c:v copy -c:a copy
+  -avoid_negative_ts make_zero -max_muxing_queue_size 1024
+  -f hls -hls_segment_type fmp4 -hls_segment_options movflags=+frag_discont
+  -hls_playlist_type event -hls_list_size 0 -hls_time 4
+  -hls_segment_filename …/igloo-hls-1183807021/segment_%d.m4s
+  -hls_fmp4_init_filename init.mp4 …/igloo-hls-1183807021/playlist.m3u8
+```
+
+### 7.2 Stream mapping — correct
+
+Explicit `-map 0:<absolute ffprobe index>` for video and, when present, audio. No reliance
+on FFmpeg's default stream selection. Attached pictures and cover-art codecs are excluded
+at scan time and again by `primaryVideoStream` (`movie_media.go:42`). Video-only movies
+omit the audio map and all audio options (`buildHLSArgs:156-159, 201-207`) — correct, and
+covered by `ffmpeg_hls_args_additional_test.go`. Ordinal→absolute translation is validated
+and range-checked (`createHLSSession:963`).
+
+`-map_metadata -1` and `-map_chapters -1` intentionally drop language tags, titles and
+dispositions. That is harmless *given* §1.2 — with one stream of each type and no
+renditions, there is no place for that metadata to be expressed. It becomes a defect the
+moment renditions are introduced.
+
+### 7.3 Remux/transcode arguments — correct, with one omission
+
+`-c:v copy` / `-c:a copy` are gated correctly; segment format is fMP4 throughout, which
+suits both copied H.264 and encoded H.264; timestamps are normalised with
+`-avoid_negative_ts make_zero` and `-fflags +genpts`; the output filename matches the
+declared format. No bitstream filter is needed for H.264-in-fMP4 from an MP4/MKV source
+(the copy path was verified to produce `avc1` with valid extradata, §5.4).
+
+**Omission: no `-hls_flags temp_file`.** Segments are written directly to their final
+names, so a partially written `segment_N.m4s` exists on disk under the name a client will
+request. The server compensates behaviourally (`segmentComplete` treats N as complete only
+once N+1 exists, or once FFmpeg has exited) rather than atomically. The compensation is
+sound for the normal path, but it is the reason `init.mp4` needs its own special-casing
+and it makes the readiness rule load-bearing. `temp_file` would make the invariant
+structural.
+
+### 7.4 H7 — the audio track is logged as a pointer (Confirmed, Low)
+
+`hls_session.go:611` logs `"audio_track", params.AudioTrack` where the field is `*int`.
+Live output:
+
+```
+msg="hls session starting" movie_id=57 … audio_track=0x21c92170d160 …
+```
+
+Every HLS session log line is unusable for diagnosing track selection — the single most
+likely thing to need diagnosing. Fix is `*params.AudioTrack` with a nil guard.
+
+---
+
+## 8. Video decoding and encoding assessment
+
+### 8.1 Build capability (both binaries verified)
+
+Artifact `A1-caps.txt`. System 6.1.1 (dev/test) and embedded 7.1.4-Jellyfin (release) both
+expose `-hls_segment_options`, `mov`'s `frag_discont`, `-readrate`,
+`-readrate_initial_burst`, `libx264`, `h264_nvenc`, `h264_qsv`, `h264_vaapi`, and the
+`cuda`/`qsv`/`vaapi` hwaccels. No option Igloo emits is missing from either build, so the
+`SupportsCLIOption` gating is currently always-true on this host and the capability
+plumbing is untested in its negative direction.
+
+### 8.2 Decoding
+
+Software decode by default. `-hwaccel cuda` is added for NVIDIA only when the `cuda`
+hwaccel is probed, deliberately without `-hwaccel_output_format` so frames land in system
+memory and the software filter chains keep working. QSV decode is deliberately disabled.
+Apple gets `-hwaccel videotoolbox`. Corrupt-frame handling, interlaced content, rotation
+and VFR are not specially handled anywhere: there is no `yadif`/`bwdif` deinterlacer, no
+`-noautorotate`/rotation filter, and no `-vsync`/`fps` normalisation. Interlaced or rotated
+sources will transcode to interlaced or mis-rotated output.
+
+### 8.3 Encoding
+
+`-profile:v high`, profile bitrate as `-b:v`/`-maxrate` with a 2× `-bufsize`, `scale=-2:H`,
+explicit bt709 tagging on both the stream and the filter chain tail, `-pix_fmt yuv420p`
+except for QSV and CUDA filter paths, GOP `ceil(4 × fps)`, and
+`-force_key_frames:0 expr:gte(t,n_forced*4)` for every encoder with `-sc_threshold:v:0 0`
+for libx264.
+
+Verified working: the transcode control run produced 75 segments of mean 4.000 s
+(3.962–4.004), i.e. the keyframe pinning does exactly what it claims (§5.2).
+
+Concerns:
+
+- **No `-level`.** `-profile:v high` is set but the level is left to the encoder. A 2160p
+  16 Mbps libx264 output will land at level 5.1+; browsers generally cope, but the stored
+  `codec_level` is available and unused, and level is what `canPlayType` strings key on.
+- **CBR-style rate control** (`-b:v` == `-maxrate`) with no `-crf` means easy content is
+  encoded at full profile bitrate. On a bandwidth-constrained home server this wastes both
+  CPU and disk.
+- **Capacity headroom is thin.** 1040p→720p ran at 4.38× realtime on this box.
+  `HLS_MAX_CPU_TRANSCODES` here is 5 (from `.env`); five concurrent sessions of that shape
+  would land near 0.9× each — below realtime. The default (`NumCPU()/4`) is more
+  conservative than the configured value.
+
+Output is browser-compatible in shape (High profile, `yuv420p`, AAC-LC), and the encoded
+path is the *safer* of the two — the copy path is where the defects are.
+
+---
+
+## 9. Audio transcoding assessment
+
+### 9.1 The copy decision
+
+`startHLSSession:557`: `copyAudio = audioCodec == "aac"`. That is the entire test — no
+profile, channel-count, or sample-rate check.
+
+- **AAC-LC 5.1 copied into fMP4 is well-formed** (Confirmed). Probing the copied output:
+  `codec_name=aac profile=LC codec_tag_string=mp4a channels=6 channel_layout=5.1
+  sample_rate=48000`, extradata present, audio-only decode clean (artifact
+  `B4-aac51-131`). Whether every browser's MSE accepts 6-channel AAC-LC was not tested
+  (browser scope excluded); Chrome and Firefox decode and downmix it in practice. Graded
+  **Likely fine**, with the settling test in §20.3.
+- **HE-AAC / xHE-AAC would be copied blindly.** `profile` is stored but not consulted. 200
+  AAC streams in this library are known `LC`, but **35 have no profile recorded at all**
+  and are copied on the strength of the codec name alone. HE-AAC v2 in fMP4 fails on some
+  browsers and xHE-AAC on most, so those 35 are unverified rather than known-safe. Graded
+  **Hypothesis** — settling it means probing those 35 streams' actual profiles, which is a
+  one-query change to the scanner's stored metadata.
+
+### 9.2 The transcode path
+
+Everything non-AAC becomes `-c:a aac -ac 2 -b:a 320k`.
+
+- **Deterministic downmix**: always stereo, so multichannel sources are handled uniformly
+  and no client can fail on an unsupported layout. Reasonable default.
+- **320 kbps for stereo AAC is above the useful ceiling** of FFmpeg's native encoder; the
+  bits are largely wasted. 160–192 kbps would be transparent.
+- **No dialogue normalisation and no loudness handling.** AC-3/E-AC-3 carry `dialnorm`
+  metadata that the native AAC encoder does not apply, so a downmixed AC-3 track can be
+  noticeably quieter or louder than the source. Not tested; graded **Hypothesis**.
+- **Atmos/TrueHD**: `truehd` and `dts` sources are transcoded (correct — no browser
+  decodes them). The object metadata is necessarily lost; nothing in the code claims
+  otherwise.
+- **No `-af aresample=async` or explicit sample-rate normalisation**, so an odd source rate
+  passes through to the encoder.
+
+The selected track always reaches the output: mapping is explicit and absolute (§7.2).
+
+---
+
+## 10. Subtitle-processing assessment
+
+Subtitles are entirely outside the HLS pipeline (§1.2). Extraction is
+`ffmpeg -v error -i <src> -map 0:<abs index> -c:s webvtt -f webvtt pipe:1`
+(`ffmpeg_subtitles.go:13`), served by `SubtitleWebVTT` (`subtitle_handler.go:35`) with a
+1-hour cache, singleflight collapsing, a 60 s timeout, `\h` → space normalisation, and
+explicit 415 rejection of `hdmv_pgs_subtitle`, `dvd_subtitle`, `dvb_subtitle`.
+
+Classification is correct: text subtitles are convertible, bitmap subtitles are rejected
+with a clear status rather than exposed as broken text, and disabled subtitles cost
+nothing. Burn-in does not exist, so **no subtitle selection can ever cause a video
+transcode** — a genuine strength of this design.
+
+### 10.1 H4 — subtitles desync on every rebased HLS session (Likely, High)
+
+The WebVTT is extracted from the source with **absolute** timestamps: a cue at 40 minutes
+carries `00:40:00.000`. The HLS session, however, is **rebased**: `-ss <start>` plus
+`-avoid_negative_ts make_zero` produces output whose first PTS is ~0 (measured: 0.083 s for
+`-ss 600`, §11.2). The client attaches the track raw:
+
+```ts
+// VideoPlayer.tsx:311-317
+const track = document.createElement("track");
+track.src = sub.url;          // absolute-timestamp WebVTT
+video.appendChild(track);
+track.track.mode = "showing";
+```
+
+`play.tsx` compensates *displayed* time via `toAbsolutePlaybackTime`
+(`movie-playback.ts:213`), but cue rendering is done by the browser against **media** time,
+which is session-local. Nothing in `web/src` rewrites cue timings — a search for
+`cue`/`TextTrack` across the source finds only unrelated YouTube and chapter code.
+
+Therefore any HLS session that does not start at 0 renders subtitles offset by
+`hlsStartSec`. That includes **every resume** and **every seek that rebases the session**
+(beyond the 120 s forward threshold or backwards past the start). Resuming a film at 40
+minutes shows the cues for minute 0 — or, more precisely, shows nothing, because the
+session's media timeline never reaches the cue times at all.
+
+Watch rooms are unaffected (always `startSec=0`). Direct play is unaffected (media time is
+absolute).
+
+Graded **Likely** rather than Confirmed only because the on-screen result was not observed
+in a browser; the mechanism is established from code and the measured rebasing. §20.3
+names the two-minute experiment that settles it.
+
+The fix is cheap and belongs on the server: `SubtitleWebVTT` should accept the session
+start and emit `-ss`-shifted cues, or the endpoint should emit
+`X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000`-style offsetting. Alternatively the client
+can shift cues after `load`, but that duplicates timing logic in the browser.
+
+---
+
+## 11. Segment-generation and seeking assessment
+
+### 11.1 Options in use
+
+`-f hls -hls_segment_type fmp4 -hls_segment_options movflags=+frag_discont
+-hls_playlist_type event -hls_list_size 0 -hls_time 4`, with `init.mp4` and
+`segment_%d.m4s`. VOD is synthesised on top of FFmpeg's event playlist (§5.1). Segment
+numbering always restarts at 0 for a rebased session, and the manifest echoes the
+*effective* start into every asset URL so segment lookups stay bound to the session that
+generated the manifest (`hls_handler.go:78-87`).
+
+### 11.2 H5 — `-ss` snaps backwards and the client never learns (Confirmed, Medium)
+
+`-ss` is placed before `-i` (fast input seek), which snaps to the nearest keyframe **at or
+before** the requested time. Measured on movie 57 (artifact `B3`):
+
+```
+true keyframes near t=600:  586.419  591.174  601.184  603.770  606.231
+requested start:            600.000
+first output PTS:           0.083  (flagged K)
+first EXTINF:               10.010  == 601.184 − 591.174
+⇒ the session actually begins at 591.174 s — 8.83 s before the request
+```
+
+The client then computes absolute time as `hlsStartSec + video.currentTime`
+(`movie-playback.ts:213`) using the *requested* 600, so for the entire session the UI clock
+— and every watch-progress value saved from it — is ~8.8 s ahead of the picture on screen.
+The error is bounded by the source GOP length, which for sparse-keyframe sources (movie
+131, keyframes up to 12.4 s apart) is over 12 s.
+
+The server knows the true offset the moment the first segment exists; it does not measure
+or publish it.
+
+Transcode sessions are unaffected in a different way: `-force_key_frames` uses output time
+`t`, which starts at 0 after the input seek, so boundaries stay aligned — but the same
+backwards snap to the input keyframe still applies to where the content begins.
+
+### 11.3 Readiness and partial-file exposure
+
+`segmentComplete` (`hls_handler.go:321`): segment N is complete when N+1 exists, or when
+FFmpeg has exited and the file is non-empty; `init.mp4` is complete once `segment_0`
+exists. Polling is 25 ms, capped at 120 s, and aborts on `r.Context().Done()` so a scrub
+does not leave goroutines polling. This is a sound design and prevents serving
+partially-written segments in the normal case.
+
+Two edges:
+
+- **A killed session can expose a truncated final segment** only if `ExitErr` is nil, which
+  cleanup makes impossible (`cleanupHLSSession` sets `ExpectedStop` and cancels, so
+  `ExitErr != nil` → 500). Safe.
+- **The last real segment of a clean session** is served on the "exited and file exists"
+  branch without any completeness check beyond size > 0. It is complete in practice because
+  FFmpeg closes it before exiting.
+
+### 11.4 Seeking behaviour
+
+- **Before generation completes?** Yes. The synthesised VOD playlist lists the whole movie
+  from the first request, and `serveReadyHLSSegment` blocks until the requested segment is
+  produced — up to 120 s. A forward seek beyond the encoder's position therefore *works*
+  but can stall for a long time, bounded by how far ahead the seek is and by `-readrate 4`.
+- **Does a seek create duplicate FFmpeg processes?** No. A rebase reuses the same
+  `playback_session` UUID and `cleanupPersonalHLSSessionsForOwnerLocked` removes the
+  superseded window. **Verified live**: two sequential manifests with the same UUID at
+  `start=0` then `start=600` left the temp-dir count unchanged at 2 (§12.2).
+- **Can a seek return stale segments?** No. Segment files are session-scoped by temp dir,
+  and the asset URLs carry the effective start.
+- **Does a seek restart too much work?** Yes, by design — any rebase discards all encoded
+  output and restarts FFmpeg. The client mitigates with a 120 s forward-rebase threshold
+  (`MOVIE_HLS_FORWARD_REBASE_THRESHOLD_SEC`) so short skips seek within the buffer.
+- **Can existing segments be reused?** Never. There is no segment cache across sessions;
+  two users watching the same movie at the same offset transcode it twice.
+
+### 11.5 Unbounded generation (H8, Confirmed, Medium)
+
+No `-t` or `-to` is passed, so a session encodes the entire remainder of the movie
+regardless of what the user watches, at up to 4× realtime. For a 97-minute source this is
+~24 minutes of continuous CPU and disk write per session. Disk cost per session is the
+whole remaining movie: ~950 MB for the movie-57 remux, and ~11.7 GB for a
+`2160p_16mbps` transcode of a 97-minute film. With `HLS_MAX_SESSIONS_PER_USER = 3` a single
+user can hold three of those concurrently. Nothing bounds total transcode-directory usage,
+and there is no disk-space check before starting a session.
+
+---
+
+## 12. Session and FFmpeg lifecycle assessment
+
+This is the strongest part of the implementation. Everything below was verified live.
+
+### 12.1 Session identity and isolation
+
+`HLSSessionKey = movie:<id>:<profile>:audio:<n|none>:session:<uuid>:start:<sec>`
+(`hls_session.go:157`); rooms use `room:<id>` (`:163`), a disjoint namespace. Ownership is
+enforced on every segment request by `canAccessPersonalHLSSession` (`:417`), which compares
+`IsRoom`, `MovieID` and `OwnerUserID`. Temp dirs are `os.MkdirTemp(root, "igloo-hls-*")`,
+so filenames are unguessable and per-session.
+
+**Cross-user or cross-configuration leakage: not possible.** A different user hitting a
+known key gets 404 (ownership check); a different profile, audio track, start, or playback
+session produces a different key and a different temp dir.
+
+### 12.2 Live verification
+
+| Scenario | Expected | Observed |
+| --- | --- | --- |
+| Same UUID, `start=0` then `start=600` (seek) | old session superseded | temp dirs 2 → 2 ✅ |
+| Different UUID, same movie (second tab/device) | isolated new session | temp dirs 2 → 3 ✅ |
+| 3 further sessions beyond the cap | LRU eviction holds at 3 | temp dirs 3, ffmpegs 3 ✅ |
+| `POST /hls/session/stop` | prompt teardown | **84 ms**, process gone, temp dir removed ✅ |
+| Abandoned session, no requests | reclaimed within ~6 min (300 s TTL + 60 s sweep) | fully reclaimed at **+7 min 32 s** — FFmpeg exited by +7 m 12 s, temp dir removed 20 s later ⚠️ |
+
+The abandonment arm reclaimed everything, but took 7 m 32 s against the ~6 min the
+documentation implies (`docs/ffmpeg.md` §HLS Playback: "fully reclaimed … within about six
+minutes"). Other test sessions were being created and stopped during the window, which can
+shift the sweep phase, so this is reported as an observation rather than a defect; the
+guarantee held and nothing leaked. A dedicated single-session run would settle whether the
+documented figure needs widening.
+
+`HLS_MAX_SESSIONS_PER_USER` admission is real: after six distinct playback sessions for one
+user, exactly three FFmpeg processes and three temp dirs remained.
+
+### 12.3 Process lifecycle
+
+`RunHLS` (`ffmpeg_hls.go:333`) owns `cmd.Wait` and delivers exactly one `onExit`; stderr is
+drained into a 20-line ring buffer with a 1 MB token cap, so there is no pipe-backpressure
+stall and no unbounded log growth. `cleanupHLSSession` (`hls_session.go:480`) is idempotent
+via `CleanupOnce`: mark `ExpectedStop`, cancel the context (`CommandContext` kills), wait
+2 s, `Process.Kill()`, wait 2 s, `RemoveAll(TempDir)`.
+
+Cleanup triggers cover every path asked about: explicit stop, supersession, per-user cap
+eviction, CPU-permit reclaim, TTL expiry via `OnEvicted` (wired at `application.go:197-208`
+into a `app.Wait`-tracked goroutine), room deletion, shutdown (`shutdown.go`), and
+boot-time orphan sweep (`startup.go:329`, globbing `igloo-hls-*`).
+
+**Does FFmpeg outlive playback?** Only for the documented idle window. Closing the tab
+fires `pagehide` → stop endpoint (84 ms). Losing that (crash, network drop, sleep) falls
+back to the 5-minute idle TTL plus a ≤1-minute sweep. Not a leak; a bounded delay whose
+cost is real on a home server given §11.5.
+
+One gap: `cleanupHLSSession` ignores the `RemoveAll` error. If removal fails (file still
+open, permissions), the directory leaks silently until the next boot sweep.
+
+---
+
+## 13. Watch-room HLS assessment
+
+### 13.1 Creation-time validation (good)
+
+`CreateWatchRoom` (`watch_room_handler.go:324`) validates in order: `movie_id > 0`, mode
+present, `isValidPlaybackMode`, `audio_track >= 0`, `subtitle_track >= 0`, movie exists,
+then — crucially — rejects a non-zero `audio_track` on a movie with **no** audio streams
+(`:383`), an out-of-range `audio_track` (`:388`), a non-zero `audio_track` combined with
+direct playback (`:396`), and ambiguous default dispositions for direct (`:402`). The
+direct-only mirror block (`:413-438`) re-applies `movieContentType`, `primaryVideoStream`
+and `isBrowserSafeH264RemuxCandidate` server-side because the server cannot probe.
+
+**Video-only movies are handled correctly.** A movie with no audio streams accepts
+`audio_track = 0` only in the sense that the field defaults to 0 and is rejected if
+non-zero; `createHLSSession` then passes `audioTrack == nil` and `buildHLSArgs` omits the
+audio map and all audio options entirely. No synthetic audio track is invented and no
+failure occurs solely because audio is absent. This matches the personal path exactly.
+
+### 13.2 Warm-up
+
+`WarmUpRoomHLSSession` runs on a background context **after** `tx.Commit()`
+(`:514-533`); on failure the room row is deleted and a 500 returned. Two observations:
+
+- The rollback calls the `DeleteWatchRoom` **query**, not `CleanupRoomHLSSession`, so the
+  tombstone/cache path is not exercised on this rollback. In practice there is nothing to
+  clean (warm-up failed), but a partially-created session would be missed.
+- Warm-up always starts at 0 and has no `-t`, so creating a room immediately begins
+  encoding the entire film (§11.5) whether or not anyone presses play.
+
+### 13.3 TTL — the premise checked and refuted
+
+A 30-minute room TTL with no refresh would expire mid-film. It does not:
+`getActiveRoomHLSSession` (`hls_session.go:455`) calls `RefreshHLSSessionTTL` on every hit,
+and both `WatchRoomHLSManifest` (via `GetOrCreateRoomHLSSession`) and
+`WatchRoomHLSSegment` route through it. Every segment fetch refreshes the room's 30
+minutes. **Not a defect.**
+
+The residual exposure is a room **paused** for over 30 minutes with a full buffer, which
+issues no requests. It would be evicted, and recovery is poor: the room URL carries no
+`start`, no `reload` and no `playback_session`, so the next manifest request creates a
+fresh session **from t=0** while every participant's playhead is elsewhere. Graded
+**Hypothesis** (the 35-minute idle arm was not run to completion).
+
+Note the asymmetry worth locking with a test: `RefreshHLSSessionTTL` re-`Set`s room
+sessions unconditionally, while the personal path re-`Get`s and identity-compares
+(`raw != session`) before extending. A stale room pointer can therefore resurrect a cache
+entry another path just removed.
+
+### 13.4 H9 — the room player has no recovery wiring (Confirmed, High)
+
+`WatchRoomPage.tsx:515-528` renders the shared `VideoPlayer` with `videoRef`, `src`,
+`isHlsSource`, `title`, `isFullscreen`, `onError`, `onPlay`, `onPause` — and **omits
+`onSessionLost`, `onCapacityBusy`, `startSec` and `onStartApplied`**. There is also no
+`useHlsSessionKeepalive` anywhere in the watch-room tree.
+
+Consequences for an HLS room:
+
+- A segment 404 — including the H2 tail, which every remux room will hit — produces a
+  generic "Stream error" with no recovery attempt.
+- A 503 from the transcode limiter is a hard failure; there is no capacity retry and no
+  "waiting for capacity" affordance.
+- Participants have no keepalive; the room relies entirely on segment traffic for TTL.
+
+Rooms are also never exercised by the HLS path in tests: `watch-room.spec.ts` creates
+`mode: "direct"` only, and no watch-room unit test references hls.js.
+
+### 13.5 Participant isolation and sharing
+
+All participants share one session, one FFmpeg process and one temp dir — intended, and
+efficient. Authorisation runs per request through `loadAuthorizedWatchRoomForRequest`, so a
+non-member cannot fetch room segments. Room and personal namespaces cannot collide
+(verified by `hls_room_test.go:13`). Deletion marks a tombstone, removes the cache entry,
+kills FFmpeg and removes the temp dir.
+
+---
+
+## 14. Hardware-acceleration assessment
+
+Configured device here is `cpu`, so the hardware paths were **not exercised at runtime**;
+this section is a code assessment.
+
+`ResolveHLSDevice` (`capabilities.go:137`) degrades to `cpu` whenever the encoder is
+absent, a runtime probe failed, or the device is unknown, and records a `Reason` that is
+logged (`hw_fallback_reason` — verified empty for cpu in the live log). Probing at startup
+goes beyond name matching: `probeH264NVENC`, `probeNvidiaCUDAScale`,
+`probeNvidiaCUDATonemap`, `probeH264QSV`, `probeQSVScale` each run a short real encode or
+filter with a 5 s timeout (`capabilities.go:226-241`). Filter and encoder *options* are
+probed individually before being emitted (`appendHLSIntelEncoderArgs`).
+
+This directly addresses the classic failure the brief asks about — "hardware encoding
+selected because an encoder name exists" — and does so properly.
+
+Assessment of the specific risks:
+
+- **Hardware decode with incompatible software filters**: avoided by design. CUDA decode is
+  enabled without `-hwaccel_output_format`, so frames land in system memory; QSV decode is
+  deliberately not enabled. HDR tone mapping on Intel never uses `scale_qsv`.
+- **Software fallback retaining hardware-only arguments**: not possible — `hwLower` is the
+  *resolved* device, and every hardware argument branches on it plus a capability check.
+  `useNvidiaCUDAFilters` / `useIntelQSVScale` are additionally gated on `!copyVideo`.
+- **Failed hardware commands retrying in software**: **not implemented.** Probes run at
+  startup only. If the GPU is healthy at boot but the device is busy, the driver is
+  upgraded, or `/dev/dri` permissions change at runtime, the session simply fails —
+  `onExit` logs the stderr tail and the manifest request has already returned. There is no
+  per-session retry that drops to `libx264`. Graded **Confirmed gap, Medium**; on this
+  host it is unreachable because the device is `cpu`.
+- **Different effective output between paths**: the pixel-format and colour handling
+  differ deliberately (`nv12` for QSV, CUDA formats inside the filter chain) but converge
+  on bt709 SDR H.264 High. Since the manifest declares no `CODECS` attribute (§1.2), there
+  is nothing that could become inconsistent.
+- **Device contention**: nothing serialises GPU access; `HLS_MAX_CPU_TRANSCODES` bounds
+  only CPU sessions, and its name is accurate — hardware sessions still consume a permit
+  because the limiter keys on `!copyVideo`, not on the device. That is the conservative
+  choice and is fine.
+
+The `2160p_16mbps` profile combined with a `cpu` device — the configuration on this
+machine, and the one every HEVC 4K title in the library falls back to — is the most
+resource-dangerous path in the system and has no guard beyond the permit count.
+
+---
+
+## 15. HLS player-controls assessment
+
+### 15.1 What exists
+
+All HLS-relevant selection happens **before** playback, in `PlaybackSettingsDialog.tsx`
+(quality/mode, audio track, subtitle track), reached from the movie-details hero. In the
+player itself, `MoviePlayerControls.tsx` provides seek ±10 s, play/pause, chapters, volume,
+fullscreen and a read-only mode badge. There is **no in-player quality, audio, or subtitle
+control at all**.
+
+### 15.2 Accessibility
+
+Good, and evidently maintained: `role="group"` with labels for the progress and control
+clusters (`:76`, `:98-101`); keyboard hints inside `aria-label`s ("Pause (Space or K)",
+"Seek forward 10 seconds (L or Right Arrow)"); `aria-pressed` on the fullscreen toggle;
+all icons `aria-hidden`; the mode badge prefixed with an `sr-only` "Current playback mode:";
+four `LiveAnnouncer` regions in `play.tsx:752-766` (playing/paused and capacity polite,
+chapter and direct-play fallback assertive); an `sr-only` shortcut list; the buffering
+spinner labelled and `pointer-events-none`. The settings dialog labels every control and
+ties the audio-track/mode interaction note to both selects via `aria-describedby`.
+
+Gaps, all HLS-specific:
+
+- **Recovery is silent.** `useHlsSessionRecovery` retries up to three times with no
+  announcement and no visible state; a screen-reader user gets nothing between "playing"
+  and a terminal error. Capacity waiting, by contrast, is announced — the pattern to copy
+  already exists.
+- **The error screen is not announced.** `MoviePlaybackStatusScreen` renders an `<h1>` and
+  `<p>` with no `role="alert"` / `aria-live`, so a mid-playback failure is silent for
+  assistive tech.
+- **The mode badge is inaccurate, not just terse** (H3) — an accessibility problem as much
+  as a UI one, since it is the only mode affordance and it can be wrong.
+
+### 15.3 Should the custom player remain?
+
+**Yes.** The controls are accessible, small, and already integrated with the design system,
+chapters, watch-progress, keyboard handling and the watch-room sync layer. Every defect in
+this audit is a server-side or manifest-level defect, or a wiring omission in
+`WatchRoomPage`. None of them is caused by the player being custom, and none would be fixed
+by a package: a player library cannot correct a manifest that misdescribes its own
+segments, cannot invent an effective-profile field the API does not return, and cannot
+shift subtitle cues the server timestamps absolutely.
+
+The one capability genuinely missing — in-player track and quality switching — is
+achievable with existing shadcn/ui primitives, and with today's architecture each switch is
+a new session anyway, so it is a navigation action rather than a player-internal one.
+Adopting a package would mean re-solving the accessibility work already done here.
+
+---
+
+## 16. Confirmed bugs
+
+**Status note (2026-07-28, same day).** The P0 and P1 items were fixed after this audit was
+written; see §23 for what changed and how each fix was verified. The findings below are
+kept as originally written so the evidence and the reasoning survive.
+
+| ID | Severity | Summary | Evidence |
+| --- | --- | --- | --- |
+| **H1** | Critical | Synthesized VOD playlist declares uniform 4 s `#EXTINF` for copy-video sessions whose real segments follow source keyframes (measured mean 5.40 s, max 12.43 s); cumulative drift +131.9 s over 507.9 s of content. Transcode control drifts 0.008 s. | §5.2, `B1/B2-extinf-drift.tsv` |
+| **H2** | Critical | The same playlist advertises `ceil(duration/4)` segments while FFmpeg produces far fewer; the surplus 404 after a clean exit, and the client misreads that as "session lost" and burns its 3-attempt recovery budget. Reproduced: 8 advertised, 1 produced, `segment_1..7 → 404`. | §5.3, `C5-tail.m3u8` |
+| **H3** | High | The effective profile is never exposed. A `remux` request on HEVC silently became a `2160p_16mbps` CPU transcode with HTTP 200, `/hls/remux/` URLs, and a player badge still reading "Remux". | §3.5, `C6-*` |
+| **H9** | High | The watch-room player omits `onSessionLost`, `onCapacityBusy`, `startSec` and the keepalive, so HLS rooms have no recovery from a 404 or a 503. | §13.4 |
+| **H5** | Medium | `-ss` snaps back to the preceding keyframe (measured 600 → 591.17 s) but the client maps absolute time from the *requested* start, so the UI clock and saved progress are ahead of the picture by up to a GOP. | §11.2, `B3` |
+| **H8** | Medium | No `-t`; every session encodes the whole remaining movie at up to 4× realtime (~950 MB remux, ~11.7 GB for a 4K transcode), with no disk-space check. | §11.5 |
+| **H11** | Medium | `Hls.isSupported() === false` returns silently — blank player, no error, no fallback. | §4.1 |
+| **H14** | Medium | Stream ordinals are not stable across re-scans (delete-and-reinsert, no `UNIQUE(movie_id, stream_index)`), silently repointing saved audio/subtitle selections and stored room tracks. | §6.3 |
+| **H6** | Low–Med | First remux of a movie blocks the manifest response on preflight — measured **6.28 s** (30 s cap), cached 24 h thereafter. | §3.3, server log |
+| **H7** | Low | `audio_track` is logged as a pointer (`audio_track=0x21c92170d160`), making session logs useless for diagnosing track selection. | §7.4 |
+| **H13** | Low | `#EXT-X-INDEPENDENT-SEGMENTS` not emitted though true; no `#EXT-X-START` on rebased sessions. | §5.5 |
+
+## 17. Likely bugs and risks
+
+| ID | Grade | Summary | What would settle it |
+| --- | --- | --- | --- |
+| **H4** | Likely, High | Subtitles desync by `hlsStartSec` on every rebased HLS session (resume, seek-rebase), because WebVTT cues are absolute and the media timeline is rebased to 0. | Browser: resume a subtitled movie at 40 min and observe (§20.3) |
+| **H10** | Likely, Low | A late `disposeHls` can null `hlsRef.current` while it holds a newer instance. | Unit test forcing overlapping effect runs |
+| **H12** | Confirmed gap | No in-player quality/audio/subtitle switching; changing any of them means leaving playback. | Product decision (§18.2) |
+| **H15** | Hypothesis | HE-AAC/xHE-AAC would be copied blindly (`copyAudio = codec == "aac"` ignores `profile`). Unreachable in this library — all 200 AAC streams are LC. | A HE-AAC sample through the remux path |
+| **H16** | Hypothesis | AC-3/E-AC-3 `dialnorm` is not applied on downmix, so loudness can shift audibly. | A/B listening test on an AC-3 title |
+| **H17** | Hypothesis | A watch room paused >30 min is evicted and restarts every participant from t=0 (no `start`, no `reload` in the room URL). | 35-minute idle room arm |
+| **H18** | Confirmed gap | No runtime hardware fallback: probes run only at startup, so a device that fails later fails the session with no software retry. | Unreachable here (`cpu`); needs a GPU host |
+| **H19** | Confirmed gap | Interlaced, rotated and VFR sources have no handling (no deinterlace, no rotation, no fps normalisation). | Sample files through transcode |
+| **H20** | Low | `cleanupHLSSession` ignores the `RemoveAll` error, so a failed temp-dir removal leaks silently until the next boot sweep. | Code fix |
+
+---
+
+## 18. Recommended HLS architecture
+
+The architecture is sound and should not be rewritten. Sessions, admission control,
+process lifecycle, the remux safety gate, explicit stream mapping and hardware resolution
+are all well built and were verified working. The problems are concentrated in one place:
+**the server describes its output instead of measuring it.**
+
+### 18.1 Make the playlist describe reality (fixes H1, H2, and most of H5)
+
+Three options, in increasing order of cost:
+
+1. **Serve FFmpeg's own playlist, always.** FFmpeg already writes an accurate event
+   playlist and updates it atomically (`playlist.m3u8.tmp` → rename, observed live). Serve
+   it as an **event** playlist during encoding — no `ENDLIST`, so clients legitimately
+   reload it and pick up real durations as they are produced — and finalise to VOD on
+   clean exit. This is the smallest change that eliminates both critical findings, at the
+   cost of losing "whole movie is seekable immediately".
+2. **Keep the synthetic VOD playlist for transcodes only** (where it is exact, measured
+   0.008 s drift) and use option 1 for copy-video. This preserves today's seek behaviour
+   for the majority of sessions and fixes the broken minority. **Recommended.**
+3. **Index keyframes at scan time** and synthesise a correct copy-video playlist from the
+   real GOP structure. This is the only option that keeps instant full-movie seeking on
+   remux, and it also gives exact `-ss` targets (fixing H5 properly) and enables segment
+   reuse later. It is the right long-term answer and matches the deferred
+   "HLS copy-video playlist follow-up" already on record. Highest cost: a scanner change,
+   a schema addition, and a re-scan.
+
+Whatever is chosen, add `#EXT-X-INDEPENDENT-SEGMENTS`, and have the server publish the
+**true** session start (measurable from the first segment) so the client can stop guessing.
+
+### 18.2 Publish the effective profile (fixes H3)
+
+Add `effective_profile` (and ideally `copy_video`, `effective_start_sec`) to the session,
+return it from the manifest — a response header is the least invasive carrier for an
+`.m3u8`, or a small `GET /api/movies/{id}/hls/session` companion endpoint — document it in
+`docs/openapi.json`, and drive the player badge from it. The client should say
+"Transcoded 2160p (remux unavailable: HEVC)" rather than "Remux".
+
+Renditions (`EXT-X-MEDIA` audio groups, subtitle renditions, an ABR ladder) are **not**
+recommended for a home server: they multiply concurrent FFmpeg work on a box that already
+runs 4K CPU transcodes near its limit, and the current one-session-per-selection model is
+honest about that cost. Revisit only if segment reuse (18.1 option 3) lands first.
+
+### 18.3 Fix subtitle timing at the source (fixes H4)
+
+Pass the session start to `SubtitleWebVTT` and emit cues shifted by it, cached per
+(movie, stream, start). Keep the absolute-timestamp variant for direct play.
+
+### 18.4 Bound the work (fixes H8)
+
+Cap generation ahead of the playhead — either `-t` sized to a generous window with session
+extension, or keep `-readrate` but add a disk-space precondition and a transcode-directory
+budget. A home server should refuse a session it cannot store.
+
+---
+
+## 19. Prioritized action plan
+
+**P0 — before HLS can be called production-ready**
+
+1. **H2** — stop advertising segments that will not exist. Option 18.1(2) is the smallest
+   correct fix. Until then, remux playback fails near the end of most films.
+2. **H1** — stop declaring 4 s durations for copy-video (same change).
+3. **H3** — publish and display the effective profile. Users are currently told a 4K CPU
+   transcode is a stream copy.
+4. **H4** — offset subtitle cues for rebased sessions. Resume + subtitles is a mainstream
+   path and it is broken.
+
+**P1 — high value, contained**
+
+5. **H9** — wire `onSessionLost`, `onCapacityBusy`, `startSec` and the keepalive into
+   `WatchRoomPage`, or extract the shared wiring so the two players cannot diverge again.
+6. **H5** — publish the true session start; map absolute time from it.
+7. **H11** — show a real error when neither MSE nor native HLS is available.
+8. **H8** — add a disk precondition and bound generation.
+
+**P2 — correctness and operability**
+
+9. **H14** — add `UNIQUE(movie_id, stream_index)` and make re-scan preserve ordinals (the
+   pre-production no-migration rule makes this cheap now and expensive later).
+10. **H7** — dereference the audio-track pointer in logs.
+11. **H6** — make preflight non-blocking (serve the manifest, decide before the first
+    segment) or shorten the wait.
+12. **H13, H20** — emit `#EXT-X-INDEPENDENT-SEGMENTS`; log `RemoveAll` failures.
+13. **§15.2** — announce recovery attempts; add `role="alert"` to the playback error
+    screen.
+
+**P3 — deferred / product**
+
+14. Keyframe indexing at scan time (18.1 option 3), enabling exact seeks and segment reuse.
+15. In-player track/quality switching (H12).
+16. Runtime hardware fallback (H18); interlaced/rotation/VFR handling (H19).
+
+---
+
+## 20. Test matrix and testing plan
+
+### 20.1 Existing coverage
+
+Substantial and good on the units: `hls_handler_test.go` (19 tests), `hls_session_test.go`
+(27), `hls_playlist_test.go` (10), `hls_room_test.go` (9), `hls_remux_safety_test.go` (2),
+plus `ffmpeg_hls_args_test.go` (20), `_additional` (4), `_hardware` (17), `_run` (11),
+`remux_validator_test.go` (12), `remux_parser_test.go` (12) and a fuzz target. Web side:
+`video-player.test.tsx`, `use-hls-capacity-retry`, `use-hls-session-keepalive`,
+`movie-hls-playback-session`, `movie-playback-data`.
+
+**The gap is systemic: nothing compares generated output to reality.** Every playlist test
+asserts the synthesizer against its own formula, which is why H1 and H2 survived. No test
+runs FFmpeg and checks the result against the manifest. No test covers
+`useHlsSessionRecovery` directly, watch-room HLS end to end, or native HLS.
+
+### 20.2 File test matrix
+
+Expected effective profile assumes `HARDWARE_ACCELERATION_DEVICE=cpu`.
+
+| # | Source | Requested | Effective | FFmpeg op | Audio | Manifest expectation | Auto? |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | H.264 8-bit + AAC stereo | remux | remux | `-c:v copy -c:a copy` | copy | `EXTINF` == real segment durations; segment count == files produced | yes |
+| 2 | H.264 8-bit + AC-3 5.1 | remux | remux | `-c:v copy -c:a aac -ac 2` | stereo AAC | as #1 | yes |
+| 3 | H.264 with sparse keyframes (movie 131) | remux | remux | copy | copy | **regression guard for H1/H2** | yes |
+| 4 | H.264 failing IDR preflight | remux | best-fit transcode | full transcode | AAC | effective profile reported ≠ requested | yes |
+| 5 | HEVC Main 10 SDR | remux | 2160p/1080p best-fit | full transcode | per codec | client shown effective profile (H3) | yes |
+| 6 | HEVC Main 10 HDR10 (`smpte2084`) | 1080p_8mbps | same | tone-map chain | AAC | bt709 output tagging | partial |
+| 7 | Dolby Vision | any | — | not represented in library | — | document as unsupported | no |
+| 8 | Interlaced | 720p_3mbps | same | transcode | AAC | **currently no deinterlace (H19)** | manual |
+| 9 | VFR | 720p_3mbps | same | transcode | AAC | segment boundaries stay 4 s | yes |
+| 10 | Multiple audio tracks | remux, `audio_track=2` | remux | copy/transcode | track 2 reaches output | `-map 0:<abs idx of 3rd>` | yes |
+| 11 | Duplicate-language audio | remux, track 1 vs 2 | remux | — | distinguishable in picker | ordinal→absolute correct | yes |
+| 12 | Commentary / audio-description | remux | remux | — | disposition preserved in picker | — | yes |
+| 13 | **Video-only** | remux | remux | no audio map | none | no `-c:a`, no `-map` for audio | yes |
+| 14 | Multiple subtitle tracks | any | — | sidecar only | — | no subtitle rendition; correct VTT | yes |
+| 15 | Forced / hearing-impaired subs | any | — | sidecar | — | disposition surfaced in picker | yes |
+| 16 | ASS/SSA | any | — | `-c:s webvtt` | — | styling loss acceptable, timing correct | yes |
+| 17 | PGS/DVD/DVB | any | — | rejected | — | HTTP 415, never a broken text track | yes |
+| 18 | Missing language metadata | remux | remux | — | picker labels by index | — | yes |
+| 19 | Missing/multiple default dispositions | direct → remux | remux | copy | — | direct refused, HLS unaffected | yes |
+| 20 | Attached cover art | any | — | excluded | — | `primaryVideoStream` skips it | yes |
+| 21 | Multiple video streams | any | — | first non-cover-art | — | correct `-map` | yes |
+| 22 | DTS / TrueHD / E-AC-3 | remux | remux | `-c:v copy` + AAC stereo | transcoded | measure output bitrate | yes |
+| 23 | Corrupt / truncated file | any | — | FFmpeg fails | — | manifest 4xx/5xx, no hung request, temp dir removed | yes |
+| 24 | 4K over the slow mount | 2160p_16mbps | same | transcode | AAC | **below realtime — expect stall** | manual |
+| 25 | Seek before generation completes | any | — | rebase | — | new session, old superseded | yes |
+| 26 | Same UUID in two tabs | any | — | supersession | — | second kills first (documented behaviour) | yes |
+| 27 | Two users, same movie | any | — | two sessions | — | isolation, no cross-access | yes |
+| 28 | Watch room, HLS mode | room profile | same | shared session | stored track | **no coverage today** | yes |
+| 29 | Resume at 40 min + subtitles | remux | remux | `-ss` | — | **H4 regression guard** | browser |
+
+### 20.3 Recommended tests
+
+**Golden-output tests (the missing layer, highest value).** A build-tagged suite that runs
+the real FFmpeg against small fixture files and asserts the *manifest matches the media*:
+
+- `TestGeneratedPlaylistMatchesRealSegments` — for a copy-video fixture, assert every
+  `#EXTINF` is within tolerance of the produced segment and that the entry count equals the
+  file count. This single test would have caught both H1 and H2.
+- `TestCopyVideoSegmentCountMatchesFiles` — the count assertion alone, cheap enough to run
+  on several fixtures.
+- `TestSessionStartMatchesFirstSegmentPTS` — locks H5.
+
+**Go unit tests** (no media required):
+
+- `TestHLSSessionKey_UsesRequestedNotEffectiveProfile` — documents H3's cache-key
+  consequence so a fix is deliberate.
+- `TestStartHLSSession_CopyAudioOnlyForAAC` — extend to profile once H15 is decided.
+- `TestBuildHLSArgs_SeekPlacedBeforeInput`, `TestNormalizedHLSStartSec_*`.
+- `TestRefreshHLSSessionTTL_RoomIgnoresIdentity` — records the room/personal asymmetry
+  (§13.3).
+- `TestCleanupHLSSession_RemovesTempDirAfterKill` and an `OnEvicted` test driving a
+  short-TTL cache — lock the lifecycle guarantees measured in §12.2.
+- `TestCleanupPersonalHLSSessionsForOwner_KillsSameUUIDDifferentStart` — encodes the
+  duplicate-tab consequence so a future per-tab UUID change breaks it deliberately.
+
+**Web unit tests:** a `use-hls-session-recovery.test.tsx` (none exists); a VideoPlayer test
+for `Hls.isSupported() === false` (H11); a test that `destroy()` runs on unmount; a
+StrictMode double-mount test (H10).
+
+**Playwright:** a watch-room HLS spec behind `E2E_BASE_URL` (case 28); extend
+`hls-transcode.spec.ts` with a remux case and a remux-fallback case — today it only covers
+transcode, and its `E2E_HLS_4K_MOVIE_ID` can never exercise remux because the library has
+no H.264 above 1080p.
+
+**Browser experiments to settle the Likely findings** (excluded from this audit's scope):
+
+- **H4**: resume a subtitled movie at 40 minutes; observe whether cues appear.
+- **H1 user impact**: serve the same segment files under (a) FFmpeg's real playlist and
+  (b) the synthesized one from a static harness, seek to a known frame in each, and compare
+  `video.currentTime` against ground truth — this determines whether hls.js's PTS
+  re-derivation masks the drift.
+- **H15**: 5.1 AAC-LC fMP4 in Firefox MSE.
+
+**Not needed:** load/concurrency tests beyond what exists — §12.2 already demonstrates the
+cap and eviction behave correctly.
+
+---
+
+## 21. Diagnostic changes
+
+No production code was modified. `git status` shows only this new document plus the
+`docs/ffmpeg.md` corrections listed below.
+
+**Repository side effects:**
+
+- `server/cmd/api/webdist/.keep` was created — the gitignored placeholder the build
+  requires, per `CLAUDE.md`. Not tracked by git.
+- The Go build cache was populated.
+
+**Sandbox artifacts (outside the repository, in the session scratchpad):**
+
+| Artifact | Contents |
+| --- | --- |
+| `A1-caps.txt` | Capability matrix, system 6.1.1 vs embedded 7.1.4-Jellyfin |
+| `B1-extinf-drift.tsv` | Movie 57 remux, per-segment real vs synthesized durations |
+| `B2-extinf-drift.tsv` | Movie 57 720p transcode control |
+| `B3-ffmpeg.log`, `B3-seg0.mp4` | `-ss 600` keyframe-landing measurement |
+| `B4-aac51-131` | 5.1 AAC-LC copy output and probe |
+| `C1-real-argv.txt`, `C1-playlist-remux.m3u8` | Live argv capture; 1458-entry playlist |
+| `C2a-abandon.log` | Abandoned-session reclamation timeline |
+| `C5-tail.m3u8` | Tail session: 8 advertised vs 1 produced |
+| `C6-headers.txt`, `C6-hevc-remux.m3u8` | HEVC remux → 2160p fallback, unreported |
+| `server.log` | Sandbox server log |
+| `igloo-copy.db`, `igloo-dev` | DB copy and throwaway binary |
+
+**Isolation:** the sandbox ran on port 8099 against a *copy* of the database with
+`transcode_dir` redirected to the scratchpad and a default admin seeded into the copy.
+`db/igloo.db` and `./transcode` were never written. The sandbox server also ran a library
+scan against the copy — expected, and confined to the copy.
+
+**`docs/ffmpeg.md` corrections** (per the decision to reconcile rather than only report):
+the §HLS Output Format and §Seeking and Resume Behavior sections stated the generated VOD
+playlist and `-ss` behaviour without noting that copy-video segment durations and counts
+are synthetic and diverge from the real output, or that `-ss` snaps backwards to a
+keyframe. Both now say what the code does, each cross-referencing the finding here. These
+notes should be revised again when H1/H2/H5 are fixed.
+
+---
+
+## 22. Final answers to the audit questions
+
+**1. Is the current HLS implementation reliable?**
+Partly. The session layer, process lifecycle, admission control, stream mapping and the
+remux safety gate are well built and were verified working. The *transcode* delivery path
+is reliable. The **copy-video (remux) delivery path is not**: its manifest misdescribes its
+own output and playback breaks before the end of the film (H1, H2).
+
+**2. Are remux, partial-transcode and full-transcode decisions correct?**
+The decisions themselves are correct and conservative — the static gate plus IDR preflight
+is a good design, and video is never transcoded merely because audio is incompatible. Two
+qualifications: audio is transcoded on codec name alone, ignoring profile (H15), and always
+downmixed to stereo at a wasteful 320 kbps; and a fallback from remux to a full transcode is
+correct but invisible (H3).
+
+**3. Are the selected audio and subtitle tracks always honoured?**
+Yes at request time — mapping is explicit and absolute, ordinals are range-checked and
+resolved server-side, and video-only movies are handled correctly. But the ordinal is not
+stable across library re-scans (H14), so a saved or room-stored selection can silently come
+to mean a different track.
+
+**4. Are manifests valid and accurately describing the output?**
+Valid, yes — the tags are well-formed and the fragments are sound. Accurate, **no** for
+copy-video: durations are fiction (mean 5.40 s declared as 4 s) and the segment count is
+inflated by up to 2.3×. For transcodes the manifest is accurate to 8 ms.
+
+**5. Does seeking work correctly before generation completes?**
+Mostly. A forward seek into unencoded territory blocks until the segment is produced (up to
+120 s) rather than failing, and rebasing is clean with no duplicate processes. But the seek
+lands up to a full GOP earlier than requested and the client is never told (H5), and on
+copy-video the playlist's time→segment mapping is wrong to begin with (H1).
+
+**6. Can sessions or segments collide or leak across users?**
+No. Verified live: keys are scoped by movie, profile, audio track, playback-session UUID
+and start; ownership is checked on every segment; rooms occupy a disjoint namespace; temp
+dirs are randomised. Different users and different tabs are properly isolated, and the
+per-user cap holds at 3.
+
+**7. Can FFmpeg processes continue after playback ends?**
+Not indefinitely. Explicit stop tears down in 84 ms; an abandoned session was measured
+fully reclaimed — process killed, temp directory removed — 7 m 32 s after creation. The
+real cost is not a leak but that an unbounded session writes the whole remaining movie to
+disk in the meantime (H8).
+
+**8. Is hardware acceleration safe and deterministic?**
+Safe and deterministic at startup — real runtime encode/filter probes gate every hardware
+path and everything degrades to `libx264` with a logged reason, which is better than most
+implementations. It is not *resilient*: probes never re-run, so a device that fails after
+boot fails the session with no software retry (H18). Unexercised here (`cpu`).
+
+**9. Does the client display the actual effective playback mode?**
+**No.** This is H3, and it is the single most misleading behaviour found: a request for
+`remux` on an HEVC file returns 200 with `/hls/remux/` URLs while the server runs a 2160p
+CPU transcode, and the badge reads "Remux".
+
+**10. Should the custom player remain?**
+Yes. It is accessible, integrated, and not the cause of any finding here. No player package
+would fix a manifest that misdescribes its segments, an unpublished effective profile, or
+absolutely-timestamped subtitles on a rebased timeline. The missing in-player track
+switching is achievable with existing components.
+
+**11. What must be fixed before HLS playback can be considered production-ready?**
+The four P0 items: make the playlist describe the real output (H2, then H1), publish and
+display the effective profile (H3), and offset subtitle cues for rebased sessions (H4).
+Wiring watch-room recovery (H9) should follow immediately, since rooms currently have no
+recovery from the very 404s H2 guarantees.
+
+---
+
+## 23. Remediation (2026-07-28)
+
+P0 and P1 were fixed in the same session that produced this audit. P2 and P3 remain open.
+
+### 23.1 What changed
+
+| ID | Fix | Where |
+| --- | --- | --- |
+| **H1, H2** | Copy-video sessions now serve **FFmpeg's own playlist** (URLs rewritten, `EVENT` while encoding, finalized `VOD` after a clean exit) instead of a playlist synthesized from the movie duration. Transcodes keep the synthesized VOD playlist, which is exact for them. A manifest request for a copy-video session that has not published a segment yet waits, then returns `503` + `Retry-After: 1` — it never falls back to synthesizing. | `hls_handler.go` (`buildHLSPlaylistBody`, `readLiveHLSPlaylist`, `hasPlayableSegment`) |
+| **H3** | Two-part. The client no longer offers `remux` for video the server will refuse to copy — `getAvailableModes` now applies `isBrowserSafeH264` to the remux branch, closing the common 10-bit case at source. For the remaining dynamic-preflight case the manifest carries `X-Igloo-Effective-Profile`, read via hls.js `MANIFEST_LOADED` and shown in the player badge through `effectiveModeLabel`. | `lib/playback.ts`, `VideoPlayer.tsx`, `play.tsx`, `hls_handler.go`, `hls_session.go` |
+| **H4** | The WebVTT endpoint accepts `start` and shifts cue timings at serve time. The cache still holds one absolute-timestamp payload per (movie, stream), so there is no extra extraction and no cache multiplication. The client appends the session start to the subtitle URL. | `helpers/subtitle_shift.go`, `subtitle_handler.go`, `lib/movie-playback.ts` |
+| **H5** | Copy-video sessions with a non-zero start measure where the media really begins, with a bounded ffprobe keyframe lookup running alongside FFmpeg, published as `X-Igloo-Actual-Start`. Advisory: on failure the header is omitted. Transcodes are unaffected — input seek is frame-accurate when re-encoding. | `ffprobe_keyframes.go`, `hls_session.go`, `hls_handler.go` |
+| **H8** | A session is refused with `503` when the transcode filesystem has under 2 GB free. A filesystem that cannot be measured is not treated as full. | `disk_space.go`, `hls_session.go` |
+| **H9** | The watch-room player is wired to `useHlsSessionRecovery`, `useHlsCapacityRetry` and `useHlsSessionKeepalive`, with a reload key that rebuilds the player; WebSocket sync then restores the host position. The keepalive also closes H17. | `WatchRoomPage.tsx`, `lib/watch-room.ts` |
+| **H11** | An unsupported browser now gets an explicit error instead of a blank player. | `VideoPlayer.tsx` |
+
+One defect was found *while* fixing H1/H2 and fixed with them: a session seeking past the
+end of a stream exits cleanly having written a single empty segment, which FFmpeg declares
+as `#EXTINF:0.000000` under an invalid `#EXT-X-TARGETDURATION:0`. Serving that verbatim
+would have replaced one bad manifest with another, so a playlist is only accepted once it
+declares at least one positive-duration segment; otherwise the session is reported as
+having produced no playable media (`404`).
+
+### 23.2 Verification
+
+`make check` and `make test-openapi` pass. New tests: `ShiftWebVTT` (9 cases), the
+copy-video playlist branch and its empty-output guard, `hasPlayableSegment`, the
+actual-start probe and header, the subtitle `start` parameter, the corrected remux
+eligibility gate, `effectiveModeLabel`, the subtitle URL offset, unsupported-browser
+reporting, effective-profile reporting, and watch-room recovery wiring.
+
+Re-running the experiments that found the bugs, against a sandbox server on a copy of the
+database (artifacts `V-*`):
+
+| Check | Before | After |
+| --- | --- | --- |
+| Copy-video `#EXTINF` values | uniform `4.000000` | identical to FFmpeg's own playlist (`8.466792`, `6.006000`, `10.010000`, …) |
+| Copy-video segment count | 1458 advertised for movie 57 | exactly the segments FFmpeg has produced; playlist is `EVENT` with no premature `ENDLIST` |
+| Advertised segments fetchable | tail 404s (8 advertised, 1 produced) | 7/7 returned `200` |
+| Seek past end of stream | invalid manifest, dead segment URLs | `404 no playable media at this position` |
+| `/hls/remux/` on HEVC | `200`, nothing named the transcode | `X-Igloo-Effective-Profile: 2160p_16mbps` |
+| Copy-video session at `start=600` | client assumed 600 | `X-Igloo-Actual-Start: 591.174`, matching the keyframe measured in §11.2 |
+
+**Not verified against live media:** the subtitle shift end to end over HTTP. Both attempts
+hit the pre-existing subtitle-extraction timeout on the Samba mount (§1.4) — unrelated to
+this change, and reproduced on the unmodified server. Coverage rests on the unit tests and
+the handler tests, which exercise the real HTTP path and the real cache. The browser-side
+confirmation of H4 (cues rendering in sync on resume) still needs a browser and remains
+recorded in §20.2 row 29.
+
+### 23.3 Known trade-off
+
+Copy-video sessions are now seekable only across what FFmpeg has produced, because the
+playlist no longer claims segments that do not exist. In practice the encoder runs several
+times faster than realtime and any seek more than 120 s ahead already rebases the session
+(`shouldRebaseHlsMovieSession`), so the exposure is a forward seek inside the no-rebase
+window during a session's first seconds — where the previous behaviour was a blocking wait
+followed by a `503`.
+
+### 23.4 Still open
+
+P2 and P3 are untouched: **H14** (stream-ordinal instability across re-scans — cheapest to
+fix now, while migrations are not required), **H7** (`audio_track` logged as a pointer),
+**H6** (preflight blocking the manifest), **H13**/**H20**, the accessibility gaps in
+§15.2 (recovery is still not announced; the error screen still has no `role="alert"`), and
+the P3 items including the scan-time keyframe index that would make H5 exact and enable
+segment reuse.

--- a/info.txt
+++ b/info.txt
@@ -1,0 +1,954 @@
+# Audit Igloo Web HLS Playback
+
+## Objective
+
+Perform a focused technical audit of HLS playback in the Igloo web application.
+
+Assume that the complete HLS path may contain bugs, incomplete behavior, incorrect assumptions, unnecessary transcoding, resource leaks, and architectural weaknesses.
+
+The audit must cover:
+
+1. The frontend `hls.js` integration.
+2. Native HLS playback where supported.
+3. Playback-mode selection leading into HLS.
+4. Audio and subtitle track selection.
+5. FFprobe metadata used by playback decisions.
+6. FFmpeg stream mapping, remuxing, decoding, and transcoding.
+7. HLS manifest and segment generation.
+8. Seeking and playback recovery.
+9. HLS session management.
+10. FFmpeg process lifecycle and cleanup.
+11. Watch-room HLS playback.
+12. Hardware acceleration where implemented.
+
+Do not assume the implementation is correct merely because common files play successfully.
+
+Actively search for:
+
+* Confirmed bugs.
+* Hidden edge cases.
+* Incorrect stream mapping.
+* Wrong default audio or subtitle tracks.
+* Invalid manifests or rendition relationships.
+* Unnecessary video or audio transcoding.
+* Incorrect remux decisions.
+* Browser compatibility problems.
+* Seeking failures.
+* Race conditions.
+* Duplicate sessions.
+* Stale segments.
+* Cross-session data exposure.
+* Abandoned FFmpeg processes.
+* Temporary-file leaks.
+* Weak error recovery.
+* Incorrect hardware-acceleration fallback.
+* Cases where the client reports a different playback mode from the mode actually used by the server.
+* Accessibility problems in HLS-specific controls.
+
+This is an investigation and recommendation task. Do not implement broad changes.
+
+Small diagnostic changes are permitted only when necessary to confirm a finding. Document every diagnostic change in the final report.
+
+Write the completed audit to:
+
+```text
+docs/web-hls-playback-audit.md
+```
+
+## Repository instructions
+
+Before beginning:
+
+* Read all applicable `CLAUDE.md` and `AGENTS.md` files.
+* Read `docs/web-direct-playback-audit.md`.
+* Read the authoritative FFmpeg and playback documentation identified by the repository instructions.
+* Follow repository-specific conventions and terminology.
+* Use the repository as the primary source of truth.
+* Reference concrete files, functions, handlers, and tests.
+* Do not repeat general project background already documented elsewhere.
+
+The direct-playback audit is supporting context, not proof that the HLS implementation is correct. Independently verify any HLS-related assumptions mentioned there.
+
+## Scope boundaries
+
+This audit is specifically about HLS playback.
+
+Inspect direct-playback code only where it affects:
+
+* Selection of HLS or remux.
+* Fallback from direct playback.
+* Preservation of position and track preferences.
+* Playback-mode reporting.
+* Duplicate requests or sessions.
+
+Do not repeat the complete direct-playback audit.
+
+The audit must distinguish clearly between:
+
+* HLS delivery with video and audio stream copy.
+* HLS delivery with video copy and audio transcode.
+* HLS delivery with video transcode and audio copy.
+* Full audio and video transcode.
+* Subtitle conversion.
+* Subtitle burn-in.
+* Native HLS playback.
+* HLS playback through `hls.js`.
+
+HLS is a delivery protocol and must not be treated as synonymous with full transcoding.
+
+## Required investigation
+
+## 1. Map the complete HLS architecture
+
+Trace the full HLS lifecycle from the user pressing Play until playback ends, fails, is abandoned, or changes mode.
+
+Document:
+
+* How HLS is selected.
+* How the requested profile is selected.
+* How selected video, audio, and subtitle tracks are represented.
+* How the frontend constructs HLS URLs.
+* How personal playback and watch-room playback differ.
+* Which backend endpoints are called.
+* How HLS sessions are identified.
+* How FFprobe metadata is loaded.
+* How FFmpeg commands are constructed.
+* How manifests and segments are created.
+* How `hls.js` or native HLS is initialized.
+* How quality, audio, and subtitle state is populated.
+* How seeking works.
+* How playback position is restored.
+* How errors are recovered.
+* How sessions and FFmpeg processes are stopped.
+* How temporary files are removed.
+
+Identify the relevant:
+
+* Routes.
+* Components.
+* Hooks.
+* Stores.
+* Services.
+* API clients.
+* Models.
+* FFprobe parsers.
+* FFmpeg command builders.
+* Manifest builders.
+* Session managers.
+* Watch-room handlers.
+* Cleanup routines.
+* Tests.
+
+Include file paths and important function names.
+
+## 2. Audit HLS pipeline selection
+
+Evaluate the logic that selects among:
+
+* Remux with video and audio copied.
+* Remux with video copied and audio transcoded.
+* Video transcode with audio copied.
+* Full transcode.
+* Subtitle conversion.
+* Subtitle burn-in.
+* Playback rejection.
+
+Determine whether the decision considers:
+
+* Input container.
+* Video codec.
+* Video profile and level.
+* Pixel format.
+* Bit depth.
+* Chroma subsampling.
+* Resolution.
+* Frame rate.
+* HDR metadata.
+* Audio codec.
+* Audio profile.
+* Channel count and layout.
+* Sample rate.
+* Subtitle codec.
+* Selected tracks.
+* Browser support.
+* Native HLS support.
+* User-selected quality.
+* Server encoder support.
+* Hardware acceleration.
+* Available CPU or session capacity.
+
+Look for cases where:
+
+* HLS is assumed to require transcoding.
+* Video is transcoded when only audio is incompatible.
+* Audio is transcoded unnecessarily.
+* Subtitles cause unnecessary video transcoding.
+* Unsupported streams are copied into HLS.
+* A requested remux silently becomes a full transcode.
+* The client continues displaying the requested mode instead of the effective mode.
+* A fallback profile is selected without being exposed to the client.
+* The same failing pipeline is repeatedly recreated.
+
+Document both the requested and effective playback profiles.
+
+## 3. Audit frontend `hls.js` and native HLS integration
+
+### Initialization and lifecycle
+
+Check:
+
+* HLS feature detection.
+* Native HLS detection.
+* Selection between native HLS and `hls.js`.
+* Dynamic import behavior.
+* Creation and destruction of `hls.js` instances.
+* Media attachment order.
+* Manifest loading order.
+* Playback readiness events.
+* Autoplay behavior.
+* Resume-position restoration.
+* React Strict Mode behavior.
+* Component remounts.
+* Source changes.
+* Stale closures.
+* Duplicate initialization.
+* Event-listener cleanup.
+* Cleanup after fatal errors.
+* Cleanup when switching movies.
+* Cleanup when navigating away.
+* Cleanup when changing playback profile or tracks.
+
+Determine whether multiple active `hls.js` instances or backend sessions can exist for the same player.
+
+### State synchronization
+
+Check whether the UI accurately reflects:
+
+* Requested profile.
+* Effective profile.
+* Current quality level.
+* Available quality levels.
+* Current audio rendition.
+* Available audio renditions.
+* Current subtitle rendition.
+* Available subtitle renditions.
+* Subtitle enabled or disabled state.
+* Buffering state.
+* Backend session state.
+* Playback errors.
+* Recovery attempts.
+
+Look for state that:
+
+* Is applied before manifest parsing.
+* Is overwritten after manifest parsing.
+* Leaks from one movie to another.
+* Does not reflect the actual active rendition.
+* Continues displaying remux after the server falls back to transcode.
+* Causes unnecessary session recreation.
+
+### Error handling
+
+Review handling of:
+
+* Manifest errors.
+* Network errors.
+* Fragment-load errors.
+* Buffer errors.
+* Media errors.
+* Decode errors.
+* Fatal and recoverable errors.
+* Authentication failures.
+* Capacity errors.
+* Expired sessions.
+* Missing segments.
+* Stale manifests.
+* Retry limits.
+* Recovery loops.
+* Media reattachment.
+* `hls.js` recreation.
+* User-facing diagnostics.
+
+Verify that the recovery logic matches the installed `hls.js` version and does not rely on deprecated patterns.
+
+## 4. Audit manifests and renditions
+
+Inspect generated master and media playlists.
+
+### Master playlist
+
+Check:
+
+* `#EXTM3U`.
+* HLS version.
+* `#EXT-X-STREAM-INF`.
+* `#EXT-X-MEDIA`.
+* `BANDWIDTH`.
+* `AVERAGE-BANDWIDTH`.
+* `CODECS`.
+* `RESOLUTION`.
+* `FRAME-RATE`.
+* Audio-group references.
+* Subtitle-group references.
+* Variant URLs.
+* Closed-caption declarations.
+
+Verify that declared codecs, resolution, frame rate, and bandwidth match the actual output.
+
+### Audio renditions
+
+Check:
+
+* `TYPE=AUDIO`.
+* `GROUP-ID`.
+* `NAME`.
+* `LANGUAGE`.
+* `DEFAULT`.
+* `AUTOSELECT`.
+* `CHANNELS`.
+* Rendition URLs.
+* Selected-track mapping.
+* Duplicate-language tracks.
+* Commentary tracks.
+* Audio-description tracks.
+* Missing language metadata.
+* Missing or multiple default dispositions.
+
+Determine whether:
+
+* The selected audio track maps to the correct FFmpeg input stream.
+* The intended track is selected initially.
+* Switching tracks works during playback.
+* Track names remain distinguishable.
+* Default and autoselect attributes are valid.
+* Channel declarations match the actual encoded output.
+
+### Subtitle renditions
+
+Check:
+
+* `TYPE=SUBTITLES`.
+* `GROUP-ID`.
+* `NAME`.
+* `LANGUAGE`.
+* `DEFAULT`.
+* `AUTOSELECT`.
+* `FORCED`.
+* Rendition URLs.
+* WebVTT validity.
+* Subtitle disabling.
+* Forced subtitles.
+* Hearing-impaired subtitles.
+* Duplicate-language subtitles.
+* Selected-track mapping.
+
+Determine whether image-based subtitles are correctly converted, burned in, rejected, or omitted instead of being exposed as invalid text renditions.
+
+### Media playlists and segments
+
+Check:
+
+* `#EXT-X-TARGETDURATION`.
+* `#EXT-X-MEDIA-SEQUENCE`.
+* `#EXTINF`.
+* `#EXT-X-ENDLIST`.
+* `#EXT-X-PLAYLIST-TYPE`.
+* `#EXT-X-INDEPENDENT-SEGMENTS`.
+* Initialization segments.
+* Discontinuities.
+* Segment duration.
+* Segment ordering.
+* Atomic playlist updates.
+* Partial-file exposure.
+* Completed-session behavior.
+
+## 5. Audit FFprobe metadata
+
+Inspect how FFprobe is invoked and how its output is stored.
+
+Check:
+
+* Video, audio, subtitle, attachment, and data streams.
+* Stream indexes.
+* Application-level track ordinals.
+* Codec names.
+* Codec tags.
+* Profiles.
+* Levels.
+* Pixel formats.
+* Bit depth.
+* Frame rate.
+* Resolution.
+* HDR and color metadata.
+* Channel layouts.
+* Sample rates.
+* Language tags.
+* Track titles.
+* Default dispositions.
+* Forced dispositions.
+* Commentary.
+* Dub and original indicators.
+* Hearing-impaired and visual-impaired indicators.
+* Attached pictures.
+* Uppercase or alternate metadata keys.
+* Missing and null fields.
+
+Determine whether the stored metadata is sufficient to:
+
+* Choose the correct pipeline.
+* Select the intended input streams.
+* Build correct codec declarations.
+* Build correct rendition names.
+* Identify defaults and forced tracks.
+* Exclude attachments and cover art.
+* Distinguish duplicate-language tracks.
+
+Pay special attention to any metadata limitations identified by the direct-playback audit. Verify whether they also affect HLS.
+
+## 6. Audit FFmpeg command construction
+
+Trace every FFmpeg command used for HLS.
+
+For each pipeline, document:
+
+* Input arguments.
+* Seek arguments.
+* Stream mapping.
+* Decoder selection.
+* Filter graph.
+* Video encoder or stream copy.
+* Audio encoder or stream copy.
+* Subtitle handling.
+* Timestamp handling.
+* Metadata handling.
+* Output container.
+* HLS options.
+* Log handling.
+* Process ownership.
+* Cancellation.
+* Cleanup.
+
+### Stream mapping
+
+Check for:
+
+* Missing explicit `-map`.
+* Incorrect video mapping.
+* Incorrect audio mapping.
+* Incorrect subtitle mapping.
+* Mapping by an unstable or misunderstood index.
+* Mapping the first stream instead of the selected stream.
+* Mapping attached pictures as video.
+* Accidentally including all streams.
+* Accidentally dropping required streams.
+* Incorrect subtitle burn-in mapping.
+* Duplicate-language ambiguity.
+* Lost language metadata.
+* Lost track titles.
+* Lost default or forced dispositions.
+
+Verify that client track ordinals are translated safely into FFmpeg stream selectors.
+
+### Remux and transcode decisions
+
+Check:
+
+* `-c:v copy`.
+* `-c:a copy`.
+* Video transcoding.
+* Audio transcoding.
+* Subtitle conversion.
+* Subtitle burn-in.
+* Required bitstream filters.
+* Segment-format compatibility.
+* Timestamp normalization.
+* Codec and container compatibility.
+* Output filename and actual format agreement.
+
+Look for:
+
+* Copying codecs that browsers cannot decode.
+* Copying streams into an incompatible HLS segment format.
+* Video transcoding when stream copy is safe.
+* Audio transcoding when stream copy is safe.
+* Audio copy when the browser cannot decode it.
+* Full transcoding when partial transcoding is sufficient.
+* Remux preflight failures that trigger an undocumented effective profile.
+
+## 7. Audit video decoding and encoding
+
+### Decoding
+
+Check:
+
+* Automatic versus explicit decoder selection.
+* Software decoding.
+* Hardware decoding.
+* Decoder availability.
+* Hardware-device initialization.
+* Software fallback.
+* Hardware-frame transfer.
+* Filter compatibility.
+* Corrupt-frame handling.
+* Decode failures.
+* 10-bit input.
+* HDR input.
+* Interlaced content.
+* Rotation.
+* Variable frame rate.
+* Pixel-format conversion.
+* Color metadata.
+
+### Encoding
+
+Check:
+
+* Encoder selection.
+* Encoder availability.
+* Software versus hardware encoding.
+* Profile.
+* Level.
+* Pixel format.
+* Preset.
+* CRF or quality mode.
+* Bitrate.
+* Maximum bitrate.
+* Buffer size.
+* Resolution scaling.
+* Aspect ratio.
+* Frame rate.
+* GOP size.
+* Keyframe interval.
+* Forced keyframes.
+* Scene-cut behavior.
+* HDR-to-SDR tone mapping.
+* Color metadata.
+* Startup latency.
+* Browser compatibility.
+
+Determine whether the output is browser-compatible rather than merely valid FFmpeg output.
+
+## 8. Audit audio transcoding
+
+Check:
+
+* Selected input stream.
+* Audio stream-copy eligibility.
+* Output codec.
+* AAC profile.
+* Channel count.
+* Channel layout.
+* Downmixing.
+* Sample rate.
+* Bitrate.
+* Audio delay.
+* Timestamp alignment.
+* Loudness changes.
+* Clipping risk.
+* Dialogue normalization.
+* Metadata preservation.
+* Default disposition.
+
+Evaluate represented codecs including:
+
+* AAC.
+* AC-3.
+* E-AC-3.
+* DTS.
+* TrueHD.
+* Opus.
+* FLAC.
+* MP3.
+* Other codecs present in the repository.
+
+Determine whether:
+
+* Compatible audio is copied safely.
+* Unsupported audio is always converted.
+* Multi-channel output is browser-compatible.
+* Downmixing is deterministic.
+* Atmos metadata is preserved, removed, or incorrectly assumed to survive.
+* The selected track is always the track that reaches the output.
+
+## 9. Audit subtitle processing
+
+Check:
+
+* Embedded subtitle extraction.
+* WebVTT conversion.
+* Character encoding.
+* Subtitle timing.
+* Timestamp offsets.
+* ASS and SSA conversion.
+* PGS and other image subtitles.
+* Subtitle burn-in.
+* Font attachments.
+* Font availability.
+* Temporary subtitle files.
+* Forced subtitles.
+* Hearing-impaired subtitles.
+* Subtitle switching.
+* Subtitle disabling.
+* Synchronization after seeking.
+* Cleanup.
+
+Determine whether subtitles are correctly classified as:
+
+* Directly deliverable.
+* Convertible to WebVTT.
+* Requiring burn-in.
+* Unsupported.
+* Safe to ignore when disabled.
+
+Look specifically for subtitle selections that cause unnecessary video transcoding.
+
+## 10. Audit segment generation and seeking
+
+Inspect all HLS-related FFmpeg options.
+
+Check:
+
+* VOD versus event playlists.
+* `hls_time`.
+* `hls_list_size`.
+* `hls_playlist_type`.
+* `hls_flags`.
+* MPEG-TS versus fragmented MP4.
+* Initialization segments.
+* Segment naming.
+* Keyframe alignment.
+* Forced keyframes.
+* GOP size.
+* Independent segments.
+* Temporary files.
+* Atomic updates.
+* Partial segment exposure.
+* Segment caching.
+* Segment reuse.
+* Start numbers.
+* Completed playlists.
+* Restarted transcodes.
+
+Determine whether:
+
+* The first playable segment is produced quickly.
+* Segment boundaries align with keyframes.
+* Segment durations match playlist declarations.
+* Seeking works before the entire file is generated.
+* Seeking creates duplicate FFmpeg processes.
+* A seek can return stale segments.
+* A seek restarts too much work.
+* Partially written segments can be served.
+* Existing segments can be reused safely.
+
+## 11. Audit session and process lifecycle
+
+Evaluate both personal playback and watch-room HLS sessions.
+
+### Session management
+
+Check:
+
+* Session identifiers.
+* User isolation.
+* Movie isolation.
+* Profile isolation.
+* Audio-track isolation.
+* Subtitle-track isolation.
+* Watch-room isolation.
+* Temporary-directory names.
+* Segment names.
+* Session collisions.
+* Stale sessions.
+* Session reuse.
+* Duplicate sessions.
+* Multiple tabs.
+* Multiple users.
+* Audio changes.
+* Subtitle changes.
+* Quality changes.
+* Server restarts.
+* Completed sessions.
+* Failed sessions.
+
+Determine whether one user or playback configuration can receive manifests or segments generated for another.
+
+### FFmpeg processes
+
+Check:
+
+* Process creation.
+* Context cancellation.
+* Client disconnect handling.
+* Graceful termination.
+* Forced termination.
+* Zombie processes.
+* Child-process cleanup.
+* Standard output and error handling.
+* Pipe backpressure.
+* Exit codes.
+* Startup failures.
+* Runtime failures.
+* Timeouts.
+* Duplicate transcodes.
+* Session sharing.
+* Reference counting.
+* Concurrency limits.
+* Queueing.
+* CPU and GPU saturation.
+* Disk exhaustion.
+* Temporary-directory cleanup.
+
+Determine whether FFmpeg continues running after:
+
+* The player closes.
+* The tab closes.
+* The user navigates away.
+* The user switches movies.
+* The user seeks.
+* The user changes audio.
+* The user changes subtitles.
+* The user changes quality.
+* `hls.js` is destroyed.
+* The network disconnects.
+* Playback ends.
+* FFmpeg fails.
+
+## 12. Audit watch-room HLS playback
+
+Inspect the watch-room path independently instead of assuming it matches personal playback.
+
+Check:
+
+* Creation-time validation.
+* Warm-up.
+* Audio-track validation.
+* Subtitle-track validation.
+* Video-only movies.
+* Selected tracks.
+* Playback-mode validation.
+* Manifest generation.
+* Session sharing between participants.
+* Host and participant synchronization.
+* Participant isolation.
+* Cleanup after the room ends.
+* Behavior when the movie is deleted.
+* Behavior when FFmpeg fails during warm-up.
+* Whether personal and watch-room paths apply the same stream-selection rules.
+
+Specifically test legitimate video-only files. A movie without audio must not receive a synthetic audio-track selection or fail solely because no audio stream exists.
+
+## 13. Audit hardware acceleration
+
+Where hardware acceleration is implemented, check:
+
+* FFmpeg build support.
+* Device detection.
+* Encoder detection.
+* Decoder detection.
+* Runtime permissions.
+* Driver assumptions.
+* Hardware upload and download filters.
+* Pixel-format conversion.
+* Scaling.
+* Tone mapping.
+* Software-filter compatibility.
+* Software fallback.
+* Concurrency.
+* Device contention.
+* Error reporting.
+* Output codec profile and level.
+* Browser compatibility.
+
+Look for:
+
+* Hardware encoding being selected because an encoder name exists, without validating the complete command.
+* Hardware decoding combined with incompatible software filters.
+* Failed hardware commands that do not retry safely in software.
+* Software fallback retaining hardware-only arguments.
+* Different effective output between hardware and software paths without correct manifest updates.
+
+## 14. Evaluate HLS-specific player controls
+
+Evaluate the existing custom player only for HLS-specific behavior:
+
+* Quality selection.
+* Audio-rendition selection.
+* Subtitle-rendition selection.
+* Effective-profile reporting.
+* Buffering feedback.
+* Recovery feedback.
+* Capacity feedback.
+* Keyboard access.
+* Focus management.
+* Screen-reader labels.
+* Track-change announcements.
+* Error announcements.
+* Maintainability.
+
+Determine whether the current custom player can support the required HLS controls using existing project components.
+
+Research player packages only if the current implementation has a confirmed limitation that cannot reasonably be addressed with existing components.
+
+A player package does not fix:
+
+* Incorrect manifests.
+* Incorrect FFmpeg commands.
+* Stream-mapping bugs.
+* Session leaks.
+* Seeking architecture.
+* Unsupported codecs.
+* Hardware-acceleration failures.
+
+## 15. Testing strategy
+
+Review existing tests and identify missing coverage.
+
+Create a practical test matrix containing at least:
+
+* H.264 and AAC requiring packaging only.
+* H.264 with incompatible audio requiring audio-only transcoding.
+* H.264 remux that fails safety preflight.
+* HEVC requiring video transcode.
+* 10-bit HEVC.
+* HDR10.
+* Dolby Vision where represented.
+* Interlaced video.
+* Variable-frame-rate video.
+* Multiple audio tracks.
+* Duplicate-language audio.
+* Commentary audio.
+* Audio-description tracks.
+* Video-only files.
+* Multiple subtitle tracks.
+* Forced subtitles.
+* Hearing-impaired subtitles.
+* ASS or SSA subtitles.
+* PGS subtitles.
+* External subtitles where supported.
+* Missing language metadata.
+* Missing default dispositions.
+* Multiple default dispositions.
+* Attached cover art.
+* Multiple video streams.
+* DTS.
+* TrueHD.
+* AC-3.
+* E-AC-3.
+* Corrupt or incomplete files.
+* Large 4K files.
+* Seeking before generation completes.
+* Multiple tabs.
+* Multiple users.
+* Watch-room playback.
+
+For each case, define:
+
+* Expected requested profile.
+* Expected effective profile.
+* Expected FFmpeg operation.
+* Expected selected video stream.
+* Expected selected audio stream.
+* Expected subtitle behavior.
+* Expected output codecs.
+* Expected manifest structure.
+* Expected segment behavior.
+* Expected seeking behavior.
+* Expected cleanup behavior.
+* Browsers to test.
+* Whether the test can be automated.
+* Whether manual validation is required.
+
+Recommend:
+
+* Playback-decision unit tests.
+* FFprobe parser tests.
+* FFmpeg command-generation tests.
+* Golden command tests.
+* Manifest validation tests.
+* Segment validation tests.
+* API integration tests.
+* Browser and Playwright tests.
+* Track-switching tests.
+* Seeking tests.
+* Error-recovery tests.
+* Watch-room tests.
+* Session-isolation tests.
+* Process-cleanup tests.
+* Concurrency tests.
+* Hardware-fallback tests.
+* Performance tests.
+* Accessibility tests.
+
+## Required deliverable
+
+Produce a structured Markdown report at:
+
+```text
+docs/web-hls-playback-audit.md
+```
+
+Use these sections:
+
+1. Scope and methodology.
+2. Current HLS architecture.
+3. HLS pipeline-selection assessment.
+4. Frontend and `hls.js` assessment.
+5. Manifest and rendition assessment.
+6. FFprobe metadata assessment.
+7. FFmpeg stream-mapping and command assessment.
+8. Video decoding and encoding assessment.
+9. Audio transcoding assessment.
+10. Subtitle-processing assessment.
+11. Segment-generation and seeking assessment.
+12. Session and FFmpeg lifecycle assessment.
+13. Watch-room HLS assessment.
+14. Hardware-acceleration assessment.
+15. HLS player-controls assessment.
+16. Confirmed bugs.
+17. Likely bugs and risks.
+18. Recommended HLS architecture.
+19. Prioritized action plan.
+20. Test matrix and testing plan.
+21. Diagnostic changes.
+22. Final answers to the audit questions.
+
+## Required conclusions
+
+The report must explicitly answer:
+
+1. Is the current HLS implementation reliable?
+2. Are remux, partial-transcode, and full-transcode decisions correct?
+3. Are the selected audio and subtitle tracks always honored?
+4. Are manifests valid and accurately describing the output?
+5. Does seeking work correctly before generation completes?
+6. Can sessions or segments collide or leak across users?
+7. Can FFmpeg processes continue after playback ends?
+8. Is hardware acceleration safe and deterministic?
+9. Does the client display the actual effective playback mode?
+10. Should the custom player remain?
+11. What must be fixed before HLS playback can be considered production-ready?
+
+## Investigation rules
+
+* Read the implementation before reaching conclusions.
+* Inspect both frontend and backend HLS code.
+* Inspect personal and watch-room playback separately.
+* Follow all applicable repository instructions.
+* Support confirmed findings with repository evidence.
+* Reference concrete files and functions.
+* Clearly separate confirmed defects from hypotheses.
+* Explicitly identify uncertainty.
+* Do not assume native-client capabilities apply to browsers.
+* Do not treat HLS as synonymous with transcoding.
+* Distinguish requested and effective playback profiles.
+* Do not assume FFmpeg defaults select the intended streams.
+* Prefer explicit stream mapping.
+* Do not assume a player package fixes backend problems.
+* Prefer deterministic playback decisions.
+* Account for limited home-server CPU, GPU, memory, disk, and network resources.
+* Treat accessibility as mandatory.
+* Do not make broad code changes during the audit.
+* Do not repeat the completed direct-playback audit.
+* Do not stop after finding the first known issue.
+* Look for failures not currently covered by tests.

--- a/server/cmd/api/disk_space.go
+++ b/server/cmd/api/disk_space.go
@@ -1,0 +1,21 @@
+//go:build linux || darwin
+
+package main
+
+import "syscall"
+
+// freeDiskBytes reports the space available at path to an unprivileged writer.
+//
+// Statfs_t types the block size differently on the two supported platforms
+// (int64 on Linux, uint32 on Darwin), but the conversion below compiles on
+// both, so this needs no per-platform variant.
+func freeDiskBytes(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+
+	err := syscall.Statfs(path, &stat)
+	if err != nil {
+		return 0, err
+	}
+
+	return stat.Bavail * uint64(stat.Bsize), nil
+}

--- a/server/cmd/api/hls_actual_start_test.go
+++ b/server/cmd/api/hls_actual_start_test.go
@@ -60,6 +60,7 @@ func TestMeasureHLSSessionStart_RecordsKeyframeBeforeRequestedStart(t *testing.T
 
 	app.Wait.Add(1)
 	app.measureHLSSessionStart(context.Background(), session, "/movies/example.mp4", 0, 600)
+	app.Wait.Wait()
 
 	if prober.calls != 1 {
 		t.Fatalf("keyframe probe calls = %d, want 1", prober.calls)
@@ -86,6 +87,7 @@ func TestMeasureHLSSessionStart_LeavesStartUnknownOnFailure(t *testing.T) {
 
 	app.Wait.Add(1)
 	app.measureHLSSessionStart(context.Background(), session, "/movies/example.mp4", 0, 600)
+	app.Wait.Wait()
 
 	if got := session.actualStartSec(); got >= 0 {
 		t.Fatalf("actual start = %v, want it to stay unknown", got)

--- a/server/cmd/api/hls_actual_start_test.go
+++ b/server/cmd/api/hls_actual_start_test.go
@@ -59,7 +59,7 @@ func TestMeasureHLSSessionStart_RecordsKeyframeBeforeRequestedStart(t *testing.T
 	session.setActualStartSec(hlsUnknownActualStart)
 
 	app.Wait.Add(1)
-	app.measureHLSSessionStart(session, "/movies/example.mp4", 0, 600)
+	app.measureHLSSessionStart(context.Background(), session, "/movies/example.mp4", 0, 600)
 
 	if prober.calls != 1 {
 		t.Fatalf("keyframe probe calls = %d, want 1", prober.calls)
@@ -85,7 +85,7 @@ func TestMeasureHLSSessionStart_LeavesStartUnknownOnFailure(t *testing.T) {
 	session.setActualStartSec(hlsUnknownActualStart)
 
 	app.Wait.Add(1)
-	app.measureHLSSessionStart(session, "/movies/example.mp4", 0, 600)
+	app.measureHLSSessionStart(context.Background(), session, "/movies/example.mp4", 0, 600)
 
 	if got := session.actualStartSec(); got >= 0 {
 		t.Fatalf("actual start = %v, want it to stay unknown", got)

--- a/server/cmd/api/hls_actual_start_test.go
+++ b/server/cmd/api/hls_actual_start_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"igloo/cmd/internal/ffprobe"
+)
+
+// stubKeyframeFfprobe answers the keyframe lookup that measures where a
+// copy-video session's media really begins.
+type stubKeyframeFfprobe struct {
+	keyframeSec float64
+	err         error
+
+	mu     sync.Mutex
+	target float64
+	calls  int
+}
+
+func (s *stubKeyframeFfprobe) GetMetadata(string) (*ffprobe.FfprobeResult, error) {
+	return nil, errors.New("not used")
+}
+
+func (s *stubKeyframeFfprobe) GetAudioMetadata(string) (*ffprobe.FfprobeResult, error) {
+	return nil, errors.New("not used")
+}
+
+func (s *stubKeyframeFfprobe) KeyframeAtOrBefore(
+	_ context.Context,
+	_ string,
+	_ int64,
+	targetSec float64,
+) (float64, error) {
+	s.mu.Lock()
+	s.target = targetSec
+	s.calls++
+	s.mu.Unlock()
+
+	if s.err != nil {
+		return 0, s.err
+	}
+	return s.keyframeSec, nil
+}
+
+func TestMeasureHLSSessionStart_RecordsKeyframeBeforeRequestedStart(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+
+	app.Wait = &sync.WaitGroup{}
+	prober := &stubKeyframeFfprobe{keyframeSec: 591.174}
+	app.Ffprobe = prober
+
+	session := &HLSSession{MovieID: 1, CopyVideo: true, StartSec: 600}
+	session.setActualStartSec(hlsUnknownActualStart)
+
+	app.Wait.Add(1)
+	app.measureHLSSessionStart(session, "/movies/example.mp4", 0, 600)
+
+	if prober.calls != 1 {
+		t.Fatalf("keyframe probe calls = %d, want 1", prober.calls)
+	}
+	if prober.target != 600 {
+		t.Fatalf("probe target = %v, want 600", prober.target)
+	}
+	if got := session.actualStartSec(); got != 591.174 {
+		t.Fatalf("actual start = %v, want 591.174", got)
+	}
+}
+
+// The probe is advisory: a failure must leave the start unknown rather than
+// publish a wrong one, so the client keeps its existing fallback.
+func TestMeasureHLSSessionStart_LeavesStartUnknownOnFailure(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+
+	app.Wait = &sync.WaitGroup{}
+	app.Ffprobe = &stubKeyframeFfprobe{err: errors.New("probe failed")}
+
+	session := &HLSSession{MovieID: 1, CopyVideo: true, StartSec: 600}
+	session.setActualStartSec(hlsUnknownActualStart)
+
+	app.Wait.Add(1)
+	app.measureHLSSessionStart(session, "/movies/example.mp4", 0, 600)
+
+	if got := session.actualStartSec(); got >= 0 {
+		t.Fatalf("actual start = %v, want it to stay unknown", got)
+	}
+}
+
+func TestWriteHLSPlaylistHeaders_PublishesEffectiveProfileAndStart(t *testing.T) {
+	session := &HLSSession{
+		EffectiveProfile: "1080p_8mbps",
+		ActualStartSec:   591.174,
+	}
+
+	recorder := httptest.NewRecorder()
+	writeHLSPlaylistHeaders(recorder, session)
+
+	if got := recorder.Header().Get(hlsEffectiveProfileHeader); got != "1080p_8mbps" {
+		t.Fatalf("effective profile header = %q, want 1080p_8mbps", got)
+	}
+
+	start, err := strconv.ParseFloat(recorder.Header().Get(hlsActualStartHeader), 64)
+	if err != nil {
+		t.Fatalf("actual start header did not parse: %v", err)
+	}
+	if start != 591.174 {
+		t.Fatalf("actual start header = %v, want 591.174", start)
+	}
+}
+
+// A remux request that falls back still serves from the /hls/remux/ path, so
+// the header is the only thing that can tell the client what it is getting.
+func TestWriteHLSPlaylistHeaders_ReportsFallbackProfile(t *testing.T) {
+	session := &HLSSession{EffectiveProfile: "2160p_16mbps", ActualStartSec: 0}
+
+	recorder := httptest.NewRecorder()
+	writeHLSPlaylistHeaders(recorder, session)
+
+	if got := recorder.Header().Get(hlsEffectiveProfileHeader); got != "2160p_16mbps" {
+		t.Fatalf("effective profile header = %q, want the profile that actually ran", got)
+	}
+}
+
+func TestWriteHLSPlaylistHeaders_OmitsUnknownStart(t *testing.T) {
+	session := &HLSSession{EffectiveProfile: "remux", ActualStartSec: hlsUnknownActualStart}
+
+	recorder := httptest.NewRecorder()
+	writeHLSPlaylistHeaders(recorder, session)
+
+	if got := recorder.Header().Get(hlsActualStartHeader); got != "" {
+		t.Fatalf("unknown start must not be published, got %q", got)
+	}
+}

--- a/server/cmd/api/hls_handler.go
+++ b/server/cmd/api/hls_handler.go
@@ -55,6 +55,10 @@ var errHLSPlaylistNotReady = errors.New("playlist not ready")
 // same offset cannot help, so it is reported as not found rather than busy.
 var errHLSSessionEmpty = errors.New("no playable media at this position")
 
+// errHLSSessionFailed means FFmpeg exited with an error before publishing a
+// playlist — a server-side failure, not a client error.
+var errHLSSessionFailed = errors.New("transcoding stopped before publishing a playlist")
+
 type hlsRequestParams struct {
 	MovieID         int64
 	Profile         string
@@ -258,7 +262,7 @@ func buildHLSPlaylistBody(
 		if finalPlaylist != "" {
 			return rewritePlaylistURLs(finalPlaylist, baseURL, querySuffix), nil
 		}
-		return generateVODPlaylist(durationSec, baseURL, querySuffix, false), nil
+		return generateVODPlaylist(durationSec, baseURL, querySuffix), nil
 	}
 
 	ticker := time.NewTicker(hlsRemuxPreflightPoll)
@@ -284,7 +288,7 @@ func buildHLSPlaylistBody(
 		exited, exitErr := session.exitStatus()
 		if exited {
 			if exitErr != nil {
-				return "", fmt.Errorf("transcoding stopped before publishing a playlist: %w", exitErr)
+				return "", fmt.Errorf("%w: %v", errHLSSessionFailed, exitErr)
 			}
 			return "", errHLSSessionEmpty
 		}
@@ -359,6 +363,11 @@ func sessionPlaylistDurationSec(session *HLSSession) float64 {
 func writeHLSSessionError(w http.ResponseWriter, err error) {
 	if errors.Is(err, errHLSSessionNotFound) || errors.Is(err, errHLSSessionEmpty) {
 		helpers.ErrorJSON(w, err, http.StatusNotFound)
+		return
+	}
+
+	if errors.Is(err, errHLSSessionFailed) {
+		helpers.ErrorJSON(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/server/cmd/api/hls_handler.go
+++ b/server/cmd/api/hls_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -18,8 +19,11 @@ import (
 
 const (
 	hlsTranscodeBusyRetryAfterSec = 5
-	hlsPlaybackSessionIDPattern   = `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`
-	hlsSegmentWait                = 120 * time.Second
+	// A session that has not published its first segment yet is seconds away,
+	// not minutes, so it gets a shorter retry hint than a capacity refusal.
+	hlsPlaylistRetryAfterSec    = 1
+	hlsPlaybackSessionIDPattern = `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`
+	hlsSegmentWait              = 120 * time.Second
 	// A segment that lands just after a check waits a full interval before it
 	// is served, and that wait is on the startup and post-seek path. The check
 	// is one or two stats against page-cached directory entries, so polling
@@ -28,14 +32,28 @@ const (
 	// waitForRemuxPreflight stats the init segment plus every segment it is
 	// waiting on, on every pass, so it keeps the relaxed cadence the tight
 	// single-segment availability check above can afford to drop.
-	hlsRemuxPreflightPoll     = 250 * time.Millisecond
+	hlsRemuxPreflightPoll = 250 * time.Millisecond
+	// Copy-video manifests are read back from FFmpeg rather than synthesized,
+	// so the first request for one waits for FFmpeg to publish a segment.
+	hlsLivePlaylistWait       = 30 * time.Second
 	hlsPlaylistContentType    = "application/vnd.apple.mpegurl"
 	hlsSegmentHTTPContentType = "video/mp4"
+	hlsEffectiveProfileHeader = "X-Igloo-Effective-Profile"
+	hlsActualStartHeader      = "X-Igloo-Actual-Start"
 )
 
 var hlsPlaybackSessionIDRegexp = regexp.MustCompile(hlsPlaybackSessionIDPattern)
 
 var errHLSSessionNotFound = errors.New("session not found")
+
+// errHLSPlaylistNotReady means FFmpeg has not published a usable playlist yet.
+// It is retryable: the session is healthy, it just has not produced output.
+var errHLSPlaylistNotReady = errors.New("playlist not ready")
+
+// errHLSSessionEmpty means FFmpeg finished without producing playable media,
+// which happens when a session starts past the end of a stream. Retrying the
+// same offset cannot help, so it is reported as not found rather than busy.
+var errHLSSessionEmpty = errors.New("no playable media at this position")
 
 type hlsRequestParams struct {
 	MovieID         int64
@@ -84,7 +102,15 @@ func (app *Application) HLSManifest(w http.ResponseWriter, r *http.Request) {
 		Reload:          params.Reload,
 	})
 
-	playlist := buildHLSPlaylistBody(session, sessionPlaylistDurationSec(session), baseURL, querySuffix)
+	playlist, err := buildHLSPlaylistBody(r.Context(), session, sessionPlaylistDurationSec(session), baseURL, querySuffix)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		app.Logger.Error("hls playlist unavailable", "error", err, "movie_id", params.MovieID)
+		writeHLSSessionError(w, err)
+		return
+	}
 
 	refreshed := app.RefreshHLSSessionTTL(key, session)
 	if !refreshed {
@@ -92,10 +118,32 @@ func (app *Application) HLSManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", hlsPlaylistContentType)
-	w.Header().Set("Cache-Control", "no-store")
+	writeHLSPlaylistHeaders(w, session)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(playlist))
+}
+
+// writeHLSPlaylistHeaders publishes the delivery shape the client cannot infer
+// from the request. The requested profile is in the URL, but the profile the
+// server actually ran may differ (remux falling back to a transcode), and a
+// copy-video session starts at the source keyframe at or before the requested
+// offset rather than at the offset itself.
+func writeHLSPlaylistHeaders(w http.ResponseWriter, session *HLSSession) {
+	w.Header().Set("Content-Type", hlsPlaylistContentType)
+	w.Header().Set("Cache-Control", "no-store")
+
+	if session == nil {
+		return
+	}
+
+	if session.EffectiveProfile != "" {
+		w.Header().Set(hlsEffectiveProfileHeader, session.EffectiveProfile)
+	}
+
+	actualStart := session.actualStartSec()
+	if actualStart >= 0 {
+		w.Header().Set(hlsActualStartHeader, strconv.FormatFloat(actualStart, 'f', 3, 64))
+	}
 }
 
 // FFmpeg writes segments asynchronously; serve only once complete.
@@ -141,16 +189,116 @@ func (app *Application) HLSSegment(w http.ResponseWriter, r *http.Request) {
 	serveReadyHLSSegment(w, r, session, filename)
 }
 
-func buildHLSPlaylistBody(session *HLSSession, durationSec float64, baseURL, querySuffix string) string {
-	session.ExitMu.Lock()
-	finalPlaylist := session.FinalPlaylist
-	session.ExitMu.Unlock()
-
-	if finalPlaylist != "" {
-		return rewritePlaylistURLs(finalPlaylist, baseURL, querySuffix)
+// readLiveHLSPlaylist returns the playlist FFmpeg is currently writing. FFmpeg
+// renames a temporary file into place, so a successful read is never torn, and
+// it appends a segment only once that segment is closed.
+//
+// A playlist is only usable once it describes real media. A session that seeks
+// past the end of a stream still exits cleanly, having written one empty
+// segment declared as `#EXTINF:0.000000` under `#EXT-X-TARGETDURATION:0` —
+// which is not a valid playlist and is not playable. Serving that would trade
+// one bad manifest for another, so it is rejected here and the caller reports
+// the session as having produced nothing.
+func readLiveHLSPlaylist(tempDir string) (string, error) {
+	raw, err := os.ReadFile(filepath.Join(tempDir, helpers.HLS_PLAYLIST_FILENAME))
+	if err != nil {
+		return "", err
 	}
 
-	return generateVODPlaylist(durationSec, baseURL, querySuffix, session.CopyVideo)
+	playlist := string(raw)
+	if !hasPlayableSegment(playlist) {
+		return "", errHLSPlaylistNotReady
+	}
+
+	return playlist, nil
+}
+
+// hasPlayableSegment reports whether a playlist declares at least one segment
+// with a positive duration.
+func hasPlayableSegment(playlist string) bool {
+	for _, line := range strings.Split(playlist, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#EXTINF:") {
+			continue
+		}
+
+		value := strings.TrimPrefix(trimmed, "#EXTINF:")
+		value = strings.TrimSuffix(strings.TrimSpace(value), ",")
+
+		duration, parseErr := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if parseErr == nil && duration > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildHLSPlaylistBody returns the media playlist for a session.
+//
+// Transcode sessions pin keyframes to the segment cadence, so a playlist
+// synthesized from the movie duration describes the output exactly. Copy-video
+// sessions can only split on source keyframes, so their segment durations and
+// count are whatever the source encode dictates: synthesizing those advertises
+// durations FFmpeg never produces and segments that will never exist. They are
+// read back from FFmpeg instead, and the request waits for the first one.
+func buildHLSPlaylistBody(
+	ctx context.Context,
+	session *HLSSession,
+	durationSec float64,
+	baseURL string,
+	querySuffix string,
+) (string, error) {
+	if session == nil {
+		return "", errHLSSessionNotFound
+	}
+
+	if !session.CopyVideo {
+		finalPlaylist := session.currentFinalPlaylist()
+		if finalPlaylist != "" {
+			return rewritePlaylistURLs(finalPlaylist, baseURL, querySuffix), nil
+		}
+		return generateVODPlaylist(durationSec, baseURL, querySuffix, false), nil
+	}
+
+	ticker := time.NewTicker(hlsRemuxPreflightPoll)
+	defer ticker.Stop()
+
+	deadline := time.Now().Add(hlsLivePlaylistWait)
+	for {
+		// onExit publishes FinalPlaylist before it marks the session exited, so
+		// checking it first closes the race against a session finishing here.
+		finalPlaylist := session.currentFinalPlaylist()
+		if finalPlaylist != "" {
+			if !hasPlayableSegment(finalPlaylist) {
+				return "", errHLSSessionEmpty
+			}
+			return rewritePlaylistURLs(finalPlaylist, baseURL, querySuffix), nil
+		}
+
+		livePlaylist, readErr := readLiveHLSPlaylist(session.TempDir)
+		if readErr == nil {
+			return rewritePlaylistURLs(livePlaylist, baseURL, querySuffix), nil
+		}
+
+		exited, exitErr := session.exitStatus()
+		if exited {
+			if exitErr != nil {
+				return "", fmt.Errorf("transcoding stopped before publishing a playlist: %w", exitErr)
+			}
+			return "", errHLSSessionEmpty
+		}
+
+		if !time.Now().Before(deadline) {
+			return "", errHLSPlaylistNotReady
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func serveReadyHLSSegment(w http.ResponseWriter, r *http.Request, session *HLSSession, filename string) {
@@ -168,11 +316,7 @@ func serveReadyHLSSegment(w http.ResponseWriter, r *http.Request, session *HLSSe
 			return
 		}
 
-		session.ExitMu.Lock()
-		exited := session.Exited
-		exitErr := session.ExitErr
-		session.ExitMu.Unlock()
-
+		exited, exitErr := session.exitStatus()
 		if exited && !fileReady(filePath) {
 			if exitErr != nil {
 				helpers.ErrorJSON(w, errors.New("transcoding stopped"), http.StatusInternalServerError)
@@ -213,7 +357,7 @@ func sessionPlaylistDurationSec(session *HLSSession) float64 {
 }
 
 func writeHLSSessionError(w http.ResponseWriter, err error) {
-	if errors.Is(err, errHLSSessionNotFound) {
+	if errors.Is(err, errHLSSessionNotFound) || errors.Is(err, errHLSSessionEmpty) {
 		helpers.ErrorJSON(w, err, http.StatusNotFound)
 		return
 	}
@@ -231,8 +375,25 @@ func writeHLSSessionError(w http.ResponseWriter, err error) {
 		helpers.ErrorJSON(w, err, http.StatusServiceUnavailable)
 		return
 	}
+
+	var storageErr *hlsStorageCapacityError
+	if errors.As(err, &storageErr) {
+		w.Header().Set("Retry-After", strconv.Itoa(hlsTranscodeBusyRetryAfterSec))
+		helpers.ErrorJSON(w, err, http.StatusServiceUnavailable)
+		return
+	}
+
+	// The session is healthy, FFmpeg just has not published output yet, so the
+	// client should come back rather than treat this as a failed session.
+	if errors.Is(err, errHLSPlaylistNotReady) {
+		w.Header().Set("Retry-After", strconv.Itoa(hlsPlaylistRetryAfterSec))
+		helpers.ErrorJSON(w, err, http.StatusServiceUnavailable)
+		return
+	}
+
 	helpers.ErrorJSON(w, err, http.StatusBadRequest)
 }
+
 func (app *Application) StopPersonalHLSSession(w http.ResponseWriter, r *http.Request) {
 	userID, ok := app.currentUserID(w, r)
 	if !ok {

--- a/server/cmd/api/hls_handler_test.go
+++ b/server/cmd/api/hls_handler_test.go
@@ -224,22 +224,24 @@ func TestBuildHLSPlaylistBody_CopyVideoExitedWithoutPlaylist(t *testing.T) {
 }
 
 func TestServeReadyHLSSegment(t *testing.T) {
-	t.Run("serves completed segment with shared headers", func(t *testing.T) {
-		tempDir := t.TempDir()
-		filename := helpers.HLS_SEGMENT_FILENAME_PREFIX + "0" + helpers.HLS_SEGMENT_FILENAME_SUFFIX
-		nextFilename := helpers.HLS_SEGMENT_FILENAME_PREFIX + "1" + helpers.HLS_SEGMENT_FILENAME_SUFFIX
-		err := os.WriteFile(filepath.Join(tempDir, filename), []byte("segment payload"), 0o600)
-		if err != nil {
-			t.Fatalf("write segment: %v", err)
-		}
-		err = os.WriteFile(filepath.Join(tempDir, nextFilename), []byte("next segment"), 0o600)
-		if err != nil {
-			t.Fatalf("write next segment: %v", err)
-		}
+	tempDir := t.TempDir()
+	filename := helpers.HLS_SEGMENT_FILENAME_PREFIX + "0" + helpers.HLS_SEGMENT_FILENAME_SUFFIX
+	nextFilename := helpers.HLS_SEGMENT_FILENAME_PREFIX + "1" + helpers.HLS_SEGMENT_FILENAME_SUFFIX
+	payload := []byte("segment payload")
+	err := os.WriteFile(filepath.Join(tempDir, filename), payload, 0o600)
+	if err != nil {
+		t.Fatalf("write segment: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(tempDir, nextFilename), []byte("next segment"), 0o600)
+	if err != nil {
+		t.Fatalf("write next segment: %v", err)
+	}
+	session := &HLSSession{TempDir: tempDir}
 
+	t.Run("serves completed segment with shared headers", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/segment", nil)
 		w := httptest.NewRecorder()
-		serveReadyHLSSegment(w, req, &HLSSession{TempDir: tempDir}, filename)
+		serveReadyHLSSegment(w, req, session, filename)
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
@@ -252,6 +254,42 @@ func TestServeReadyHLSSegment(t *testing.T) {
 		}
 		if w.Body.String() != "segment payload" {
 			t.Fatalf("body = %q, want segment payload", w.Body.String())
+		}
+	})
+
+	t.Run("serves a requested byte range", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/segment", nil)
+		req.Header.Set("Range", "bytes=0-6")
+		w := httptest.NewRecorder()
+		serveReadyHLSSegment(w, req, session, filename)
+
+		if w.Code != http.StatusPartialContent {
+			t.Fatalf("status = %d, want 206: %s", w.Code, w.Body.String())
+		}
+		if got := w.Header().Get("Accept-Ranges"); got != "bytes" {
+			t.Fatalf("Accept-Ranges = %q, want bytes", got)
+		}
+		wantContentRange := fmt.Sprintf("bytes 0-6/%d", len(payload))
+		if got := w.Header().Get("Content-Range"); got != wantContentRange {
+			t.Fatalf("Content-Range = %q, want %q", got, wantContentRange)
+		}
+		if w.Body.String() != "segment" {
+			t.Fatalf("body = %q, want segment", w.Body.String())
+		}
+	})
+
+	t.Run("rejects an unsatisfiable byte range", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/segment", nil)
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", len(payload)))
+		w := httptest.NewRecorder()
+		serveReadyHLSSegment(w, req, session, filename)
+
+		if w.Code != http.StatusRequestedRangeNotSatisfiable {
+			t.Fatalf("status = %d, want 416: %s", w.Code, w.Body.String())
+		}
+		wantContentRange := fmt.Sprintf("bytes */%d", len(payload))
+		if got := w.Header().Get("Content-Range"); got != wantContentRange {
+			t.Fatalf("Content-Range = %q, want %q", got, wantContentRange)
 		}
 	})
 

--- a/server/cmd/api/hls_handler_test.go
+++ b/server/cmd/api/hls_handler_test.go
@@ -544,6 +544,51 @@ func TestHLSManifest_PropagatesEffectiveStartToAssetsAndSegmentLookup(t *testing
 	}
 }
 
+func TestHLSManifest_RepeatedRequestsReusePersonalSession(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+	app.Settings = &database.Setting{}
+	app.InitSession()
+	ffmpegRunner := &fakeFFmpeg{plans: []fakeFFmpegRunPlan{{}}}
+	app.FFmpeg = ffmpegRunner
+
+	movieID := insertTestHLSMovieFixture(t, app, "h264", 1080)
+	userID := int64(42)
+
+	router := chi.NewRouter()
+	router.Get("/api/movies/{id}/hls/{profile}/playlist.m3u8", func(w http.ResponseWriter, r *http.Request) {
+		app.SessionManager.Put(r.Context(), cookieUserID, userID)
+		app.HLSManifest(w, r)
+	})
+	handler := app.SessionManager.LoadAndSave(router)
+
+	manifestURL := fmt.Sprintf(
+		"/api/movies/%d/hls/%s/playlist.m3u8?audio_track=0&playback_session=%s&start=590",
+		movieID,
+		helpers.HLS_PROFILE_720P_3MBPS,
+		testPlaybackSessionID,
+	)
+	for requestNumber := 1; requestNumber <= 2; requestNumber++ {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(
+			recorder,
+			httptest.NewRequest(http.MethodGet, manifestURL, nil),
+		)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf(
+				"manifest request %d status = %d, want 200: %s",
+				requestNumber,
+				recorder.Code,
+				recorder.Body.String(),
+			)
+		}
+	}
+
+	if calls := ffmpegRunner.CallCount(); calls != 1 {
+		t.Fatalf("FFmpeg calls = %d, want 1 for repeated session URL", calls)
+	}
+}
+
 func TestHLSSegment_UsesRequestedRemuxKeyWhenEffectiveProfileFallsBack(t *testing.T) {
 	app := setupTestApp(t)
 	defer app.DB.Close()

--- a/server/cmd/api/hls_handler_test.go
+++ b/server/cmd/api/hls_handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -140,18 +141,85 @@ func TestSessionPlaylistDurationSec(t *testing.T) {
 
 func TestBuildHLSPlaylistBody(t *testing.T) {
 	session := &HLSSession{DurationSec: 12, CopyVideo: false}
-	generated := buildHLSPlaylistBody(session, session.DurationSec, "/api/hls/", "?audio_track=0")
+	generated, err := buildHLSPlaylistBody(t.Context(), session, session.DurationSec, "/api/hls/", "?audio_track=0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !strings.Contains(generated, "segment_0.m4s?audio_track=0") {
 		t.Fatalf("generated playlist did not include rewritten segment URL: %s", generated)
 	}
 
 	session.FinalPlaylist = "#EXTM3U\n#EXT-X-MAP:URI=\"init.mp4\"\n#EXTINF:4,\nsegment_0.m4s\n"
-	finalized := buildHLSPlaylistBody(session, session.DurationSec, "/api/hls/", "?audio_track=1")
+	finalized, err := buildHLSPlaylistBody(t.Context(), session, session.DurationSec, "/api/hls/", "?audio_track=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !strings.Contains(finalized, "/api/hls/init.mp4?audio_track=1") {
 		t.Fatalf("final playlist did not rewrite init URL: %s", finalized)
 	}
 	if !strings.Contains(finalized, "/api/hls/segment_0.m4s?audio_track=1") {
 		t.Fatalf("final playlist did not rewrite segment URL: %s", finalized)
+	}
+}
+
+// A copy-video session's segments split on source keyframes, so the playlist
+// has to come from FFmpeg. Synthesizing one advertises durations FFmpeg never
+// produced and segments that will never exist (audit H1/H2).
+func TestBuildHLSPlaylistBody_CopyVideoServesFFmpegPlaylist(t *testing.T) {
+	tempDir := t.TempDir()
+	livePlaylist := "#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-TARGETDURATION:10\n" +
+		"#EXT-X-PLAYLIST-TYPE:EVENT\n#EXT-X-MAP:URI=\"init.mp4\"\n" +
+		"#EXTINF:8.466792,\nsegment_0.m4s\n#EXTINF:6.006000,\nsegment_1.m4s\n"
+
+	writeErr := os.WriteFile(filepath.Join(tempDir, helpers.HLS_PLAYLIST_FILENAME), []byte(livePlaylist), 0o644)
+	if writeErr != nil {
+		t.Fatalf("failed to seed playlist: %v", writeErr)
+	}
+
+	session := &HLSSession{DurationSec: 600, CopyVideo: true, TempDir: tempDir}
+
+	playlist, err := buildHLSPlaylistBody(t.Context(), session, session.DurationSec, "/api/hls/", "?start=0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(playlist, "#EXTINF:8.466792,") {
+		t.Fatalf("real segment duration was not preserved: %s", playlist)
+	}
+	if strings.Contains(playlist, "#EXTINF:4.000000,") {
+		t.Fatalf("playlist still contains synthesized 4s durations: %s", playlist)
+	}
+	if strings.Count(playlist, ".m4s?start=0") != 2 {
+		t.Fatalf("expected exactly the two real segments, got: %s", playlist)
+	}
+	if strings.Contains(playlist, "#EXT-X-ENDLIST") {
+		t.Fatalf("a still-encoding session must not be advertised as complete: %s", playlist)
+	}
+}
+
+// Without a published playlist the request must not fall back to a synthesized
+// one; it retries instead.
+func TestBuildHLSPlaylistBody_CopyVideoWithoutPlaylistIsRetryable(t *testing.T) {
+	session := &HLSSession{DurationSec: 600, CopyVideo: true, TempDir: t.TempDir()}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := buildHLSPlaylistBody(ctx, session, session.DurationSec, "/api/hls/", "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the abandoned request to stop waiting, got %v", err)
+	}
+}
+
+// A copy-video session that exits cleanly without output must 404 rather than
+// hand back a playlist describing segments that do not exist.
+func TestBuildHLSPlaylistBody_CopyVideoExitedWithoutPlaylist(t *testing.T) {
+	session := &HLSSession{DurationSec: 600, CopyVideo: true, TempDir: t.TempDir()}
+	session.Exited = true
+
+	_, err := buildHLSPlaylistBody(t.Context(), session, session.DurationSec, "/api/hls/", "")
+	if !errors.Is(err, errHLSSessionEmpty) {
+		t.Fatalf("expected an empty-session error, got %v", err)
 	}
 }
 
@@ -766,5 +834,52 @@ func TestRefreshHLSSessionTTL_DoesNotReinsertEvictedPersonalSession(t *testing.T
 	_, cached := app.HLSSessionCache.Get(key)
 	if cached {
 		t.Fatal("evicted personal session was reinserted")
+	}
+}
+
+// A session that seeks past the end of a stream exits cleanly having written
+// one empty segment, which FFmpeg declares as `#EXTINF:0.000000` under an
+// invalid `#EXT-X-TARGETDURATION:0`. Serving that would be a valid-looking
+// manifest for unplayable media.
+func TestBuildHLSPlaylistBody_CopyVideoRejectsEmptyOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	degenerate := "#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-TARGETDURATION:0\n" +
+		"#EXT-X-PLAYLIST-TYPE:EVENT\n#EXT-X-MAP:URI=\"init.mp4\"\n" +
+		"#EXTINF:0.000000,\nsegment_0.m4s\n#EXT-X-ENDLIST\n"
+
+	writeErr := os.WriteFile(filepath.Join(tempDir, helpers.HLS_PLAYLIST_FILENAME), []byte(degenerate), 0o644)
+	if writeErr != nil {
+		t.Fatalf("failed to seed playlist: %v", writeErr)
+	}
+
+	session := &HLSSession{DurationSec: 30, CopyVideo: true, TempDir: tempDir}
+	session.Exited = true
+
+	_, err := buildHLSPlaylistBody(t.Context(), session, session.DurationSec, "/api/hls/", "")
+	if !errors.Is(err, errHLSSessionEmpty) {
+		t.Fatalf("expected an empty session to be reported as producing nothing, got %v", err)
+	}
+}
+
+func TestHasPlayableSegment(t *testing.T) {
+	cases := []struct {
+		name     string
+		playlist string
+		want     bool
+	}{
+		{"real segment", "#EXTINF:8.466792,\nsegment_0.m4s\n", true},
+		{"zero duration only", "#EXTINF:0.000000,\nsegment_0.m4s\n", false},
+		{"no segments", "#EXTM3U\n#EXT-X-TARGETDURATION:4\n", false},
+		{"zero then real", "#EXTINF:0.000000,\nseg0\n#EXTINF:4.000000,\nseg1\n", true},
+		{"malformed duration", "#EXTINF:abc,\nsegment_0.m4s\n", false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := hasPlayableSegment(testCase.playlist)
+			if got != testCase.want {
+				t.Fatalf("hasPlayableSegment = %v, want %v", got, testCase.want)
+			}
+		})
 	}
 }

--- a/server/cmd/api/hls_limiter.go
+++ b/server/cmd/api/hls_limiter.go
@@ -17,7 +17,10 @@ type hlsStorageCapacityError struct {
 }
 
 func (e *hlsStorageCapacityError) Error() string {
-	return "not enough free space in the transcode directory to start playback"
+	return fmt.Sprintf(
+		"not enough free space in the transcode directory to start playback (free: %d bytes, required: %d bytes)",
+		e.FreeBytes, e.RequiredBytes,
+	)
 }
 
 const (

--- a/server/cmd/api/hls_limiter.go
+++ b/server/cmd/api/hls_limiter.go
@@ -9,6 +9,17 @@ import (
 	"sync"
 )
 
+// hlsStorageCapacityError reports that the transcode directory is too full to
+// start another session.
+type hlsStorageCapacityError struct {
+	FreeBytes     uint64
+	RequiredBytes uint64
+}
+
+func (e *hlsStorageCapacityError) Error() string {
+	return "not enough free space in the transcode directory to start playback"
+}
+
 const (
 	envHLSMaxCPUTranscodes        = "HLS_MAX_CPU_TRANSCODES"
 	envHLSMaxSessionsPerUser      = "HLS_MAX_SESSIONS_PER_USER"

--- a/server/cmd/api/hls_playlist.go
+++ b/server/cmd/api/hls_playlist.go
@@ -10,10 +10,6 @@ import (
 	"igloo/cmd/internal/helpers"
 )
 
-// Copy mode splits only at keyframes, so its target-duration ceiling is
-// intentionally larger than the regular HLS segment duration.
-const hlsCopyVideoTargetDuration = 30
-
 type hlsAssetQueryParams struct {
 	AudioTrack      *int
 	StartSec        *int
@@ -78,10 +74,12 @@ func rewritePlaylistURLs(playlist, baseURL, querySuffix string) string {
 // generateVODPlaylist builds a complete HLS VOD M3U8 playlist from the known
 // total duration. All segments are listed upfront with #EXT-X-ENDLIST so
 // hls.js treats it as on-demand (starts from 0, shows full duration, allows seeking).
+// Only transcode sessions use it: their -force_key_frames boundaries make the
+// arithmetic exact, while copy-video sessions serve FFmpeg's own playlist.
 //
 // FFmpeg produces the actual segment files in the background; the segment
 // handler waits for each file to appear on disk before serving.
-func generateVODPlaylist(totalDurationSec float64, baseURL, querySuffix string, copyVideo bool) string {
+func generateVODPlaylist(totalDurationSec float64, baseURL, querySuffix string) string {
 	segDur := float64(helpers.HLS_SEGMENT_TIME_SEC)
 	segCount := int(math.Ceil(totalDurationSec / segDur))
 	if segCount < 1 {
@@ -91,12 +89,7 @@ func generateVODPlaylist(totalDurationSec float64, baseURL, querySuffix string, 
 	var b strings.Builder
 	b.WriteString("#EXTM3U\n")
 	b.WriteString("#EXT-X-VERSION:7\n")
-	// Copy-video segments follow source keyframes, so they need a larger target duration.
-	targetDuration := helpers.HLS_SEGMENT_TIME_SEC * 2
-	if copyVideo {
-		targetDuration = hlsCopyVideoTargetDuration
-	}
-	b.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", targetDuration))
+	b.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", helpers.HLS_SEGMENT_TIME_SEC*2))
 	b.WriteString("#EXT-X-MEDIA-SEQUENCE:0\n")
 	b.WriteString("#EXT-X-PLAYLIST-TYPE:VOD\n")
 	b.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s%s%s\"\n", baseURL, helpers.HLS_INIT_FILENAME, querySuffix))

--- a/server/cmd/api/hls_playlist_test.go
+++ b/server/cmd/api/hls_playlist_test.go
@@ -178,7 +178,7 @@ func TestGenerateVODPlaylist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			baseURL := "/api/movies/1/hls/720p_3mbps/"
 			querySuffix := buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: &tt.audioTrack})
-			got := generateVODPlaylist(tt.durationSec, baseURL, querySuffix, false)
+			got := generateVODPlaylist(tt.durationSec, baseURL, querySuffix)
 
 			if !strings.HasPrefix(got, "#EXTM3U\n") {
 				t.Error("playlist must start with #EXTM3U")
@@ -217,7 +217,7 @@ func TestGenerateVODPlaylist(t *testing.T) {
 }
 
 func TestGenerateVODPlaylist_ZeroDuration(t *testing.T) {
-	got := generateVODPlaylist(0, "/base/", buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: testIntPtr(0)}), false)
+	got := generateVODPlaylist(0, "/base/", buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: testIntPtr(0)}))
 
 	if !strings.Contains(got, "#EXT-X-ENDLIST") {
 		t.Error("zero-duration playlist must still be valid with ENDLIST")
@@ -228,7 +228,7 @@ func TestGenerateVODPlaylist_ZeroDuration(t *testing.T) {
 }
 
 func TestGenerateVODPlaylist_TranscodeTargetDurationIsDoubleSegmentTime(t *testing.T) {
-	got := generateVODPlaylist(100, "/base/", buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: testIntPtr(0)}), false)
+	got := generateVODPlaylist(100, "/base/", buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: testIntPtr(0)}))
 
 	want := fmt.Sprintf("#EXT-X-TARGETDURATION:%d", helpers.HLS_SEGMENT_TIME_SEC*2)
 	if !strings.Contains(got, want) {
@@ -236,20 +236,11 @@ func TestGenerateVODPlaylist_TranscodeTargetDurationIsDoubleSegmentTime(t *testi
 	}
 }
 
-func TestGenerateVODPlaylist_CopyVideoUsesLargerTargetDuration(t *testing.T) {
-	got := generateVODPlaylist(100, "/base/", buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: testIntPtr(0)}), true)
-
-	want := fmt.Sprintf("#EXT-X-TARGETDURATION:%d", hlsCopyVideoTargetDuration)
-	if !strings.Contains(got, want) {
-		t.Errorf("expected target duration %q for copy-video mode, got:\n%s", want, got)
-	}
-}
-
 func TestGenerateVODPlaylist_LastSegmentDurationCapped(t *testing.T) {
 	segDur := float64(helpers.HLS_SEGMENT_TIME_SEC)
 	totalDur := segDur + 1.5
 
-	got := generateVODPlaylist(totalDur, "/base/", buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: testIntPtr(0)}), false)
+	got := generateVODPlaylist(totalDur, "/base/", buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: testIntPtr(0)}))
 
 	lines := strings.Split(got, "\n")
 	var infDurations []string

--- a/server/cmd/api/hls_session.go
+++ b/server/cmd/api/hls_session.go
@@ -52,22 +52,22 @@ const (
 
 // HLSSession holds state for one HLS transcode session.
 type HLSSession struct {
-	MovieID          int64
-	OwnerUserID      int64
-	PlaybackSession  string
-	TempDir          string
-	Cmd              *exec.Cmd
-	Cancel           context.CancelFunc
-	CleanupOnce      sync.Once
-	DurationSec      float64
-	StartSec         float64
-	Exited           bool
-	ExitErr          error
-	ExpectedStop     bool
-	FinalPlaylist    string
-	ExitMu           sync.Mutex
-	IsRoom           bool
-	CopyVideo        bool // true when FFmpeg uses -c:v copy for the effective session profile
+	MovieID         int64
+	OwnerUserID     int64
+	PlaybackSession string
+	TempDir         string
+	Cmd             *exec.Cmd
+	Cancel          context.CancelFunc
+	CleanupOnce     sync.Once
+	DurationSec     float64
+	StartSec        float64
+	Exited          bool
+	ExitErr         error
+	ExpectedStop    bool
+	FinalPlaylist   string
+	ExitMu          sync.Mutex
+	IsRoom          bool
+	CopyVideo       bool // true when FFmpeg uses -c:v copy for the effective session profile
 	// EffectiveProfile is the profile FFmpeg actually ran, which differs from
 	// the requested one whenever the remux safety gate forced a transcode.
 	EffectiveProfile string
@@ -638,6 +638,7 @@ func (app *Application) checkHLSTranscodeSpace(transcodeRoot string) error {
 // It is advisory: on failure the start stays unknown and the session reports
 // nothing, leaving the client on its previous fallback.
 func (app *Application) measureHLSSessionStart(
+	parentCtx context.Context,
 	session *HLSSession,
 	filePath string,
 	streamIndex int64,
@@ -645,7 +646,7 @@ func (app *Application) measureHLSSessionStart(
 ) {
 	defer app.Wait.Done()
 
-	ctx, cancel := context.WithTimeout(context.Background(), hlsStartProbeTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, hlsStartProbeTimeout)
 	defer cancel()
 
 	actualStartSec, err := app.Ffprobe.KeyframeAtOrBefore(ctx, filePath, streamIndex, requestedStartSec)
@@ -737,7 +738,7 @@ func (app *Application) startHLSSession(params *hlsSessionStartParams) (*HLSSess
 	if copyVideo && startSec > 0 && app.Ffprobe != nil && app.Wait != nil {
 		session.setActualStartSec(hlsUnknownActualStart)
 		app.Wait.Add(1)
-		go app.measureHLSSessionStart(session, params.Movie.FilePath, params.PrimaryVideo.StreamIndex, startSec)
+		go app.measureHLSSessionStart(runCtx, session, params.Movie.FilePath, params.PrimaryVideo.StreamIndex, startSec)
 	}
 
 	app.Logger.Info("hls session starting",

--- a/server/cmd/api/hls_session.go
+++ b/server/cmd/api/hls_session.go
@@ -36,6 +36,14 @@ const (
 	// hlsMaxPersonalSessionsPerUserDefault caps concurrent personal sessions per
 	// user so abandoned clients cannot pile up ffmpeg processes and temp dirs.
 	hlsMaxPersonalSessionsPerUserDefault = 3
+	// hlsUnknownActualStart marks a session whose real media start has not been
+	// measured; callers fall back to the requested start.
+	hlsUnknownActualStart = -1.0
+	hlsStartProbeTimeout  = 15 * time.Second
+	// A session generates the whole remaining movie, so it needs real headroom.
+	// This is a floor that keeps a home server from filling its disk mid-film,
+	// not an estimate of any particular session's output size.
+	hlsMinFreeTranscodeBytes = 2 << 30
 	// hlsIdlePermitReclaimThreshold is the minimum idle time before a session may
 	// be reclaimed to free a transcode permit. Active clients refresh the TTL on
 	// every segment fetch, so a session this idle is abandoned or backgrounded.
@@ -60,6 +68,49 @@ type HLSSession struct {
 	ExitMu           sync.Mutex
 	IsRoom           bool
 	CopyVideo        bool // true when FFmpeg uses -c:v copy for the effective session profile
+	// EffectiveProfile is the profile FFmpeg actually ran, which differs from
+	// the requested one whenever the remux safety gate forced a transcode.
+	EffectiveProfile string
+	// ActualStartSec is where the session's media really begins. Input seeking
+	// is frame-accurate when re-encoding but can only land on a source keyframe
+	// when copying video, so a copy-video session can start before StartSec.
+	// Negative means unknown; callers then fall back to StartSec. Guarded by
+	// ExitMu along with the exit fields above.
+	ActualStartSec float64
+}
+
+// setActualStartSec records where the session's media really begins.
+func (s *HLSSession) setActualStartSec(startSec float64) {
+	s.ExitMu.Lock()
+	defer s.ExitMu.Unlock()
+
+	s.ActualStartSec = startSec
+}
+
+// actualStartSec returns the measured media start, or a negative value when it
+// is unknown and the caller should fall back to the requested start.
+func (s *HLSSession) actualStartSec() float64 {
+	s.ExitMu.Lock()
+	defer s.ExitMu.Unlock()
+
+	return s.ActualStartSec
+}
+
+// currentFinalPlaylist returns the finalized VOD playlist, or "" while FFmpeg
+// is still running.
+func (s *HLSSession) currentFinalPlaylist() string {
+	s.ExitMu.Lock()
+	defer s.ExitMu.Unlock()
+
+	return s.FinalPlaylist
+}
+
+// exitStatus reports whether FFmpeg has exited and, if so, with what error.
+func (s *HLSSession) exitStatus() (bool, error) {
+	s.ExitMu.Lock()
+	defer s.ExitMu.Unlock()
+
+	return s.Exited, s.ExitErr
 }
 
 type hlsSessionStartParams struct {
@@ -547,6 +598,69 @@ func normalizedHLSStartSec(startSec int, durationSec float64) int {
 	return clampedStart
 }
 
+// checkHLSTranscodeSpace refuses a new session when the transcode filesystem is
+// too full to hold its output. A failure to measure the filesystem is not
+// treated as a refusal: an unreadable statfs should not take playback down.
+func (app *Application) checkHLSTranscodeSpace(transcodeRoot string) error {
+	freeBytes, err := freeDiskBytes(transcodeRoot)
+	if err != nil {
+		app.Logger.Warn("could not measure transcode directory free space",
+			"path", transcodeRoot,
+			"error", err.Error(),
+		)
+		return nil
+	}
+
+	if freeBytes >= hlsMinFreeTranscodeBytes {
+		return nil
+	}
+
+	app.Logger.Error("refusing hls session: transcode directory is nearly full",
+		"path", transcodeRoot,
+		"free_bytes", freeBytes,
+		"required_bytes", uint64(hlsMinFreeTranscodeBytes),
+	)
+
+	return &hlsStorageCapacityError{
+		FreeBytes:     freeBytes,
+		RequiredBytes: hlsMinFreeTranscodeBytes,
+	}
+}
+
+// measureHLSSessionStart records where a copy-video session's media actually
+// begins. Stream copy cannot discard frames, so FFmpeg's input seek lands on
+// the source keyframe at or before the requested offset and the session starts
+// early by up to one GOP. Without this the client maps session time to absolute
+// movie time using the requested offset, so the clock and every watch-progress
+// write run ahead of the picture.
+//
+// It runs alongside FFmpeg rather than before it so it adds no startup latency.
+// It is advisory: on failure the start stays unknown and the session reports
+// nothing, leaving the client on its previous fallback.
+func (app *Application) measureHLSSessionStart(
+	session *HLSSession,
+	filePath string,
+	streamIndex int64,
+	requestedStartSec float64,
+) {
+	defer app.Wait.Done()
+
+	ctx, cancel := context.WithTimeout(context.Background(), hlsStartProbeTimeout)
+	defer cancel()
+
+	actualStartSec, err := app.Ffprobe.KeyframeAtOrBefore(ctx, filePath, streamIndex, requestedStartSec)
+	if err != nil {
+		app.Logger.Warn("hls actual start probe failed",
+			"movie_id", session.MovieID,
+			"requested_start_sec", requestedStartSec,
+			"error", err.Error(),
+		)
+		return
+	}
+
+	session.setActualStartSec(actualStartSec)
+}
+
 func (app *Application) startHLSSession(params *hlsSessionStartParams) (*HLSSession, error) {
 	videoCodec := strings.ToLower(params.PrimaryVideo.Codec)
 	audioCodec := ""
@@ -568,8 +682,18 @@ func (app *Application) startHLSSession(params *hlsSessionStartParams) (*HLSSess
 	deviceDecision := ffmpeg.ResolveHLSDevice(hwDevice, ffmpegCaps)
 
 	transcodeRoot := app.hlsTranscodeRoot()
-	if err := os.MkdirAll(transcodeRoot, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create transcode directory %s: %w", transcodeRoot, err)
+
+	mkdirErr := os.MkdirAll(transcodeRoot, 0o755)
+	if mkdirErr != nil {
+		return nil, fmt.Errorf("failed to create transcode directory %s: %w", transcodeRoot, mkdirErr)
+	}
+
+	// A session writes the whole remaining movie ahead of the playhead, so a
+	// nearly-full disk should refuse playback up front rather than fail
+	// mid-stream with a truncated stream and a confusing player error.
+	spaceErr := app.checkHLSTranscodeSpace(transcodeRoot)
+	if spaceErr != nil {
+		return nil, spaceErr
 	}
 
 	tempDir, err := os.MkdirTemp(transcodeRoot, "igloo-hls-*")
@@ -592,17 +716,29 @@ func (app *Application) startHLSSession(params *hlsSessionStartParams) (*HLSSess
 	startSegment := int64(startSec / float64(helpers.HLS_SEGMENT_TIME_SEC))
 	runCtx, cancel := context.WithCancel(context.Background())
 	session := &HLSSession{
-		MovieID:         params.Movie.ID,
-		PlaybackSession: params.PlaybackSession,
-		TempDir:         tempDir,
-		Cancel:          cancel,
-		DurationSec:     params.DurationSec,
-		StartSec:        startSec,
-		IsRoom:          params.IsRoom,
-		CopyVideo:       copyVideo,
+		MovieID:          params.Movie.ID,
+		PlaybackSession:  params.PlaybackSession,
+		TempDir:          tempDir,
+		Cancel:           cancel,
+		DurationSec:      params.DurationSec,
+		StartSec:         startSec,
+		IsRoom:           params.IsRoom,
+		CopyVideo:        copyVideo,
+		EffectiveProfile: params.EffectiveProfile,
+		// Re-encoding seeks accurately, so a transcode starts exactly where it
+		// was asked to. Copy-video cannot and is measured below.
+		ActualStartSec: startSec,
 	}
 
 	videoStreamIndex := int(params.PrimaryVideo.StreamIndex)
+
+	// Measuring the real start is advisory, so it is skipped rather than
+	// allowed to fail a session when the prober is unavailable.
+	if copyVideo && startSec > 0 && app.Ffprobe != nil && app.Wait != nil {
+		session.setActualStartSec(hlsUnknownActualStart)
+		app.Wait.Add(1)
+		go app.measureHLSSessionStart(session, params.Movie.FilePath, params.PrimaryVideo.StreamIndex, startSec)
+	}
 
 	app.Logger.Info("hls session starting",
 		"movie_id", params.Movie.ID,

--- a/server/cmd/api/movies_scanner_test.go
+++ b/server/cmd/api/movies_scanner_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 type stubMovieScannerFfprobe struct {
+	noKeyframeProbe
 	result  *ffprobe.FfprobeResult
 	results []*ffprobe.FfprobeResult
 	errs    []error
@@ -39,6 +40,20 @@ func (s *stubMovieScannerFfprobe) GetMetadata(filePath string) (*ffprobe.Ffprobe
 
 func (s *stubMovieScannerFfprobe) GetAudioMetadata(filePath string) (*ffprobe.FfprobeResult, error) {
 	return s.GetMetadata(filePath)
+}
+
+// noKeyframeProbe completes ffprobe.FfprobeInterface for stubs that only
+// exercise scanning. Keyframe lookup is advisory on the playback path, so a
+// stub that never serves HLS refuses it rather than inventing an offset.
+type noKeyframeProbe struct{}
+
+func (noKeyframeProbe) KeyframeAtOrBefore(
+	_ context.Context,
+	_ string,
+	_ int64,
+	_ float64,
+) (float64, error) {
+	return 0, errors.New("keyframe probing is not stubbed")
 }
 
 type stubMovieScannerTmdb struct {

--- a/server/cmd/api/music_scanner_test.go
+++ b/server/cmd/api/music_scanner_test.go
@@ -77,6 +77,7 @@ func testMusicMetadataWithTags(tags ffprobe.FormatTags) *ffprobe.FfprobeResult {
 }
 
 type countingMusicScannerFfprobe struct {
+	noKeyframeProbe
 	result *ffprobe.FfprobeResult
 	calls  int
 }
@@ -92,6 +93,7 @@ func (s *countingMusicScannerFfprobe) GetAudioMetadata(filePath string) (*ffprob
 }
 
 type failingPathMusicScannerFfprobe struct {
+	noKeyframeProbe
 	result      *ffprobe.FfprobeResult
 	failingPath string
 	calls       int
@@ -116,6 +118,7 @@ func (s *failingPathMusicScannerFfprobe) GetAudioMetadata(filePath string) (*ffp
 }
 
 type musicScannerFfprobeByPath struct {
+	noKeyframeProbe
 	results       map[string]*ffprobe.FfprobeResult
 	errors        map[string]error
 	metadataCalls map[string]int

--- a/server/cmd/api/subtitle_handler.go
+++ b/server/cmd/api/subtitle_handler.go
@@ -45,6 +45,16 @@ func (app *Application) SubtitleWebVTT(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// An HLS session started with -ss has a media timeline that begins at zero,
+	// while these cues carry absolute source timestamps. `start` is that
+	// session's offset, so the cues can be rebased onto the timeline they will
+	// actually be played against.
+	startSec, err := parseSubtitleStartSec(r)
+	if err != nil {
+		helpers.ErrorJSON(w, err, http.StatusBadRequest)
+		return
+	}
+
 	movie, err := app.Queries.GetMovieByID(r.Context(), movieID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -86,10 +96,7 @@ func (app *Application) SubtitleWebVTT(w http.ResponseWriter, r *http.Request) {
 			)
 			app.SubtitleVTTCache.Delete(cacheKey)
 		} else {
-			w.Header().Set("Content-Type", subtitleWebVTTContentType)
-			w.Header().Set("Cache-Control", "no-cache")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(vtt)
+			writeSubtitleWebVTT(w, vtt, startSec)
 			return
 		}
 	}
@@ -136,8 +143,35 @@ func (app *Application) SubtitleWebVTT(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writeSubtitleWebVTT(w, out, startSec)
+}
+
+// parseSubtitleStartSec reads the optional `start` query parameter naming the
+// HLS session offset these cues will be played against.
+func parseSubtitleStartSec(r *http.Request) (float64, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get("start"))
+	if raw == "" {
+		return 0, nil
+	}
+
+	startSec, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, errors.New("invalid start")
+	}
+
+	if startSec < 0 {
+		return 0, errors.New("start must not be negative")
+	}
+
+	return startSec, nil
+}
+
+// writeSubtitleWebVTT serves the cached absolute-timestamp WebVTT, rebased onto
+// the requesting session's timeline. The cache stays keyed on movie and stream
+// alone, so shifting here costs no extra extraction and no extra cache entries.
+func writeSubtitleWebVTT(w http.ResponseWriter, vtt []byte, startSec float64) {
 	w.Header().Set("Content-Type", subtitleWebVTTContentType)
 	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(out)
+	_, _ = w.Write(helpers.ShiftWebVTT(vtt, startSec))
 }

--- a/server/cmd/api/subtitle_handler.go
+++ b/server/cmd/api/subtitle_handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -156,6 +157,12 @@ func parseSubtitleStartSec(r *http.Request) (float64, error) {
 
 	startSec, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
+		return 0, errors.New("invalid start")
+	}
+
+	// ParseFloat accepts "NaN" and "Inf", which would corrupt the cue shifting
+	// math downstream.
+	if math.IsNaN(startSec) || math.IsInf(startSec, 0) {
 		return 0, errors.New("invalid start")
 	}
 

--- a/server/cmd/api/subtitle_handler_test.go
+++ b/server/cmd/api/subtitle_handler_test.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"igloo/cmd/internal/helpers"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -34,6 +37,75 @@ func serveSubtitleWebVTT(app *Application, movieID int64, trackIndex string) *ht
 	recorder := httptest.NewRecorder()
 	router.ServeHTTP(recorder, req)
 	return recorder
+}
+
+func serveSubtitleWebVTTWithQuery(
+	app *Application,
+	movieID int64,
+	trackIndex string,
+	query string,
+) *httptest.ResponseRecorder {
+	router := chi.NewRouter()
+	router.Get("/api/movies/{id}/subtitles/{trackIndex}/web.vtt", app.SubtitleWebVTT)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf("/api/movies/%d/subtitles/%s/web.vtt%s", movieID, trackIndex, query),
+		nil,
+	)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+// A rebased HLS session's media timeline starts at zero while these cues carry
+// absolute source timestamps, so `start` rebases them onto the session they
+// will be played against (audit H4).
+func TestSubtitleWebVTT_ShiftsCuesBySessionStart(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+	fake := &fakeFFmpeg{}
+	app.FFmpeg = fake
+
+	movieID := insertTestHLSMovieFixture(t, app, "h264", 1080)
+	insertTestSubtitleFixture(t, app, movieID, 2, "subrip")
+
+	absolute := "WEBVTT\n\n00:10:05.000 --> 00:10:07.000\nLine\n"
+	app.SubtitleVTTCache.Set(helpers.SubtitleCacheKey(movieID, 2), []byte(absolute), subtitleCacheTTL)
+
+	recorder := serveSubtitleWebVTTWithQuery(app, movieID, "0", "?start=600")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "00:00:05.000 --> 00:00:07.000") {
+		t.Fatalf("cues were not rebased onto the session: %s", recorder.Body.String())
+	}
+
+	// The cache holds the absolute payload, so an unshifted request still gets
+	// absolute cues without a second extraction.
+	unshifted := serveSubtitleWebVTT(app, movieID, "0")
+	if !strings.Contains(unshifted.Body.String(), "00:10:05.000 --> 00:10:07.000") {
+		t.Fatalf("cache must keep absolute cues: %s", unshifted.Body.String())
+	}
+	if fake.SubtitleCallCount() != 0 {
+		t.Fatalf("shifting must not trigger extraction, got %d calls", fake.SubtitleCallCount())
+	}
+}
+
+func TestSubtitleWebVTT_RejectsNegativeStart(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+	app.FFmpeg = &fakeFFmpeg{}
+
+	movieID := insertTestHLSMovieFixture(t, app, "h264", 1080)
+	insertTestSubtitleFixture(t, app, movieID, 2, "subrip")
+
+	recorder := serveSubtitleWebVTTWithQuery(app, movieID, "0", "?start=-5")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a negative start, got %d", recorder.Code)
+	}
 }
 
 func TestSubtitleWebVTT_ExtractsTextSubtitle(t *testing.T) {

--- a/server/cmd/api/watch_room_media_handler.go
+++ b/server/cmd/api/watch_room_media_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"net/http"
@@ -33,10 +34,17 @@ func (app *Application) WatchRoomHLSManifest(w http.ResponseWriter, r *http.Requ
 	audioTrack := int(room.AudioTrack)
 	querySuffix := buildHLSAssetQuerySuffix(hlsAssetQueryParams{AudioTrack: &audioTrack})
 
-	playlist := buildHLSPlaylistBody(session, session.DurationSec, baseURL, querySuffix)
+	playlist, err := buildHLSPlaylistBody(r.Context(), session, session.DurationSec, baseURL, querySuffix)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		app.Logger.Error("watch room hls playlist unavailable", "error", err, "room_id", room.ID)
+		writeHLSSessionError(w, err)
+		return
+	}
 
-	w.Header().Set("Content-Type", hlsPlaylistContentType)
-	w.Header().Set("Cache-Control", "no-store")
+	writeHLSPlaylistHeaders(w, session)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(playlist))
 }

--- a/server/cmd/internal/ffprobe/ffprobe.go
+++ b/server/cmd/internal/ffprobe/ffprobe.go
@@ -16,6 +16,7 @@ const versionCheckTimeout = 5 * time.Second
 type FfprobeInterface interface {
 	GetMetadata(filePath string) (*FfprobeResult, error)
 	GetAudioMetadata(filePath string) (*FfprobeResult, error)
+	KeyframeAtOrBefore(ctx context.Context, filePath string, streamIndex int64, targetSec float64) (float64, error)
 }
 
 type ffprobe struct {

--- a/server/cmd/internal/ffprobe/ffprobe_keyframes.go
+++ b/server/cmd/internal/ffprobe/ffprobe_keyframes.go
@@ -40,14 +40,14 @@ func (f *ffprobe) KeyframeAtOrBefore(
 		from = 0
 	}
 
-	// Read from the lookback point up to just past the target: the keyframe we
-	// want is the last one at or before it.
-	window := targetSec - from + 1
+	// Read from the lookback point up to one second past the target: the
+	// keyframe we want is the last one at or before it.
+	to := targetSec + 1
 
 	args := []string{
 		"-v", "error",
 		"-select_streams", strconv.FormatInt(streamIndex, 10),
-		"-read_intervals", fmt.Sprintf("%.3f%%+%.3f", from, window),
+		"-read_intervals", fmt.Sprintf("%.3f%%%.3f", from, to),
 		"-show_entries", "packet=pts_time,flags",
 		"-of", "csv=p=0",
 		filePath,

--- a/server/cmd/internal/ffprobe/ffprobe_keyframes.go
+++ b/server/cmd/internal/ffprobe/ffprobe_keyframes.go
@@ -1,0 +1,103 @@
+package ffprobe
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// keyframeLookbackSec bounds how far before the requested offset ffprobe reads
+// looking for a keyframe. Source GOPs on real library files run to roughly
+// twelve seconds, so this leaves generous headroom without turning a bounded
+// probe into a long read over a slow network mount.
+const keyframeLookbackSec = 30.0
+
+// KeyframeAtOrBefore returns the presentation time of the last keyframe at or
+// before targetSec on the given absolute stream index.
+//
+// FFmpeg's input seek (-ss before -i) lands on the keyframe at or before the
+// requested offset. When re-encoding it then discards frames up to the offset,
+// so output starts exactly where asked; when copying video it cannot, so the
+// session really begins at that earlier keyframe. This reports where.
+func (f *ffprobe) KeyframeAtOrBefore(
+	ctx context.Context,
+	filePath string,
+	streamIndex int64,
+	targetSec float64,
+) (float64, error) {
+	if strings.TrimSpace(filePath) == "" {
+		return 0, fmt.Errorf("source path is required")
+	}
+
+	if targetSec <= 0 {
+		return 0, fmt.Errorf("target must be greater than zero")
+	}
+
+	from := targetSec - keyframeLookbackSec
+	if from < 0 {
+		from = 0
+	}
+
+	// Read from the lookback point up to just past the target: the keyframe we
+	// want is the last one at or before it.
+	window := targetSec - from + 1
+
+	args := []string{
+		"-v", "error",
+		"-select_streams", strconv.FormatInt(streamIndex, 10),
+		"-read_intervals", fmt.Sprintf("%.3f%%+%.3f", from, window),
+		"-show_entries", "packet=pts_time,flags",
+		"-of", "csv=p=0",
+		filePath,
+	}
+
+	cmd := exec.CommandContext(ctx, f.bin, args...)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+		return 0, fmt.Errorf("ffprobe keyframe lookup failed: %w", err)
+	}
+
+	best := -1.0
+	for _, line := range strings.Split(string(out), "\n") {
+		ptsTime, isKeyframe, ok := parseKeyframePacket(line)
+		if !ok || !isKeyframe {
+			continue
+		}
+		if ptsTime > targetSec {
+			continue
+		}
+		if ptsTime > best {
+			best = ptsTime
+		}
+	}
+
+	if best < 0 {
+		return 0, fmt.Errorf("no keyframe found at or before %.3f", targetSec)
+	}
+
+	return best, nil
+}
+
+// parseKeyframePacket reads one `pts_time,flags` CSV row. Rows with an unset
+// pts (ffprobe writes "N/A") are skipped rather than treated as zero.
+func parseKeyframePacket(line string) (float64, bool, bool) {
+	fields := strings.Split(strings.TrimSpace(line), ",")
+	if len(fields) < 2 {
+		return 0, false, false
+	}
+
+	ptsTime, err := strconv.ParseFloat(strings.TrimSpace(fields[0]), 64)
+	if err != nil {
+		return 0, false, false
+	}
+
+	isKeyframe := strings.Contains(fields[1], "K")
+
+	return ptsTime, isKeyframe, true
+}

--- a/server/cmd/internal/ffprobe/ffprobe_keyframes_test.go
+++ b/server/cmd/internal/ffprobe/ffprobe_keyframes_test.go
@@ -1,0 +1,40 @@
+package ffprobe
+
+import "testing"
+
+func TestParseKeyframePacket(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		wantPts float64
+		wantKey bool
+		wantOK  bool
+	}{
+		{name: "keyframe row", line: "12.500000,K__", wantPts: 12.5, wantKey: true, wantOK: true},
+		{name: "non-keyframe row", line: "13.250000,___", wantPts: 13.25, wantKey: false, wantOK: true},
+		{name: "keyframe with discard flag", line: "0.000000,K_D", wantPts: 0, wantKey: true, wantOK: true},
+		{name: "unset pts", line: "N/A,K__", wantOK: false},
+		{name: "empty line", line: "", wantOK: false},
+		{name: "single field", line: "12.500000", wantOK: false},
+		{name: "non-numeric pts", line: "garbage,K__", wantOK: false},
+		{name: "surrounding whitespace", line: "  7.000000,K__  \r", wantPts: 7, wantKey: true, wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pts, isKeyframe, ok := parseKeyframePacket(tt.line)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if pts != tt.wantPts {
+				t.Errorf("pts = %v, want %v", pts, tt.wantPts)
+			}
+			if isKeyframe != tt.wantKey {
+				t.Errorf("isKeyframe = %v, want %v", isKeyframe, tt.wantKey)
+			}
+		})
+	}
+}

--- a/server/cmd/internal/ffprobe/ffprobe_keyframes_test.go
+++ b/server/cmd/internal/ffprobe/ffprobe_keyframes_test.go
@@ -1,6 +1,12 @@
 package ffprobe
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestParseKeyframePacket(t *testing.T) {
 	tests := []struct {
@@ -36,5 +42,93 @@ func TestParseKeyframePacket(t *testing.T) {
 				t.Errorf("isKeyframe = %v, want %v", isKeyframe, tt.wantKey)
 			}
 		})
+	}
+}
+
+func TestKeyframeAtOrBeforeUsesAbsoluteBoundedInterval(t *testing.T) {
+	argsPath := filepath.Join(t.TempDir(), "args.log")
+	t.Setenv("FFPROBE_ARGS_LOG", argsPath)
+
+	binPath := filepath.Join(t.TempDir(), "ffprobe")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$FFPROBE_ARGS_LOG"
+printf '%s\n' '565.000000,K__'
+printf '%s\n' '599.000000,K__'
+printf '%s\n' '600.500000,K__'
+`
+	err := os.WriteFile(binPath, []byte(script), 0755)
+	if err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	probe := &ffprobe{bin: binPath}
+	keyframe, err := probe.KeyframeAtOrBefore(
+		context.Background(),
+		"/tmp/movie.mkv",
+		2,
+		600,
+	)
+	if err != nil {
+		t.Fatalf("KeyframeAtOrBefore failed: %v", err)
+	}
+	if keyframe != 599 {
+		t.Fatalf("keyframe = %.3f, want 599", keyframe)
+	}
+
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read ffprobe arguments: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(argsData)), "\n")
+	for index, arg := range args {
+		if arg != "-read_intervals" {
+			continue
+		}
+		if index+1 >= len(args) {
+			t.Fatal("-read_intervals has no value")
+		}
+		if args[index+1] != "570.000%601.000" {
+			t.Fatalf("read interval = %q, want %q", args[index+1], "570.000%601.000")
+		}
+		return
+	}
+
+	t.Fatal("-read_intervals argument not found")
+}
+
+func TestKeyframeAtOrBeforeClampsNearZeroInterval(t *testing.T) {
+	argsPath := filepath.Join(t.TempDir(), "args.log")
+	t.Setenv("FFPROBE_ARGS_LOG", argsPath)
+
+	binPath := filepath.Join(t.TempDir(), "ffprobe")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$FFPROBE_ARGS_LOG"
+printf '%s\n' '0.000000,K__'
+`
+	err := os.WriteFile(binPath, []byte(script), 0755)
+	if err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	probe := &ffprobe{bin: binPath}
+	keyframe, err := probe.KeyframeAtOrBefore(
+		context.Background(),
+		"/tmp/movie.mkv",
+		0,
+		0.25,
+	)
+	if err != nil {
+		t.Fatalf("KeyframeAtOrBefore failed: %v", err)
+	}
+	if keyframe != 0 {
+		t.Fatalf("keyframe = %.3f, want 0", keyframe)
+	}
+
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read ffprobe arguments: %v", err)
+	}
+	if !strings.Contains(string(argsData), "0.000%1.250") {
+		t.Fatalf("arguments do not contain clamped interval: %q", argsData)
 	}
 }

--- a/server/cmd/internal/helpers/subtitle_shift.go
+++ b/server/cmd/internal/helpers/subtitle_shift.go
@@ -1,0 +1,168 @@
+package helpers
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// webvttCueTiming matches the timing line of a WebVTT cue. WebVTT accepts both
+// `MM:SS.mmm` and `HH:MM:SS.mmm`, and anything after the end timestamp is cue
+// settings (`align:start`, `position:50%`, …) that must survive untouched.
+var webvttCueTiming = regexp.MustCompile(
+	`^((?:\d+:)?\d{2}:\d{2}\.\d{3})\s+-->\s+((?:\d+:)?\d{2}:\d{2}\.\d{3})(.*)$`,
+)
+
+// ShiftWebVTT rebases cue timings by offsetSec seconds.
+//
+// Subtitles are extracted from the source with absolute timestamps, but an HLS
+// session started with `-ss` has a media timeline that begins at zero. Handing
+// the browser absolute cues against a rebased timeline puts every subtitle out
+// by the session start, so the cues are shifted to match the session they will
+// be played against.
+//
+// Cues that end before the new zero are dropped; a cue straddling it is kept
+// with its start clamped to zero. Headers, `NOTE`/`STYLE`/`REGION` blocks, cue
+// identifiers and cue text all pass through unchanged.
+func ShiftWebVTT(raw []byte, offsetSec float64) []byte {
+	if len(raw) == 0 || offsetSec <= 0 {
+		return raw
+	}
+
+	lines := strings.Split(string(raw), "\n")
+	shifted := make([]string, 0, len(lines))
+
+	// A dropped cue takes its identifier and text with it, so track whether the
+	// block currently being copied belongs to a cue that fell before zero.
+	droppingCue := false
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			droppingCue = false
+			shifted = append(shifted, line)
+			continue
+		}
+
+		match := webvttCueTiming.FindStringSubmatch(trimmed)
+		if match == nil {
+			if droppingCue {
+				continue
+			}
+			shifted = append(shifted, line)
+			continue
+		}
+
+		startSec, startErr := parseWebVTTTimestamp(match[1])
+		endSec, endErr := parseWebVTTTimestamp(match[2])
+		if startErr != nil || endErr != nil {
+			shifted = append(shifted, line)
+			continue
+		}
+
+		newEnd := endSec - offsetSec
+		if newEnd < 0 {
+			// The cue is entirely before the session start. Drop it, and drop
+			// the identifier line already emitted for it.
+			droppingCue = true
+			shifted = dropTrailingCueIdentifier(shifted)
+			continue
+		}
+
+		newStart := startSec - offsetSec
+		if newStart < 0 {
+			newStart = 0
+		}
+
+		droppingCue = false
+		shifted = append(shifted, fmt.Sprintf(
+			"%s --> %s%s",
+			formatWebVTTTimestamp(newStart),
+			formatWebVTTTimestamp(newEnd),
+			match[3],
+		))
+	}
+
+	return []byte(strings.Join(shifted, "\n"))
+}
+
+// dropTrailingCueIdentifier removes the optional identifier line that precedes
+// a cue's timing line, so dropping a cue does not leave its label behind.
+func dropTrailingCueIdentifier(lines []string) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+
+	last := strings.TrimSpace(lines[len(lines)-1])
+	if last == "" {
+		return lines
+	}
+
+	// Structural blocks are not cue identifiers and must be preserved.
+	if strings.HasPrefix(last, "WEBVTT") ||
+		strings.HasPrefix(last, "NOTE") ||
+		strings.HasPrefix(last, "STYLE") ||
+		strings.HasPrefix(last, "REGION") {
+		return lines
+	}
+
+	return lines[:len(lines)-1]
+}
+
+func parseWebVTTTimestamp(value string) (float64, error) {
+	parts := strings.Split(value, ":")
+
+	var hours, minutes int
+	var seconds float64
+	var err error
+
+	switch len(parts) {
+	case 2:
+		minutes, err = strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, err
+		}
+		seconds, err = strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			return 0, err
+		}
+	case 3:
+		hours, err = strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, err
+		}
+		minutes, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, err
+		}
+		seconds, err = strconv.ParseFloat(parts[2], 64)
+		if err != nil {
+			return 0, err
+		}
+	default:
+		return 0, fmt.Errorf("invalid WebVTT timestamp %q", value)
+	}
+
+	return float64(hours)*3600 + float64(minutes)*60 + seconds, nil
+}
+
+func formatWebVTTTimestamp(totalSec float64) string {
+	if totalSec < 0 {
+		totalSec = 0
+	}
+
+	// Round to milliseconds first so 59.9999 does not format as ":60.000".
+	totalMillis := int64(totalSec*1000 + 0.5)
+
+	hours := totalMillis / 3600000
+	totalMillis -= hours * 3600000
+	minutes := totalMillis / 60000
+	totalMillis -= minutes * 60000
+	seconds := totalMillis / 1000
+	millis := totalMillis - seconds*1000
+
+	return fmt.Sprintf("%02d:%02d:%02d.%03d", hours, minutes, seconds, millis)
+}

--- a/server/cmd/internal/helpers/subtitle_shift_test.go
+++ b/server/cmd/internal/helpers/subtitle_shift_test.go
@@ -1,0 +1,127 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShiftWebVTT_RebasesCuesOntoSessionTimeline(t *testing.T) {
+	raw := []byte("WEBVTT\n\n" +
+		"00:10:05.000 --> 00:10:07.500\nFirst line\n\n" +
+		"00:10:09.250 --> 00:10:11.000\nSecond line\n")
+
+	got := string(ShiftWebVTT(raw, 600))
+
+	if !strings.Contains(got, "00:00:05.000 --> 00:00:07.500") {
+		t.Fatalf("first cue was not rebased: %s", got)
+	}
+	if !strings.Contains(got, "00:00:09.250 --> 00:00:11.000") {
+		t.Fatalf("second cue was not rebased: %s", got)
+	}
+	if !strings.HasPrefix(got, "WEBVTT") {
+		t.Fatalf("header was not preserved: %s", got)
+	}
+	if !strings.Contains(got, "First line") || !strings.Contains(got, "Second line") {
+		t.Fatalf("cue text was not preserved: %s", got)
+	}
+}
+
+func TestShiftWebVTT_ZeroOffsetIsUnchanged(t *testing.T) {
+	raw := []byte("WEBVTT\n\n00:00:05.000 --> 00:00:07.500\nLine\n")
+
+	got := string(ShiftWebVTT(raw, 0))
+
+	if got != string(raw) {
+		t.Fatalf("zero offset must not rewrite the payload, got: %s", got)
+	}
+}
+
+func TestShiftWebVTT_DropsCuesEntirelyBeforeTheSessionStart(t *testing.T) {
+	raw := []byte("WEBVTT\n\n" +
+		"00:00:05.000 --> 00:00:07.000\nEarly line\n\n" +
+		"00:10:05.000 --> 00:10:07.000\nKept line\n")
+
+	got := string(ShiftWebVTT(raw, 600))
+
+	if strings.Contains(got, "Early line") {
+		t.Fatalf("a cue before the session start should be dropped: %s", got)
+	}
+	if !strings.Contains(got, "Kept line") {
+		t.Fatalf("a cue inside the session should survive: %s", got)
+	}
+}
+
+func TestShiftWebVTT_ClampsCueStraddlingTheStart(t *testing.T) {
+	raw := []byte("WEBVTT\n\n00:09:58.000 --> 00:10:03.000\nStraddling\n")
+
+	got := string(ShiftWebVTT(raw, 600))
+
+	if !strings.Contains(got, "00:00:00.000 --> 00:00:03.000") {
+		t.Fatalf("straddling cue was not clamped to zero: %s", got)
+	}
+}
+
+func TestShiftWebVTT_PreservesCueSettingsAndIdentifiers(t *testing.T) {
+	raw := []byte("WEBVTT\n\n" +
+		"cue-42\n00:10:05.000 --> 00:10:07.000 align:start position:10%\nLine\n")
+
+	got := string(ShiftWebVTT(raw, 600))
+
+	if !strings.Contains(got, "00:00:05.000 --> 00:00:07.000 align:start position:10%") {
+		t.Fatalf("cue settings were not preserved: %s", got)
+	}
+	if !strings.Contains(got, "cue-42") {
+		t.Fatalf("cue identifier was not preserved: %s", got)
+	}
+}
+
+// A dropped cue must take its identifier with it, or the identifier attaches
+// itself to the following cue.
+func TestShiftWebVTT_DropsIdentifierOfDroppedCue(t *testing.T) {
+	raw := []byte("WEBVTT\n\n" +
+		"early-cue\n00:00:01.000 --> 00:00:02.000\nEarly\n\n" +
+		"kept-cue\n00:10:05.000 --> 00:10:07.000\nKept\n")
+
+	got := string(ShiftWebVTT(raw, 600))
+
+	if strings.Contains(got, "early-cue") {
+		t.Fatalf("identifier of a dropped cue was left behind: %s", got)
+	}
+	if !strings.Contains(got, "kept-cue") {
+		t.Fatalf("identifier of a surviving cue was removed: %s", got)
+	}
+}
+
+func TestShiftWebVTT_AcceptsShortTimestampForm(t *testing.T) {
+	raw := []byte("WEBVTT\n\n10:05.000 --> 10:07.000\nLine\n")
+
+	got := string(ShiftWebVTT(raw, 600))
+
+	if !strings.Contains(got, "00:00:05.000 --> 00:00:07.000") {
+		t.Fatalf("MM:SS.mmm form was not handled: %s", got)
+	}
+}
+
+func TestShiftWebVTT_PreservesStructuralBlocks(t *testing.T) {
+	raw := []byte("WEBVTT\n\n" +
+		"NOTE this is a comment\n\n" +
+		"STYLE\n::cue { color: white }\n\n" +
+		"00:10:05.000 --> 00:10:07.000\nLine\n")
+
+	got := string(ShiftWebVTT(raw, 600))
+
+	if !strings.Contains(got, "NOTE this is a comment") {
+		t.Fatalf("NOTE block was dropped: %s", got)
+	}
+	if !strings.Contains(got, "::cue { color: white }") {
+		t.Fatalf("STYLE block was dropped: %s", got)
+	}
+}
+
+func TestShiftWebVTT_EmptyInputIsUnchanged(t *testing.T) {
+	got := ShiftWebVTT(nil, 600)
+
+	if len(got) != 0 {
+		t.Fatalf("empty input must stay empty, got %q", string(got))
+	}
+}

--- a/web/e2e/direct-play-media.spec.ts
+++ b/web/e2e/direct-play-media.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { expect, test, type Page } from "@playwright/test";
 import { readE2EEnv, type E2EEnv } from "./e2e-env";
 import { directPlayAudioSelectionEligible } from "../src/lib/playback";
@@ -257,7 +258,7 @@ test.describe("Direct-play eligibility with real media", () => {
         data: {
           progress_sec: resumeTargetSec,
           duration_sec: durationSec,
-          save_session_id: `e2e-subtitle-persistence-${Date.now()}`,
+          save_session_id: randomUUID(),
           save_sequence: 1,
         },
         failOnStatusCode: false,

--- a/web/e2e/hls-transcode.spec.ts
+++ b/web/e2e/hls-transcode.spec.ts
@@ -104,6 +104,31 @@ function responsePath(response: Response) {
   return new URL(response.url()).pathname;
 }
 
+function isSuccessfulHlsAssetResponse(response: Response) {
+  return response.status() === 200 || response.status() === 206;
+}
+
+function assertSuccessfulHlsAssetResponse(response: Response) {
+  expect([200, 206]).toContain(response.status());
+
+  if (response.status() !== 206) return;
+
+  expect(response.request().headers()["range"]).toMatch(/^bytes=/i);
+  expect(response.headers()["accept-ranges"]).toBe("bytes");
+
+  const contentRange = response.headers()["content-range"];
+  const match = /^bytes (\d+)-(\d+)\/(\d+)$/.exec(contentRange ?? "");
+  expect(match, "206 response must contain a valid Content-Range").not.toBeNull();
+
+  if (match) {
+    const start = Number.parseInt(match[1], 10);
+    const end = Number.parseInt(match[2], 10);
+    const size = Number.parseInt(match[3], 10);
+    expect(start).toBeLessThanOrEqual(end);
+    expect(end).toBeLessThan(size);
+  }
+}
+
 function segmentName(url: string) {
   const match = new URL(url).pathname.match(/\/(segment_\d+\.m4s)$/);
   return match?.[1] ?? null;
@@ -168,7 +193,7 @@ async function waitForUniqueSegments(
 
   const remember = (response: Response) => {
     if (!responsePath(response).startsWith(assetPath)) return;
-    if (response.status() !== 200) return;
+    if (!isSuccessfulHlsAssetResponse(response)) return;
 
     const name = segmentName(response.url());
     if (name) found.set(name, response);
@@ -180,7 +205,7 @@ async function waitForUniqueSegments(
     const response = await page.waitForResponse(
       candidate => {
         if (!responsePath(candidate).startsWith(assetPath)) return false;
-        if (candidate.status() !== 200) return false;
+        if (!isSuccessfulHlsAssetResponse(candidate)) return false;
 
         const name = segmentName(candidate.url());
         return !!name && !found.has(name);
@@ -285,9 +310,10 @@ test.describe("HLS transcoding playback", () => {
       const initResponse = await page.waitForResponse(
         response =>
           responsePath(response) === `${assetPath}init.mp4` &&
-          response.status() === 200,
+          isSuccessfulHlsAssetResponse(response),
         { timeout: hlsEnv!.responseTimeoutMs },
       );
+      assertSuccessfulHlsAssetResponse(initResponse);
       expect(initResponse.headers()["content-type"]).toContain("video/mp4");
       assertHlsQuery(initResponse, query);
 
@@ -299,6 +325,7 @@ test.describe("HLS transcoding playback", () => {
         hlsEnv!.responseTimeoutMs,
       );
       for (const response of segmentResponses) {
+        assertSuccessfulHlsAssetResponse(response);
         expect(response.headers()["content-type"]).toContain("video/mp4");
         assertHlsQuery(response, query);
       }

--- a/web/e2e/movie-player.spec.ts
+++ b/web/e2e/movie-player.spec.ts
@@ -24,6 +24,37 @@ async function openMoviePlayer(page: Page) {
   ).toBeVisible();
 }
 
+async function recordHlsManifestRequests(
+  page: Page,
+  manifestRequests: string[],
+) {
+  const usesNativeHls = await page.evaluate(() => {
+    const video = document.createElement("video");
+    return (
+      video.canPlayType("application/vnd.apple.mpegurl") !== "" ||
+      video.canPlayType("application/x-mpegURL") !== ""
+    );
+  });
+
+  await page.route(
+    "**/api/movies/101/hls/*/playlist.m3u8*",
+    async route => {
+      manifestRequests.push(route.request().url());
+      if (usesNativeHls && route.request().resourceType() === "fetch") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/vnd.apple.mpegurl",
+          body: "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:1\n#EXT-X-ENDLIST\n",
+        });
+      }
+    },
+  );
+
+  // Native HLS performs one metadata preflight, then one media load of the
+  // same URL. hls.js reads metadata from its single manifest request.
+  return usesNativeHls ? 2 : 1;
+}
+
 for (const {
   label,
   mode,
@@ -61,11 +92,9 @@ for (const {
     await page.route("**/api/movies/101/stream*", route => {
       mediaRequests.push(route.request().url());
     });
-    await page.route(
-      "**/api/movies/101/hls/*/playlist.m3u8*",
-      route => {
-        mediaRequests.push(route.request().url());
-      },
+    const expectedHlsRequestCount = await recordHlsManifestRequests(
+      page,
+      mediaRequests,
     );
 
     await page.goto(
@@ -79,8 +108,13 @@ for (const {
 
     releasePlaybackSettings();
 
-    await expect.poll(() => mediaRequests.length).toBe(1);
-    expect(mediaRequests[0]).toContain(expectedRequestPath);
+    const expectedRequestCount =
+      mode === "direct" ? 1 : expectedHlsRequestCount;
+    await expect.poll(() => mediaRequests.length).toBe(expectedRequestCount);
+    expect(mediaRequests).toHaveLength(expectedRequestCount);
+    for (const request of mediaRequests) {
+      expect(request).toContain(expectedRequestPath);
+    }
   });
 }
 
@@ -157,11 +191,9 @@ test("cold non-first audio waits for metadata and never requests the raw stream"
   await page.route("**/api/movies/101/stream*", route => {
     mediaRequests.push(route.request().url());
   });
-  await page.route(
-    "**/api/movies/101/hls/*/playlist.m3u8*",
-    route => {
-      mediaRequests.push(route.request().url());
-    },
+  const expectedRequestCount = await recordHlsManifestRequests(
+    page,
+    mediaRequests,
   );
 
   await page.goto(
@@ -175,12 +207,14 @@ test("cold non-first audio waits for metadata and never requests the raw stream"
 
   releaseTechnicalDetails();
 
-  await expect.poll(() => mediaRequests.length).toBe(1);
+  await expect.poll(() => mediaRequests.length).toBe(expectedRequestCount);
+  expect(mediaRequests).toHaveLength(expectedRequestCount);
   const requestUrl = new URL(mediaRequests[0]);
   expect(requestUrl.pathname).toBe(
     "/api/movies/101/hls/remux/playlist.m3u8",
   );
   expect(requestUrl.searchParams.get("audio_track")).toBe("1");
+  expect(mediaRequests.every(url => url === mediaRequests[0])).toBe(true);
   expect(
     mediaRequests.some(url => new URL(url).pathname.endsWith("/stream")),
   ).toBe(false);
@@ -221,11 +255,9 @@ test("cold direct deep link to an ineligible file never requests the raw stream"
   await page.route("**/api/movies/101/stream*", route => {
     mediaRequests.push(route.request().url());
   });
-  await page.route(
-    "**/api/movies/101/hls/*/playlist.m3u8*",
-    route => {
-      mediaRequests.push(route.request().url());
-    },
+  const expectedRequestCount = await recordHlsManifestRequests(
+    page,
+    mediaRequests,
   );
 
   await page.goto(
@@ -242,10 +274,12 @@ test("cold direct deep link to an ineligible file never requests the raw stream"
   await expect
     .poll(() => new URL(page.url()).searchParams.get("mode"))
     .toBe("remux");
-  await expect.poll(() => mediaRequests.length).toBe(1);
+  await expect.poll(() => mediaRequests.length).toBe(expectedRequestCount);
+  expect(mediaRequests).toHaveLength(expectedRequestCount);
   expect(new URL(mediaRequests[0]).pathname).toBe(
     "/api/movies/101/hls/remux/playlist.m3u8",
   );
+  expect(mediaRequests.every(url => url === mediaRequests[0])).toBe(true);
   expect(
     mediaRequests.some(url => new URL(url).pathname.endsWith("/stream")),
   ).toBe(false);

--- a/web/src/components/playback/VideoPlayer.tsx
+++ b/web/src/components/playback/VideoPlayer.tsx
@@ -6,6 +6,7 @@ import type { Events } from "hls.js";
 import { Spinner } from "@/components/ui/spinner";
 import {
   HLS_CAPACITY_RETRY_FALLBACK_SEC,
+  HLS_EFFECTIVE_PROFILE_HEADER,
   HLS_JS_BACK_BUFFER_LENGTH_SEC,
   HLS_JS_LOAD_TIMEOUT_MS,
   MOTION_MEDIA_OVERLAY_ENTER_CLASS,
@@ -39,6 +40,11 @@ type VideoPlayerProps = {
   onStartApplied?: (time: number) => void;
   onSessionLost?: (currentTime: number) => void;
   onCapacityBusy?: (retryAfterSec: number) => void;
+  /**
+   * Reports the profile the server actually ran, which differs from the
+   * requested one whenever the remux safety gate forced a transcode.
+   */
+  onEffectiveProfile?: (profileId: string) => void;
 };
 
 function loadHlsLight() {
@@ -66,6 +72,7 @@ export default function VideoPlayer({
   onStartApplied,
   onSessionLost,
   onCapacityBusy,
+  onEffectiveProfile,
 }: VideoPlayerProps) {
   const hlsRef = useRef<Hls | null>(null);
 
@@ -134,6 +141,23 @@ export default function VideoPlayer({
     return true;
   });
 
+  // Reads the effective profile off the manifest response. Mirrors the
+  // XMLHttpRequest access `handleCapacityBusy` uses for Retry-After; hls.js
+  // types `networkDetails` as unknown because the loader is pluggable.
+  const reportEffectiveProfile = useEffectEvent((networkDetails: unknown) => {
+    if (!onEffectiveProfile) return;
+
+    try {
+      const xhr = networkDetails as XMLHttpRequest | null | undefined;
+      const profile = xhr?.getResponseHeader?.(HLS_EFFECTIVE_PROFILE_HEADER);
+      if (profile) {
+        onEffectiveProfile(profile);
+      }
+    } catch {
+      // Header unavailable on this loader; the badge keeps the requested mode.
+    }
+  });
+
   const handleHlsError = useEffectEvent(
     (
       video: HTMLVideoElement,
@@ -177,7 +201,15 @@ export default function VideoPlayer({
     void (async () => {
       try {
         const { default: Hls } = await loadHlsLight();
-        if (cancelled || !Hls.isSupported()) return;
+        if (cancelled) return;
+        if (!Hls.isSupported()) {
+          // Neither Media Source Extensions nor native HLS: without this the
+          // player would sit blank with no explanation at all.
+          reportError(
+            "This browser cannot play streamed video (no Media Source Extensions support).",
+          );
+          return;
+        }
 
         const hls = new Hls({
           xhrSetup(xhr: XMLHttpRequest) {
@@ -204,6 +236,13 @@ export default function VideoPlayer({
             handleStartApplied(startSec);
           });
         }
+
+        // The manifest response names the profile the server really ran. The
+        // request URL cannot: a remux request that fails the safety gate is
+        // still served from the /hls/remux/ path.
+        hls.once(Hls.Events.MANIFEST_LOADED, (_event, data) => {
+          reportEffectiveProfile(data.networkDetails);
+        });
 
         let mediaRecoveryAttempted = false;
         hls.on(Hls.Events.ERROR, (_event: Events.ERROR, data: ErrorData) => {

--- a/web/src/components/playback/VideoPlayer.tsx
+++ b/web/src/components/playback/VideoPlayer.tsx
@@ -5,6 +5,7 @@ import type { ErrorData } from "hls.js";
 import type { Events } from "hls.js";
 import { Spinner } from "@/components/ui/spinner";
 import {
+  HLS_ACTUAL_START_HEADER,
   HLS_CAPACITY_RETRY_FALLBACK_SEC,
   HLS_EFFECTIVE_PROFILE_HEADER,
   HLS_JS_BACK_BUFFER_LENGTH_SEC,
@@ -37,6 +38,8 @@ type VideoPlayerProps = {
   onNativeError?: (code: number | null | undefined) => void;
   subtitleTrack?: SubtitleTrackInfo | null;
   startSec?: number;
+  /** Requested absolute start that identifies the current HLS session. */
+  requestedStartSec?: number;
   onStartApplied?: (time: number) => void;
   onSessionLost?: (currentTime: number) => void;
   onCapacityBusy?: (retryAfterSec: number) => void;
@@ -45,6 +48,8 @@ type VideoPlayerProps = {
    * requested one whenever the remux safety gate forced a transcode.
    */
   onEffectiveProfile?: (profileId: string) => void;
+  /** Reports the validated absolute start measured for the HLS media. */
+  onActualStart?: (startSec: number) => void;
 };
 
 function loadHlsLight() {
@@ -53,6 +58,92 @@ function loadHlsLight() {
 
 const HLS_NETWORK_ERROR = "networkError" as ErrorData["type"];
 const HLS_MEDIA_ERROR = "mediaError" as ErrorData["type"];
+
+type ManifestHeaders = {
+  get: (name: string) => string | null;
+};
+
+type ManifestMetadata = {
+  effectiveProfile: string | null;
+  actualStartSec: number | null;
+};
+
+function readManifestHeader(
+  headers: ManifestHeaders | null,
+  name: string,
+): string | null {
+  if (!headers) return null;
+
+  try {
+    return headers.get(name);
+  } catch {
+    return null;
+  }
+}
+
+function manifestHeadersFromNetworkDetails(
+  networkDetails: unknown,
+): ManifestHeaders | null {
+  try {
+    const xhr = networkDetails as XMLHttpRequest | null | undefined;
+    if (typeof xhr?.getResponseHeader !== "function") return null;
+
+    return {
+      get: (name) => xhr.getResponseHeader(name),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseManifestMetadata(
+  headers: ManifestHeaders | null,
+  requestedStartSec: number | undefined,
+): ManifestMetadata {
+  const effectiveProfile =
+    readManifestHeader(headers, HLS_EFFECTIVE_PROFILE_HEADER)?.trim() || null;
+  const rawActualStart = readManifestHeader(
+    headers,
+    HLS_ACTUAL_START_HEADER,
+  )?.trim();
+
+  if (
+    !rawActualStart ||
+    requestedStartSec === undefined ||
+    !Number.isFinite(requestedStartSec) ||
+    requestedStartSec < 0
+  ) {
+    return { effectiveProfile, actualStartSec: null };
+  }
+
+  const parsedActualStart = Number(rawActualStart);
+  const validActualStart =
+    Number.isFinite(parsedActualStart) &&
+    parsedActualStart >= 0 &&
+    parsedActualStart <= requestedStartSec;
+
+  return {
+    effectiveProfile,
+    actualStartSec: validActualStart ? Math.max(0, parsedActualStart) : null,
+  };
+}
+
+function retryAfterSecFromHeaders(headers: ManifestHeaders | null): number {
+  const header = readManifestHeader(headers, "Retry-After");
+  const parsed = header ? Number.parseInt(header, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return HLS_CAPACITY_RETRY_FALLBACK_SEC;
+}
+
+async function releaseResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // The headers are still usable; body release is best-effort.
+  }
+}
 
 export default function VideoPlayer({
   videoRef,
@@ -69,10 +160,12 @@ export default function VideoPlayer({
   onNativeError,
   subtitleTrack = null,
   startSec = 0,
+  requestedStartSec,
   onStartApplied,
   onSessionLost,
   onCapacityBusy,
   onEffectiveProfile,
+  onActualStart,
 }: VideoPlayerProps) {
   const hlsRef = useRef<Hls | null>(null);
 
@@ -122,41 +215,32 @@ export default function VideoPlayer({
 
   // Returns false when no onCapacityBusy consumer exists so the caller can
   // fall through to the regular fatal-error handling.
-  const handleCapacityBusy = useEffectEvent((data: ErrorData): boolean => {
-    if (!onCapacityBusy) return false;
+  const handleCapacityBusy = useEffectEvent(
+    (headers: ManifestHeaders | null): boolean => {
+      if (!onCapacityBusy) return false;
 
-    let retryAfterSec = HLS_CAPACITY_RETRY_FALLBACK_SEC;
-    try {
-      const xhr = data.networkDetails as XMLHttpRequest | null | undefined;
-      const header = xhr?.getResponseHeader?.("Retry-After");
-      const parsed = header ? Number.parseInt(header, 10) : NaN;
-      if (Number.isFinite(parsed) && parsed > 0) {
-        retryAfterSec = parsed;
+      onCapacityBusy(retryAfterSecFromHeaders(headers));
+      return true;
+    },
+  );
+
+  const reportManifestMetadata = useEffectEvent(
+    (headers: ManifestHeaders | null) => {
+      const metadata = parseManifestMetadata(headers, requestedStartSec);
+
+      if (metadata.effectiveProfile && onEffectiveProfile) {
+        onEffectiveProfile(metadata.effectiveProfile);
       }
-    } catch {
-      // Header unavailable on this loader; keep the fallback delay.
-    }
-
-    onCapacityBusy(retryAfterSec);
-    return true;
-  });
-
-  // Reads the effective profile off the manifest response. Mirrors the
-  // XMLHttpRequest access `handleCapacityBusy` uses for Retry-After; hls.js
-  // types `networkDetails` as unknown because the loader is pluggable.
-  const reportEffectiveProfile = useEffectEvent((networkDetails: unknown) => {
-    if (!onEffectiveProfile) return;
-
-    try {
-      const xhr = networkDetails as XMLHttpRequest | null | undefined;
-      const profile = xhr?.getResponseHeader?.(HLS_EFFECTIVE_PROFILE_HEADER);
-      if (profile) {
-        onEffectiveProfile(profile);
+      if (metadata.actualStartSec !== null && onActualStart) {
+        onActualStart(metadata.actualStartSec);
       }
-    } catch {
-      // Header unavailable on this loader; the badge keeps the requested mode.
-    }
-  });
+    },
+  );
+  const needsNativeManifestPreflight =
+    isHlsSource &&
+    (onCapacityBusy !== undefined ||
+      onEffectiveProfile !== undefined ||
+      onActualStart !== undefined);
 
   const handleHlsError = useEffectEvent(
     (
@@ -241,7 +325,9 @@ export default function VideoPlayer({
         // request URL cannot: a remux request that fails the safety gate is
         // still served from the /hls/remux/ path.
         hls.once(Hls.Events.MANIFEST_LOADED, (_event, data) => {
-          reportEffectiveProfile(data.networkDetails);
+          reportManifestMetadata(
+            manifestHeadersFromNetworkDetails(data.networkDetails),
+          );
         });
 
         let mediaRecoveryAttempted = false;
@@ -261,7 +347,12 @@ export default function VideoPlayer({
               data.details === Hls.ErrorDetails.LEVEL_LOAD_ERROR) &&
             data.response?.code === 503;
 
-          if (isCapacityBusyError && handleCapacityBusy(data)) {
+          if (
+            isCapacityBusyError &&
+            handleCapacityBusy(
+              manifestHeadersFromNetworkDetails(data.networkDetails),
+            )
+          ) {
             return;
           }
 
@@ -297,12 +388,59 @@ export default function VideoPlayer({
     if (!video || !src) return;
     if (isHlsSource && !supportsNativeHLS) return;
 
-    video.src = src;
-    return () => {
+    const clearSource = () => {
       video.removeAttribute("src");
       video.load();
     };
-  }, [isHlsSource, src, videoRef]);
+    if (!needsNativeManifestPreflight) {
+      video.src = src;
+      return clearSource;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    void (async () => {
+      try {
+        // React Strict Mode immediately cleans up and re-runs effects once in
+        // development. Defer the request until that probe mount can cancel so
+        // it cannot issue a duplicate manifest preflight.
+        await Promise.resolve();
+        if (cancelled) return;
+
+        const response = await fetch(src, {
+          credentials: "include",
+          signal: controller.signal,
+        });
+        await releaseResponseBody(response);
+        if (cancelled) return;
+
+        const handledCapacityFailure =
+          response.status === 503 &&
+          handleCapacityBusy(response.headers);
+        if (handledCapacityFailure) return;
+
+        if (response.ok) {
+          reportManifestMetadata(response.headers);
+        }
+        if (!cancelled) {
+          video.src = src;
+        }
+      } catch {
+        if (!cancelled) {
+          // Metadata is advisory. Let the native player use its existing
+          // loading and error behavior when the preflight itself fails.
+          video.src = src;
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      clearSource();
+    };
+  }, [isHlsSource, needsNativeManifestPreflight, src, videoRef]);
 
   useEffect(() => {
     const video = videoRef.current;

--- a/web/src/components/watch-room/WatchRoomPage.tsx
+++ b/web/src/components/watch-room/WatchRoomPage.tsx
@@ -78,10 +78,10 @@ export function WatchRoomPage({ roomId }: WatchRoomPageProps) {
   const streamUrl = room
     ? watchRoomStreamUrl(room.id, room.playback_mode, streamReloadKey)
     : "";
-  // Rooms have no per-client playback session, so the window is just the room,
-  // its mode, and the reload generation.
+  // Reload changes only the source URL. Keeping it out of this key prevents a
+  // player rebuild from replenishing either recovery budget.
   const streamWindowKey = room
-    ? `${room.id}:${room.playback_mode}:${streamReloadKey}`
+    ? `${room.id}:${room.playback_mode}`
     : "";
   const posterUrl =
     room?.movie_poster != null

--- a/web/src/components/watch-room/WatchRoomPage.tsx
+++ b/web/src/components/watch-room/WatchRoomPage.tsx
@@ -30,6 +30,9 @@ import {
 } from "@/lib/query-opts";
 import { buildMovieSubtitleTrackInfo } from "@/lib/movie-playback";
 import { watchRoomStreamUrl } from "@/lib/watch-room";
+import { useHlsCapacityRetry } from "@/hooks/useHlsCapacityRetry";
+import { useHlsSessionKeepalive } from "@/hooks/useHlsSessionKeepalive";
+import { useHlsSessionRecovery } from "@/hooks/useHlsSessionRecovery";
 import { cn } from "@/lib/utils";
 import DeleteWatchRoomDialog from "@/components/watch-room/DeleteWatchRoomDialog";
 import { Button } from "@/components/ui/button";
@@ -57,6 +60,7 @@ export function WatchRoomPage({ roomId }: WatchRoomPageProps) {
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [streamReloadKey, setStreamReloadKey] = useState(0);
 
   const {
     isFullscreen,
@@ -70,8 +74,14 @@ export function WatchRoomPage({ roomId }: WatchRoomPageProps) {
   const room = data?.error === false ? data.data.room : null;
   const currentRoomId = room?.id ?? null;
   const movieTitle = room?.movie_title ?? "";
+  const isHlsRoom = room ? room.playback_mode !== "direct" : false;
   const streamUrl = room
-    ? watchRoomStreamUrl(room.id, room.playback_mode)
+    ? watchRoomStreamUrl(room.id, room.playback_mode, streamReloadKey)
+    : "";
+  // Rooms have no per-client playback session, so the window is just the room,
+  // its mode, and the reload generation.
+  const streamWindowKey = room
+    ? `${room.id}:${room.playback_mode}:${streamReloadKey}`
     : "";
   const posterUrl =
     room?.movie_poster != null
@@ -115,6 +125,34 @@ export function WatchRoomPage({ roomId }: WatchRoomPageProps) {
         subtitleStreams,
       })
     : null;
+
+  // Room HLS sessions can be evicted or refused exactly like personal ones, and
+  // until now a room had no recovery at all: a fragment 404 or a capacity 503
+  // went straight to a dead "Stream error" (audit H9). Recovery rebuilds the
+  // player; the WebSocket sync then pulls the playhead back to the host's
+  // position, so participants are not thrown back to the start.
+  const { waitingForCapacity, handleCapacityBusy } = useHlsCapacityRetry({
+    streamWindowKey,
+    onRetry: () => setStreamReloadKey(prev => prev + 1),
+    onMaxAttempts: () =>
+      setPlaybackError(
+        "The server is running at its transcoding limit. Try again shortly.",
+      ),
+  });
+
+  const { handleSessionLost } = useHlsSessionRecovery({
+    streamWindowKey,
+    onRecover: () => setStreamReloadKey(prev => prev + 1),
+    onMaxAttempts: () =>
+      setPlaybackError("The playback session expired. Reload to keep watching."),
+  });
+
+  // Rooms keep a long TTL but nothing refreshes it while every participant is
+  // paused, so without this a paused room can be evicted mid-film.
+  useHlsSessionKeepalive({
+    enabled: isHlsRoom && !playbackError,
+    streamUrl,
+  });
 
   const playVideo = async () => {
     const video = videoRef.current;
@@ -272,6 +310,9 @@ export function WatchRoomPage({ roomId }: WatchRoomPageProps) {
             room={room}
             streamUrl={streamUrl}
             subtitleTrack={subtitleTrack}
+            waitingForCapacity={waitingForCapacity}
+            onSessionLost={handleSessionLost}
+            onCapacityBusy={handleCapacityBusy}
             videoRef={videoRef}
             playing={playing}
             currentTime={currentTime}
@@ -469,6 +510,9 @@ type WatchRoomPlayerPanelProps = {
   playerFullscreenMode: boolean;
   isFullscreen: boolean;
   isImmersiveViewport: boolean;
+  waitingForCapacity: boolean;
+  onSessionLost: (currentTime: number) => void;
+  onCapacityBusy: (retryAfterSec: number) => void;
   onError: (error: string | null) => void;
   onPlayingChange: (playing: boolean) => void;
   onTimeUpdate: (time: number) => void;
@@ -493,6 +537,9 @@ function WatchRoomPlayerPanel({
   playerFullscreenMode,
   isFullscreen,
   isImmersiveViewport,
+  waitingForCapacity,
+  onSessionLost,
+  onCapacityBusy,
   onError,
   onPlayingChange,
   onTimeUpdate,
@@ -525,7 +572,18 @@ function WatchRoomPlayerPanel({
           onTimeUpdate={onTimeUpdate}
           onDurationChange={onDurationChange}
           subtitleTrack={subtitleTrack}
+          onSessionLost={onSessionLost}
+          onCapacityBusy={onCapacityBusy}
         />
+
+        {waitingForCapacity && (
+          <p
+            className="border-t border-border px-4 py-3 text-sm text-muted-foreground sm:px-5"
+            role="status"
+          >
+            Waiting for server capacity…
+          </p>
+        )}
 
         <div className="border-t border-border p-4 sm:p-5">
           <ProgressBar

--- a/web/src/hooks/useMoviePlaybackData.ts
+++ b/web/src/hooks/useMoviePlaybackData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { STREAM_MODES, TMDB_POSTER_SIZE } from "@/lib/constants";
 import {
@@ -136,19 +136,31 @@ export function useMoviePlaybackData({
     0,
     movieDurationSec ?? 0,
   );
-  const hlsStartSec = hlsStartTimeSec(isHlsPlayback, playbackStartSec);
+  const streamAudioTrack =
+    techLoaded && audioStreams.length === 0 ? null : resolvedAudioTrack;
+  const requestedHlsStartSec = hlsStartTimeSec(
+    isHlsPlayback,
+    playbackStartSec,
+  );
+  const sessionWindowKey = `${movieId}:${resolvedMode}:${streamAudioTrack ?? "none"}:${playbackSessionId}:${Math.floor(requestedHlsStartSec)}`;
+  const [reportedActualStart, setReportedActualStart] = useState<{
+    sessionWindowKey: string;
+    startSec: number;
+  } | null>(null);
+  const actualHlsStartSec =
+    reportedActualStart?.sessionWindowKey === sessionWindowKey
+      ? reportedActualStart.startSec
+      : requestedHlsStartSec;
   const hlsPlaybackOffset = hlsPlaybackOffsetSec(
     isHlsPlayback,
     playbackStartSec,
-    hlsStartSec,
+    actualHlsStartSec,
   );
-  const streamAudioTrack =
-    techLoaded && audioStreams.length === 0 ? null : resolvedAudioTrack;
   const streamUrl = buildMovieStreamUrl(
     movieId,
     resolvedMode,
     streamAudioTrack,
-    hlsStartSec,
+    requestedHlsStartSec,
     streamReloadKey,
     playbackSessionId,
   );
@@ -161,15 +173,35 @@ export function useMoviePlaybackData({
     availableModes !== null && availableModes.length === 0;
   const directPlayAvailable =
     availableModes?.some((m) => m.id === "direct") ?? false;
-  const playbackTiming = { isHlsPlayback, hlsStartSec, movieDurationSec };
+  const playbackTiming = {
+    isHlsPlayback,
+    actualHlsStartSec,
+    movieDurationSec,
+  };
   const subtitleInfo = buildMovieSubtitleTrackInfo({
     movieId,
     resolvedSubtitleTrack,
     techLoaded,
     subtitleStreams,
-    hlsStartSec,
+    actualHlsStartSec,
   });
-  const sessionWindowKey = `${movieId}:${resolvedMode}:${streamAudioTrack ?? "none"}:${playbackSessionId}:${Math.floor(hlsStartSec)}`;
+
+  const handleActualHlsStart = (startSec: number) => {
+    const validStart =
+      Number.isFinite(startSec) &&
+      startSec >= 0 &&
+      startSec <= requestedHlsStartSec;
+    if (!validStart) return;
+
+    setReportedActualStart((previous) => {
+      const unchanged =
+        previous?.sessionWindowKey === sessionWindowKey &&
+        previous.startSec === startSec;
+      if (unchanged) return previous;
+
+      return { sessionWindowKey, startSec };
+    });
+  };
 
   const syncSearch = useEffectEvent((target: PlaybackSettings) => {
     onSyncSearch(target);
@@ -224,12 +256,14 @@ export function useMoviePlaybackData({
     resolvedSubtitleTrack,
     isHlsPlayback,
     playbackStartSec,
-    hlsStartSec,
+    requestedHlsStartSec,
+    actualHlsStartSec,
     hlsPlaybackOffset,
     streamUrl,
     subtitleInfo,
     playbackTiming,
     movieDurationSec,
     sessionWindowKey,
+    handleActualHlsStart,
   };
 }

--- a/web/src/hooks/useMoviePlaybackData.ts
+++ b/web/src/hooks/useMoviePlaybackData.ts
@@ -167,6 +167,7 @@ export function useMoviePlaybackData({
     resolvedSubtitleTrack,
     techLoaded,
     subtitleStreams,
+    hlsStartSec,
   });
   const sessionWindowKey = `${movieId}:${resolvedMode}:${streamAudioTrack ?? "none"}:${playbackSessionId}:${Math.floor(hlsStartSec)}`;
 

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -246,6 +246,13 @@ export const HLS_CAPACITY_RETRY_MAX_ATTEMPTS = 6;
 /** Retry delay when the server's 503 response carries no usable Retry-After header. */
 export const HLS_CAPACITY_RETRY_FALLBACK_SEC = 5;
 
+/**
+ * Manifest response header naming the profile the server actually ran. A remux
+ * request that fails the server's safety gate is still served from the
+ * /hls/remux/ path, so the URL alone cannot tell the client what it is getting.
+ */
+export const HLS_EFFECTIVE_PROFILE_HEADER = "X-Igloo-Effective-Profile";
+
 /** Manifest refetch cadence that keeps the server HLS session's idle TTL (5 min) refreshed while the player is mounted. */
 export const HLS_SESSION_KEEPALIVE_INTERVAL_MS = 120_000;
 /** hls.js: manifest / level / fragment request timeout (ms). */

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -252,6 +252,8 @@ export const HLS_CAPACITY_RETRY_FALLBACK_SEC = 5;
  * /hls/remux/ path, so the URL alone cannot tell the client what it is getting.
  */
 export const HLS_EFFECTIVE_PROFILE_HEADER = "X-Igloo-Effective-Profile";
+/** Manifest response header reporting where rebased HLS media actually begins. */
+export const HLS_ACTUAL_START_HEADER = "X-Igloo-Actual-Start";
 
 /** Manifest refetch cadence that keeps the server HLS session's idle TTL (5 min) refreshed while the player is mounted. */
 export const HLS_SESSION_KEEPALIVE_INTERVAL_MS = 120_000;

--- a/web/src/lib/movie-playback.ts
+++ b/web/src/lib/movie-playback.ts
@@ -31,7 +31,7 @@ type MoviePlaybackStatusArgs = {
 
 type PlaybackTimingOptions = {
   isHlsPlayback: boolean;
-  hlsStartSec: number;
+  actualHlsStartSec: number;
   movieDurationSec?: number;
 };
 
@@ -41,13 +41,13 @@ type SubtitleTrackInfoOptions = {
   techLoaded: boolean;
   subtitleStreams: SubtitleType[];
   /** Session start the cues must be rebased onto; 0 for direct play. */
-  hlsStartSec?: number;
+  actualHlsStartSec?: number;
 };
 
 type RebaseOptions = {
   isHlsPlayback: boolean;
   targetTimeSec: number;
-  hlsStartSec: number;
+  actualHlsStartSec: number;
   currentVideoTimeSec: number;
 };
 
@@ -203,34 +203,38 @@ export function hlsStartTimeSec(isHlsPlayback: boolean, startSec: number) {
 export function hlsPlaybackOffsetSec(
   isHlsPlayback: boolean,
   startSec: number,
-  hlsStartSec: number,
+  actualHlsStartSec: number,
 ) {
-  return isHlsPlayback ? Math.max(0, startSec - hlsStartSec) : 0;
+  return isHlsPlayback ? Math.max(0, startSec - actualHlsStartSec) : 0;
 }
 
 export function toAbsolutePlaybackTime(
   timeSec: number,
-  { isHlsPlayback, hlsStartSec }: PlaybackTimingOptions,
+  { isHlsPlayback, actualHlsStartSec }: PlaybackTimingOptions,
 ) {
-  return isHlsPlayback ? hlsStartSec + timeSec : timeSec;
+  return isHlsPlayback ? actualHlsStartSec + timeSec : timeSec;
 }
 
 export function toMediaPlaybackTime(
   timeSec: number,
-  { isHlsPlayback, hlsStartSec }: PlaybackTimingOptions,
+  { isHlsPlayback, actualHlsStartSec }: PlaybackTimingOptions,
 ) {
-  return isHlsPlayback ? Math.max(0, timeSec - hlsStartSec) : timeSec;
+  return isHlsPlayback ? Math.max(0, timeSec - actualHlsStartSec) : timeSec;
 }
 
 export function toAbsoluteDuration(
   durationSec: number,
-  { isHlsPlayback, hlsStartSec, movieDurationSec }: PlaybackTimingOptions,
+  {
+    isHlsPlayback,
+    actualHlsStartSec,
+    movieDurationSec,
+  }: PlaybackTimingOptions,
 ) {
   if (!isHlsPlayback) return durationSec;
   if (movieDurationSec && movieDurationSec > 0) {
     return movieDurationSec;
   }
-  return hlsStartSec + durationSec;
+  return actualHlsStartSec + durationSec;
 }
 
 export function displayedMovieDuration(
@@ -248,7 +252,7 @@ export function buildMovieSubtitleTrackInfo({
   resolvedSubtitleTrack,
   techLoaded,
   subtitleStreams,
-  hlsStartSec = 0,
+  actualHlsStartSec = 0,
 }: SubtitleTrackInfoOptions) {
   if (resolvedSubtitleTrack === null || !techLoaded) return null;
   if (
@@ -263,7 +267,8 @@ export function buildMovieSubtitleTrackInfo({
   // timeline starts at zero, so the server must shift them by the session
   // start or every subtitle is out by that offset (audit H4). Direct play and
   // sessions starting at zero need no shift.
-  const query = hlsStartSec > 0 ? `?start=${hlsStartSec}` : "";
+  const query =
+    actualHlsStartSec > 0 ? `?start=${actualHlsStartSec}` : "";
 
   return {
     url: `/api/movies/${movieId}/subtitles/${resolvedSubtitleTrack}/web.vtt${query}`,
@@ -302,12 +307,12 @@ export function clampMoviePlaybackTime(
 export function shouldRebaseHlsMovieSession({
   isHlsPlayback,
   targetTimeSec,
-  hlsStartSec,
+  actualHlsStartSec,
   currentVideoTimeSec,
 }: RebaseOptions) {
   return (
     isHlsPlayback &&
-    (targetTimeSec < hlsStartSec ||
+    (targetTimeSec < actualHlsStartSec ||
       targetTimeSec >
         currentVideoTimeSec + MOVIE_HLS_FORWARD_REBASE_THRESHOLD_SEC)
   );

--- a/web/src/lib/movie-playback.ts
+++ b/web/src/lib/movie-playback.ts
@@ -263,11 +263,7 @@ export function buildMovieSubtitleTrackInfo({
   // timeline starts at zero, so the server must shift them by the session
   // start or every subtitle is out by that offset (audit H4). Direct play and
   // sessions starting at zero need no shift.
-  const params = new URLSearchParams();
-  if (hlsStartSec > 0) {
-    params.set("start", String(Math.floor(hlsStartSec)));
-  }
-  const query = params.size > 0 ? `?${params}` : "";
+  const query = hlsStartSec > 0 ? `?start=${Math.floor(hlsStartSec)}` : "";
 
   return {
     url: `/api/movies/${movieId}/subtitles/${resolvedSubtitleTrack}/web.vtt${query}`,

--- a/web/src/lib/movie-playback.ts
+++ b/web/src/lib/movie-playback.ts
@@ -263,7 +263,7 @@ export function buildMovieSubtitleTrackInfo({
   // timeline starts at zero, so the server must shift them by the session
   // start or every subtitle is out by that offset (audit H4). Direct play and
   // sessions starting at zero need no shift.
-  const query = hlsStartSec > 0 ? `?start=${Math.floor(hlsStartSec)}` : "";
+  const query = hlsStartSec > 0 ? `?start=${hlsStartSec}` : "";
 
   return {
     url: `/api/movies/${movieId}/subtitles/${resolvedSubtitleTrack}/web.vtt${query}`,

--- a/web/src/lib/movie-playback.ts
+++ b/web/src/lib/movie-playback.ts
@@ -40,6 +40,8 @@ type SubtitleTrackInfoOptions = {
   resolvedSubtitleTrack: number | null;
   techLoaded: boolean;
   subtitleStreams: SubtitleType[];
+  /** Session start the cues must be rebased onto; 0 for direct play. */
+  hlsStartSec?: number;
 };
 
 type RebaseOptions = {
@@ -246,6 +248,7 @@ export function buildMovieSubtitleTrackInfo({
   resolvedSubtitleTrack,
   techLoaded,
   subtitleStreams,
+  hlsStartSec = 0,
 }: SubtitleTrackInfoOptions) {
   if (resolvedSubtitleTrack === null || !techLoaded) return null;
   if (
@@ -256,8 +259,18 @@ export function buildMovieSubtitleTrackInfo({
   }
 
   const sub = subtitleStreams[resolvedSubtitleTrack];
+  // Cues carry absolute source timestamps, but a rebased HLS session's media
+  // timeline starts at zero, so the server must shift them by the session
+  // start or every subtitle is out by that offset (audit H4). Direct play and
+  // sessions starting at zero need no shift.
+  const params = new URLSearchParams();
+  if (hlsStartSec > 0) {
+    params.set("start", String(Math.floor(hlsStartSec)));
+  }
+  const query = params.size > 0 ? `?${params}` : "";
+
   return {
-    url: `/api/movies/${movieId}/subtitles/${resolvedSubtitleTrack}/web.vtt`,
+    url: `/api/movies/${movieId}/subtitles/${resolvedSubtitleTrack}/web.vtt${query}`,
     label: formatSubtitleLabel(sub, resolvedSubtitleTrack),
     srclang: normalizeLang(unwrapStringOrUndefined(sub.language)) ?? "",
   };

--- a/web/src/lib/playback.ts
+++ b/web/src/lib/playback.ts
@@ -196,7 +196,7 @@ export function getAvailableModes(args: AvailableModesArgs) {
   const { video, audioStreams, mimeType } = args;
   const sourceHeight = video?.height ?? 0;
 
-  return STREAM_MODES.filter((m) => {
+  const availableModes = STREAM_MODES.filter((m) => {
     if (m.type === "direct") {
       if (!video) return !args.videoStreamsLoaded;
       const staticRulesPass =
@@ -226,6 +226,13 @@ export function getAvailableModes(args: AvailableModesArgs) {
     }
     return sourceHeight > 0 && m.maxHeight <= sourceHeight;
   });
+
+  if (availableModes.length > 0 || !video) {
+    return availableModes;
+  }
+
+  const fallbackMode = STREAM_MODES.find((mode) => mode.id === "720p_3mbps");
+  return fallbackMode ? [fallbackMode] : availableModes;
 }
 
 /**

--- a/web/src/lib/playback.ts
+++ b/web/src/lib/playback.ts
@@ -216,7 +216,13 @@ export function getAvailableModes(args: AvailableModesArgs) {
     }
     if (m.type === "remux") {
       if (!video) return !args.videoStreamsLoaded;
-      return isVideoDirectPlayable(video.codec);
+      // Remux copies the video stream untouched, so it needs the same
+      // browser-safety rules as direct play: the server refuses to copy 10-bit,
+      // 4:2:2 and 4:4:4 H.264 and silently falls back to a full transcode.
+      // Offering remux for those advertises a mode the server never runs.
+      // This also keeps direct ⊂ remux, which the audio-track upgrade in
+      // `resolveModeForAudioTrack` depends on.
+      return isVideoDirectPlayable(video.codec) && isBrowserSafeH264(video);
     }
     return sourceHeight > 0 && m.maxHeight <= sourceHeight;
   });
@@ -432,6 +438,36 @@ export function directPlayModeLabel(
   if (!langName) return fallback;
   const base = fallback.split(" — ")[0];
   return `${base} — ${langName} audio`;
+}
+
+/**
+ * Player-badge label for an HLS session, given the profile the server reports
+ * it actually ran. The requested profile is only a request: the remux safety
+ * gate can fall back to a transcode after the manifest URL is already fixed, so
+ * the badge must describe the effective profile or it misreports a full
+ * transcode as a stream copy (audit H3).
+ */
+export function effectiveModeLabel(
+  requestedMode: StreamModeId,
+  effectiveProfile: string | null,
+): string {
+  const requestedLabel =
+    STREAM_MODES.find(m => m.id === requestedMode)?.label ?? requestedMode;
+
+  if (!effectiveProfile || effectiveProfile === requestedMode) {
+    return requestedLabel;
+  }
+
+  const effectiveLabel = STREAM_MODES.find(
+    m => m.id === effectiveProfile,
+  )?.label;
+  if (!effectiveLabel) return requestedLabel;
+
+  if (requestedMode === "remux") {
+    return `${effectiveLabel} — remux unavailable`;
+  }
+
+  return effectiveLabel;
 }
 
 export function describePlaybackExperience(

--- a/web/src/lib/watch-room.ts
+++ b/web/src/lib/watch-room.ts
@@ -1,12 +1,24 @@
 import type { WatchRoomServerEventType } from "@/types";
 import { WATCH_ROOM_EVENT_TYPES } from "@/lib/constants";
 
-export function watchRoomStreamUrl(roomId: number, playbackMode: string) {
+/**
+ * `reloadKey` is a client-side remount trigger, not a server parameter: the
+ * room manifest handler ignores unknown query values. Bumping it changes the
+ * `src` identity so the player rebuilds its hls.js instance after a lost
+ * session, mirroring the `reload` parameter personal playback uses.
+ */
+export function watchRoomStreamUrl(
+  roomId: number,
+  playbackMode: string,
+  reloadKey = 0,
+) {
   if (playbackMode === "direct") {
     return `/api/watch-rooms/${roomId}/stream`;
   }
 
-  return `/api/watch-rooms/${roomId}/hls/playlist.m3u8`;
+  const query = reloadKey > 0 ? `?reload=${reloadKey}` : "";
+
+  return `/api/watch-rooms/${roomId}/hls/playlist.m3u8${query}`;
 }
 
 export function watchRoomWebSocketUrl(roomId: number) {

--- a/web/src/routes/_auth/movies/$id/play.tsx
+++ b/web/src/routes/_auth/movies/$id/play.tsx
@@ -20,6 +20,7 @@ import {
   playbackSettingsQueryOpts,
 } from "@/lib/query-opts";
 import {
+  effectiveModeLabel,
   getAvailableModes,
   getDefaultPlaybackSettings,
   getPrimaryVideoStream,
@@ -203,6 +204,12 @@ function PlayMoviePage() {
   const [playbackError, setPlaybackError] = useState<string | null>(null);
   const [resumeActionPending, setResumeActionPending] = useState(false);
   const [streamReloadKey, setStreamReloadKey] = useState(0);
+  // Tagged with the session it describes rather than cleared by an effect, so
+  // a rebase or mode change invalidates it by derivation.
+  const [reportedProfile, setReportedProfile] = useState<{
+    streamWindowKey: string;
+    profile: string;
+  } | null>(null);
   const playbackSessionId = useMemo(
     () => getOrCreateMovieHlsPlaybackSessionId(movieId),
     [movieId],
@@ -583,6 +590,13 @@ function PlayMoviePage() {
     durationRef.current = movieDurationSec;
   }, [isHlsPlayback, movieDurationSec]);
 
+  // The effective profile belongs to one session, so an answer carried over
+  // from a previous one is ignored rather than used to describe this one.
+  const effectiveProfile =
+    reportedProfile?.streamWindowKey === sessionWindowKey
+      ? reportedProfile.profile
+      : null;
+
   const handleNativePlaybackError = (code: number | null | undefined) => {
     if (handleDirectPlayFallbackError(code)) {
       fallbackConsumedErrorRef.current = true;
@@ -695,6 +709,9 @@ function PlayMoviePage() {
         handleSessionLost(toAbsolutePlaybackTime(time, playbackTiming))
       }
       onCapacityBusy={handleCapacityBusy}
+      onEffectiveProfile={profile =>
+        setReportedProfile({ streamWindowKey: sessionWindowKey, profile })
+      }
     />
   );
 
@@ -840,7 +857,11 @@ function PlayMoviePage() {
         duration={duration}
         displayedDuration={displayedDuration}
         playing={playing}
-        modeLabel={modeLabel}
+        modeLabel={
+          isHlsPlayback
+            ? effectiveModeLabel(resolvedMode, effectiveProfile)
+            : modeLabel
+        }
         chapters={chapters}
         videoRef={videoRef}
         onSeek={seek}

--- a/web/src/routes/_auth/movies/$id/play.tsx
+++ b/web/src/routes/_auth/movies/$id/play.tsx
@@ -259,13 +259,15 @@ function PlayMoviePage() {
     resolvedSubtitleTrack,
     isHlsPlayback,
     playbackStartSec,
-    hlsStartSec,
+    requestedHlsStartSec,
+    actualHlsStartSec,
     hlsPlaybackOffset,
     streamUrl,
     subtitleInfo,
     playbackTiming,
     movieDurationSec,
     sessionWindowKey,
+    handleActualHlsStart,
   } = useMoviePlaybackData({
     movieId,
     search,
@@ -492,7 +494,7 @@ function PlayMoviePage() {
     const shouldRebaseHlsSession = shouldRebaseHlsMovieSession({
       isHlsPlayback,
       targetTimeSec: t,
-      hlsStartSec,
+      actualHlsStartSec,
       currentVideoTimeSec: currentVideoTime,
     });
 
@@ -700,6 +702,7 @@ function PlayMoviePage() {
       onNativeError={handleNativePlaybackError}
       subtitleTrack={subtitleInfo}
       startSec={isHlsPlayback ? hlsPlaybackOffset : playbackStartSec}
+      requestedStartSec={requestedHlsStartSec}
       onStartApplied={(time) => {
         const absoluteTime = toAbsolutePlaybackTime(time, playbackTiming);
         currentTimeRef.current = absoluteTime;
@@ -712,6 +715,7 @@ function PlayMoviePage() {
       onEffectiveProfile={profile =>
         setReportedProfile({ streamWindowKey: sessionWindowKey, profile })
       }
+      onActualStart={handleActualHlsStart}
     />
   );
 

--- a/web/src/test/playback/available-modes.test.ts
+++ b/web/src/test/playback/available-modes.test.ts
@@ -227,6 +227,63 @@ describe("browser-safe H.264 gate", () => {
   });
 });
 
+describe("low-resolution transcode fallback", () => {
+  it.each([
+    [
+      "unsafe H.264",
+      h264Video({
+        height: 480,
+        bit_depth: { Int64: 10, Valid: true },
+      }),
+    ],
+    ["non-H.264 below 720p", h264Video({ codec: "hevc", height: 480 })],
+    ["unknown-height video", h264Video({ codec: "hevc", height: 0 })],
+  ])("offers only 720p when %s otherwise has no mode", (_case, video) => {
+    const ids = modeIds(
+      getAvailableModes({
+        videoStreamsLoaded: true,
+        video,
+        audioStreams: [aacAudio()],
+        mimeType: "video/x-matroska",
+      }),
+    );
+
+    expect(ids).toEqual(["720p_3mbps"]);
+  });
+
+  it("keeps a confirmed video-less movie unavailable", () => {
+    const ids = modeIds(
+      getAvailableModes({
+        videoStreamsLoaded: true,
+        audioStreams: [aacAudio()],
+        mimeType: "video/mp4",
+      }),
+    );
+
+    expect(ids).toEqual([]);
+  });
+
+  it("does not add or reorder modes when normal filtering found valid options", () => {
+    const ids = modeIds(
+      getAvailableModes({
+        videoStreamsLoaded: true,
+        video: h264Video(),
+        audioStreams: [aacAudio()],
+        mimeType: "video/mp4",
+      }),
+    );
+
+    expect(ids).toEqual([
+      "direct",
+      "remux",
+      "1080p_8mbps",
+      "1080p_6mbps",
+      "1080p_4mbps",
+      "720p_3mbps",
+    ]);
+  });
+});
+
 describe("directPlayModeLabel", () => {
   const audioStream = (language: string | null): AudioStreamType => ({
     id: 1,

--- a/web/src/test/playback/available-modes.test.ts
+++ b/web/src/test/playback/available-modes.test.ts
@@ -159,16 +159,39 @@ describe("browser-safe H.264 gate", () => {
       "4:4:4 pixel format alone",
       { pixel_format: { String: "yuv444p", Valid: true } },
     ],
-  ])("refuses direct play for %s while keeping remux", (_name, overrides) => {
+  ])(
+    "refuses both direct play and remux for %s",
+    (_name, overrides) => {
+      const ids = modeIds(
+        getAvailableModes({
+          videoStreamsLoaded: true,
+          video: h264Video(overrides),
+          audioStreams: [aacAudio()],
+          mimeType: "video/mp4",
+        }),
+      );
+      expect(ids).not.toContain("direct");
+      // Remux copies the stream untouched, so the server refuses these for the
+      // same reason and falls back to a transcode. Offering remux here
+      // advertised a mode that never ran and left the badge reporting a stream
+      // copy while a full transcode was running (audit H3).
+      expect(ids).not.toContain("remux");
+      // A transcode path must still be offered, or the file becomes unplayable.
+      expect(ids.length).toBeGreaterThan(0);
+    },
+  );
+
+  it("keeps remux for browser-safe H.264 that direct play also accepts", () => {
     const ids = modeIds(
       getAvailableModes({
         videoStreamsLoaded: true,
-        video: h264Video(overrides),
+        video: h264Video(),
         audioStreams: [aacAudio()],
         mimeType: "video/mp4",
       }),
     );
-    expect(ids).not.toContain("direct");
+    // The direct ⊂ remux invariant that resolveModeForAudioTrack relies on.
+    expect(ids).toContain("direct");
     expect(ids).toContain("remux");
   });
 

--- a/web/src/test/playback/movie-playback-data.test.tsx
+++ b/web/src/test/playback/movie-playback-data.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useMoviePlaybackData } from "@/hooks/useMoviePlaybackData";
@@ -12,7 +12,10 @@ import {
 } from "@/lib/constants";
 import {
   deriveMoviePlaybackStatus,
+  shouldRebaseHlsMovieSession,
+  toAbsoluteDuration,
   toAbsolutePlaybackTime,
+  toMediaPlaybackTime,
 } from "@/lib/movie-playback";
 import type {
   AuthUser,
@@ -260,7 +263,8 @@ describe("useMoviePlaybackData", () => {
     );
 
     expect(result.current.playbackStartSec).toBe(120);
-    expect(result.current.hlsStartSec).toBe(110);
+    expect(result.current.requestedHlsStartSec).toBe(110);
+    expect(result.current.actualHlsStartSec).toBe(110);
     expect(result.current.hlsPlaybackOffset).toBe(10);
     expect(result.current.streamUrl).toBe(
       `/api/movies/7/hls/720p_3mbps/playlist.m3u8?playback_session=${playbackSessionId}&start=110&audio_track=0&reload=3`,
@@ -271,6 +275,93 @@ describe("useMoviePlaybackData", () => {
     expect(result.current.sessionWindowKey).toBe(
       `7:720p_3mbps:0:${playbackSessionId}:110`,
     );
+  });
+
+  it("keeps requested session identity while mapping playback through the measured start", () => {
+    const movieId = 74;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    seedPreferenceResolutionMovie(queryClient, movieId);
+    seedSettledPlaybackPreferences(queryClient);
+    const search = {
+      mode: "remux" as const,
+      audio_track: 0,
+      subtitle_track: 0,
+      start: 600,
+    };
+
+    const { result, rerender } = renderHook(
+      (props: { search: typeof search }) =>
+        useMoviePlaybackData({
+          movieId,
+          search: props.search,
+          streamReloadKey: 0,
+          playbackSessionId,
+          onSyncSearch: vi.fn(),
+        }),
+      {
+        initialProps: { search },
+        wrapper: wrapperFor(queryClient),
+      },
+    );
+
+    expect(result.current.requestedHlsStartSec).toBe(590);
+    expect(result.current.actualHlsStartSec).toBe(590);
+    expect(result.current.hlsPlaybackOffset).toBe(10);
+    expect(result.current.subtitleInfo?.url).toContain("start=590");
+
+    act(() => {
+      result.current.handleActualHlsStart(581);
+    });
+
+    expect(result.current.requestedHlsStartSec).toBe(590);
+    expect(result.current.actualHlsStartSec).toBe(581);
+    expect(result.current.hlsPlaybackOffset).toBe(19);
+    expect(result.current.streamUrl).toContain("start=590");
+    expect(result.current.streamUrl).not.toContain("start=581");
+    expect(result.current.sessionWindowKey).toBe(
+      `74:remux:0:${playbackSessionId}:590`,
+    );
+    expect(result.current.subtitleInfo?.url).toContain("start=581");
+    expect(
+      toAbsolutePlaybackTime(19, result.current.playbackTiming),
+    ).toBe(600);
+    expect(toMediaPlaybackTime(600, result.current.playbackTiming)).toBe(19);
+    expect(toAbsoluteDuration(19, result.current.playbackTiming)).toBe(600);
+    expect(
+      shouldRebaseHlsMovieSession({
+        isHlsPlayback: true,
+        targetTimeSec: 580,
+        actualHlsStartSec: result.current.actualHlsStartSec,
+        currentVideoTimeSec: 600,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRebaseHlsMovieSession({
+        isHlsPlayback: true,
+        targetTimeSec: 581,
+        actualHlsStartSec: result.current.actualHlsStartSec,
+        currentVideoTimeSec: 600,
+      }),
+    ).toBe(false);
+
+    const timingAfterMeasurement = result.current.playbackTiming;
+    act(() => {
+      result.current.handleActualHlsStart(581);
+    });
+    expect(result.current.playbackTiming).toBe(timingAfterMeasurement);
+
+    rerender({
+      search: {
+        ...search,
+        start: 500,
+      },
+    });
+    expect(result.current.requestedHlsStartSec).toBe(490);
+    expect(result.current.actualHlsStartSec).toBe(490);
+    expect(result.current.hlsPlaybackOffset).toBe(10);
+    expect(result.current.subtitleInfo?.url).toContain("start=490");
   });
 
   // Audit D9: while direct play is active the audible stream is always

--- a/web/src/test/playback/playback-settings-dialog.test.tsx
+++ b/web/src/test/playback/playback-settings-dialog.test.tsx
@@ -325,8 +325,7 @@ describe("PlaybackSettingsDialog", () => {
       const details = technicalDetails();
       details.data!.movie.mime_type = "video/x-matroska";
       details.data!.movie.container = "mkv";
-      details.data!.video_streams[0].codec = "hevc";
-      details.data!.video_streams[0].height = 480;
+      details.data!.video_streams = [];
       queryClient.setQueryData([MOVIE_TECHNICAL_DETAILS_KEY, 22], details);
       const onSave = vi.fn();
 

--- a/web/src/test/playback/subtitle-track-info.test.ts
+++ b/web/src/test/playback/subtitle-track-info.test.ts
@@ -26,7 +26,7 @@ describe("buildMovieSubtitleTrackInfo", () => {
       resolvedSubtitleTrack: 0,
       techLoaded: true,
       subtitleStreams: [subtitle()],
-      hlsStartSec: 590,
+      actualHlsStartSec: 590,
     });
 
     expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt?start=590");
@@ -41,7 +41,7 @@ describe("buildMovieSubtitleTrackInfo", () => {
       resolvedSubtitleTrack: 0,
       techLoaded: true,
       subtitleStreams: [subtitle()],
-      hlsStartSec: 591.174,
+      actualHlsStartSec: 591.174,
     });
 
     expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt?start=591.174");
@@ -53,7 +53,7 @@ describe("buildMovieSubtitleTrackInfo", () => {
       resolvedSubtitleTrack: 0,
       techLoaded: true,
       subtitleStreams: [subtitle()],
-      hlsStartSec: 0,
+      actualHlsStartSec: 0,
     });
 
     expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt");
@@ -80,8 +80,14 @@ describe("buildMovieSubtitleTrackInfo", () => {
       subtitleStreams: [subtitle()],
     };
 
-    const first = buildMovieSubtitleTrackInfo({ ...args, hlsStartSec: 0 });
-    const rebased = buildMovieSubtitleTrackInfo({ ...args, hlsStartSec: 900 });
+    const first = buildMovieSubtitleTrackInfo({
+      ...args,
+      actualHlsStartSec: 0,
+    });
+    const rebased = buildMovieSubtitleTrackInfo({
+      ...args,
+      actualHlsStartSec: 900,
+    });
 
     expect(first?.url).not.toBe(rebased?.url);
   });

--- a/web/src/test/playback/subtitle-track-info.test.ts
+++ b/web/src/test/playback/subtitle-track-info.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { buildMovieSubtitleTrackInfo } from "@/lib/movie-playback";
+import { effectiveModeLabel } from "@/lib/playback";
+import type { SubtitleType } from "@/types";
+
+function subtitle(overrides: Partial<SubtitleType> = {}): SubtitleType {
+  return {
+    id: 1,
+    title: { String: "", Valid: false },
+    codec: "subrip",
+    language: { String: "eng", Valid: true },
+    stream_index: 2,
+    is_default: false,
+    is_forced: false,
+    ...overrides,
+  } as SubtitleType;
+}
+
+describe("buildMovieSubtitleTrackInfo", () => {
+  // Cues are extracted with absolute source timestamps while a rebased HLS
+  // session's media timeline starts at zero, so the server needs the offset to
+  // shift them or every subtitle is out by the session start (audit H4).
+  it("passes the session start so the server can rebase the cues", () => {
+    const info = buildMovieSubtitleTrackInfo({
+      movieId: 7,
+      resolvedSubtitleTrack: 0,
+      techLoaded: true,
+      subtitleStreams: [subtitle()],
+      hlsStartSec: 590,
+    });
+
+    expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt?start=590");
+  });
+
+  it("omits the offset when the session starts at zero", () => {
+    const info = buildMovieSubtitleTrackInfo({
+      movieId: 7,
+      resolvedSubtitleTrack: 0,
+      techLoaded: true,
+      subtitleStreams: [subtitle()],
+      hlsStartSec: 0,
+    });
+
+    expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt");
+  });
+
+  it("omits the offset for direct play, which has no offset to apply", () => {
+    const info = buildMovieSubtitleTrackInfo({
+      movieId: 7,
+      resolvedSubtitleTrack: 0,
+      techLoaded: true,
+      subtitleStreams: [subtitle()],
+    });
+
+    expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt");
+  });
+
+  // A changed URL is what re-attaches the <track>, since VideoPlayer keys its
+  // subtitle effect on the URL alone.
+  it("changes the URL when the session rebases", () => {
+    const args = {
+      movieId: 7,
+      resolvedSubtitleTrack: 0,
+      techLoaded: true,
+      subtitleStreams: [subtitle()],
+    };
+
+    const first = buildMovieSubtitleTrackInfo({ ...args, hlsStartSec: 0 });
+    const rebased = buildMovieSubtitleTrackInfo({ ...args, hlsStartSec: 900 });
+
+    expect(first?.url).not.toBe(rebased?.url);
+  });
+});
+
+describe("effectiveModeLabel", () => {
+  it("names the profile that actually ran when remux fell back", () => {
+    expect(effectiveModeLabel("remux", "2160p_16mbps")).toBe(
+      "4K — highest quality — remux unavailable",
+    );
+  });
+
+  it("keeps the requested label when the server ran what was asked", () => {
+    expect(effectiveModeLabel("remux", "remux")).toBe(
+      "Original video, adjusted audio",
+    );
+  });
+
+  it("keeps the requested label before the server has reported", () => {
+    expect(effectiveModeLabel("720p_3mbps", null)).toBe(
+      "720p — lower bandwidth",
+    );
+  });
+
+  it("ignores an unrecognized profile rather than showing a raw id", () => {
+    expect(effectiveModeLabel("remux", "something_else")).toBe(
+      "Original video, adjusted audio",
+    );
+  });
+});

--- a/web/src/test/playback/subtitle-track-info.test.ts
+++ b/web/src/test/playback/subtitle-track-info.test.ts
@@ -32,6 +32,21 @@ describe("buildMovieSubtitleTrackInfo", () => {
     expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt?start=590");
   });
 
+  // The measured actual start is fractional (a keyframe timestamp such as
+  // 591.174), and the server parses `start` as a float — flooring it would
+  // misalign every cue by up to a second.
+  it("preserves a fractional session start", () => {
+    const info = buildMovieSubtitleTrackInfo({
+      movieId: 7,
+      resolvedSubtitleTrack: 0,
+      techLoaded: true,
+      subtitleStreams: [subtitle()],
+      hlsStartSec: 591.174,
+    });
+
+    expect(info?.url).toBe("/api/movies/7/subtitles/0/web.vtt?start=591.174");
+  });
+
   it("omits the offset when the session starts at zero", () => {
     const info = buildMovieSubtitleTrackInfo({
       movieId: 7,

--- a/web/src/test/playback/video-player.test.tsx
+++ b/web/src/test/playback/video-player.test.tsx
@@ -1,5 +1,11 @@
-import { createRef } from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { createRef, StrictMode, useRef, useState } from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import VideoPlayer from "@/components/playback/VideoPlayer";
 import {
@@ -11,11 +17,22 @@ type FakeHlsListener = (event: string, data: unknown) => void;
 
 const fakeHlsInstances = vi.hoisted(() => [] as FakeHlsInstance[]);
 const fakeHlsSupport = vi.hoisted(() => ({ supported: true }));
+const nativeHlsSupport = vi.hoisted(() => ({ supported: false }));
 
 type FakeHlsInstance = {
   listeners: Map<string, FakeHlsListener[]>;
   trigger: (event: string, data: unknown) => void;
 };
+
+vi.mock("@/lib/playback", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/playback")>();
+  return {
+    ...actual,
+    get supportsNativeHLS() {
+      return nativeHlsSupport.supported;
+    },
+  };
+});
 
 vi.mock("hls.js/light", () => {
   class FakeHls implements FakeHlsInstance {
@@ -102,8 +119,10 @@ afterAll(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
   fakeHlsInstances.length = 0;
   fakeHlsSupport.supported = true;
+  nativeHlsSupport.supported = false;
 });
 
 function renderPlayer(
@@ -490,5 +509,308 @@ describe("VideoPlayer HLS capability and effective profile", () => {
     });
 
     expect(onEffectiveProfile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["valid", "581", 581],
+    ["zero", "0", 0],
+    ["missing", null, null],
+    ["malformed", "581 seconds", null],
+    ["negative", "-1", null],
+    ["non-finite NaN", "NaN", null],
+    ["non-finite infinity", "Infinity", null],
+    ["later than requested", "590.001", null],
+  ])(
+    "validates a %s actual-start manifest header",
+    async (_case, header, expected) => {
+      const onActualStart = vi.fn();
+      await renderHls({
+        requestedStartSec: 590,
+        onActualStart,
+      });
+
+      act(() => {
+        fakeHlsInstances[0].trigger("hlsManifestLoaded", {
+          networkDetails: {
+            getResponseHeader: (name: string) =>
+              name === "X-Igloo-Actual-Start" ? header : null,
+          },
+        });
+      });
+
+      if (expected === null) {
+        expect(onActualStart).not.toHaveBeenCalled();
+      } else {
+        expect(onActualStart).toHaveBeenCalledOnce();
+        expect(onActualStart).toHaveBeenCalledWith(expected);
+      }
+    },
+  );
+
+  it("reads both manifest headers from the existing hls.js request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const onEffectiveProfile = vi.fn();
+    const onActualStart = vi.fn();
+    await renderHls({
+      requestedStartSec: 590,
+      onEffectiveProfile,
+      onActualStart,
+    });
+
+    act(() => {
+      fakeHlsInstances[0].trigger("hlsManifestLoaded", {
+        networkDetails: {
+          getResponseHeader: (name: string) => {
+            if (name === "X-Igloo-Effective-Profile") return "remux";
+            if (name === "X-Igloo-Actual-Start") return "581";
+            return null;
+          },
+        },
+      });
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(onEffectiveProfile).toHaveBeenCalledWith("remux");
+    expect(onActualStart).toHaveBeenCalledWith(581);
+  });
+
+  it("rebuilds at most once when an earlier actual start changes the local offset", async () => {
+    function ActualStartHarness() {
+      const videoRef = useRef<HTMLVideoElement>(null);
+      const [actualStartSec, setActualStartSec] = useState(590);
+      return (
+        <VideoPlayer
+          videoRef={videoRef}
+          src={hlsSrc}
+          isHlsSource
+          title="Test Movie"
+          onError={vi.fn()}
+          startSec={600 - actualStartSec}
+          requestedStartSec={590}
+          onActualStart={(nextStartSec) => {
+            setActualStartSec((previous) =>
+              previous === nextStartSec ? previous : nextStartSec,
+            );
+          }}
+        />
+      );
+    }
+
+    render(<ActualStartHarness />);
+    await waitFor(() => {
+      expect(fakeHlsInstances).toHaveLength(1);
+    });
+
+    act(() => {
+      fakeHlsInstances[0].trigger("hlsManifestLoaded", {
+        networkDetails: {
+          getResponseHeader: (name: string) =>
+            name === "X-Igloo-Actual-Start" ? "581" : null,
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(fakeHlsInstances).toHaveLength(2);
+    });
+
+    act(() => {
+      fakeHlsInstances[1].trigger("hlsManifestLoaded", {
+        networkDetails: {
+          getResponseHeader: (name: string) =>
+            name === "X-Igloo-Actual-Start" ? "581" : null,
+        },
+      });
+    });
+    await act(async () => {});
+    expect(fakeHlsInstances).toHaveLength(2);
+  });
+});
+
+function nativeManifestResponse(
+  status: number,
+  headers: Record<string, string> = {},
+) {
+  const cancel = vi.fn().mockResolvedValue(undefined);
+  const response = {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers(headers),
+    body: { cancel },
+  } as unknown as Response;
+  return { response, cancel };
+}
+
+describe("VideoPlayer native HLS manifest preflight", () => {
+  const firstSrc = "/api/movies/1/hls/remux/playlist.m3u8?start=590";
+  const secondSrc =
+    "/api/movies/1/hls/remux/playlist.m3u8?start=700&reload=1";
+
+  it("uses one authenticated preflight, releases its body, and reports metadata", async () => {
+    nativeHlsSupport.supported = true;
+    const { response, cancel } = nativeManifestResponse(200, {
+      "X-Igloo-Effective-Profile": "remux",
+      "X-Igloo-Actual-Start": "581",
+    });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+    const onEffectiveProfile = vi.fn();
+    const onActualStart = vi.fn();
+
+    const { video } = renderPlayer({
+      src: firstSrc,
+      isHlsSource: true,
+      requestedStartSec: 590,
+      onEffectiveProfile,
+      onActualStart,
+    });
+
+    await waitFor(() => {
+      expect(video).toHaveAttribute("src", firstSrc);
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(firstSrc, {
+      credentials: "include",
+      signal: expect.any(AbortSignal),
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(onEffectiveProfile).toHaveBeenCalledWith("remux");
+    expect(onActualStart).toHaveBeenCalledWith(581);
+  });
+
+  it("issues only one preflight through the Strict Mode effect probe", async () => {
+    nativeHlsSupport.supported = true;
+    const { response } = nativeManifestResponse(200, {
+      "X-Igloo-Actual-Start": "581",
+    });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+    const videoRef = createRef<HTMLVideoElement>();
+
+    render(
+      <StrictMode>
+        <VideoPlayer
+          videoRef={videoRef}
+          src={firstSrc}
+          isHlsSource
+          title="Test Movie"
+          onError={vi.fn()}
+          requestedStartSec={590}
+          onActualStart={vi.fn()}
+        />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(videoRef.current).toHaveAttribute("src", firstSrc);
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("skips the preflight when native HLS has no manifest consumer", () => {
+    nativeHlsSupport.supported = true;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { video } = renderPlayer({
+      src: firstSrc,
+      isHlsSource: true,
+    });
+
+    expect(video).toHaveAttribute("src", firstSrc);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts a stale preflight and never assigns its obsolete source", async () => {
+    nativeHlsSupport.supported = true;
+    let resolveFirst!: (response: Response) => void;
+    let resolveSecond!: (response: Response) => void;
+    const firstPromise = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondPromise = new Promise<Response>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(firstPromise)
+      .mockReturnValueOnce(secondPromise);
+    vi.stubGlobal("fetch", fetchMock);
+    const videoRef = createRef<HTMLVideoElement>();
+    const baseProps = {
+      videoRef,
+      isHlsSource: true,
+      title: "Test Movie",
+      onError: vi.fn(),
+      requestedStartSec: 590,
+      onActualStart: vi.fn(),
+    };
+    const view = render(<VideoPlayer {...baseProps} src={firstSrc} />);
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+    const firstSignal = fetchMock.mock.calls[0][1]?.signal as AbortSignal;
+
+    view.rerender(
+      <VideoPlayer
+        {...baseProps}
+        src={secondSrc}
+        requestedStartSec={700}
+      />,
+    );
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+    expect(firstSignal.aborted).toBe(true);
+
+    await act(async () => {
+      resolveFirst(nativeManifestResponse(200).response);
+      resolveSecond(nativeManifestResponse(200).response);
+    });
+    await waitFor(() => {
+      expect(videoRef.current).toHaveAttribute("src", secondSrc);
+    });
+    expect(videoRef.current).not.toHaveAttribute("src", firstSrc);
+  });
+
+  it("honors a capacity 503 without immediately assigning the failing source", async () => {
+    nativeHlsSupport.supported = true;
+    const { response, cancel } = nativeManifestResponse(503, {
+      "Retry-After": "7",
+    });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+    const onCapacityBusy = vi.fn();
+
+    const { video } = renderPlayer({
+      src: firstSrc,
+      isHlsSource: true,
+      onCapacityBusy,
+    });
+
+    await waitFor(() => {
+      expect(onCapacityBusy).toHaveBeenCalledWith(7);
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(video).not.toHaveAttribute("src");
+  });
+
+  it("lets native HLS load normally after an unexpected preflight failure", async () => {
+    nativeHlsSupport.supported = true;
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { video } = renderPlayer({
+      src: firstSrc,
+      isHlsSource: true,
+      onActualStart: vi.fn(),
+      requestedStartSec: 590,
+    });
+
+    await waitFor(() => {
+      expect(video).toHaveAttribute("src", firstSrc);
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/web/src/test/playback/video-player.test.tsx
+++ b/web/src/test/playback/video-player.test.tsx
@@ -10,6 +10,7 @@ import {
 type FakeHlsListener = (event: string, data: unknown) => void;
 
 const fakeHlsInstances = vi.hoisted(() => [] as FakeHlsInstance[]);
+const fakeHlsSupport = vi.hoisted(() => ({ supported: true }));
 
 type FakeHlsInstance = {
   listeners: Map<string, FakeHlsListener[]>;
@@ -19,11 +20,12 @@ type FakeHlsInstance = {
 vi.mock("hls.js/light", () => {
   class FakeHls implements FakeHlsInstance {
     static isSupported() {
-      return true;
+      return fakeHlsSupport.supported;
     }
     static Events = {
       ERROR: "hlsError",
       MANIFEST_PARSED: "hlsManifestParsed",
+      MANIFEST_LOADED: "hlsManifestLoaded",
     };
     static ErrorDetails = {
       FRAG_LOAD_ERROR: "fragLoadError",
@@ -101,6 +103,7 @@ afterAll(() => {
 afterEach(() => {
   vi.useRealTimers();
   fakeHlsInstances.length = 0;
+  fakeHlsSupport.supported = true;
 });
 
 function renderPlayer(
@@ -428,5 +431,64 @@ describe("VideoPlayer hls.js error routing", () => {
 
     expect(onSessionLost).toHaveBeenCalledOnce();
     expect(onCapacityBusy).not.toHaveBeenCalled();
+  });
+});
+
+describe("VideoPlayer HLS capability and effective profile", () => {
+  const hlsSrc = "/api/movies/1/hls/remux/playlist.m3u8";
+
+  async function renderHls(
+    props: Partial<React.ComponentProps<typeof VideoPlayer>> = {},
+  ) {
+    const result = renderPlayer({ src: hlsSrc, isHlsSource: true, ...props });
+    await act(async () => {});
+    return result;
+  }
+
+  // Without this the player sat blank with no error at all, so a browser
+  // lacking Media Source Extensions looked like a broken app (audit H11).
+  it("reports an error when hls.js is unsupported", async () => {
+    fakeHlsSupport.supported = false;
+    const onError = vi.fn();
+
+    await renderHls({ onError });
+
+    expect(fakeHlsInstances).toHaveLength(0);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toMatch(/cannot play streamed video/i);
+  });
+
+  // A remux request that fails the server's safety gate is still served from
+  // the /hls/remux/ path, so only the response header can report what actually
+  // ran (audit H3).
+  it("reports the effective profile from the manifest response header", async () => {
+    const onEffectiveProfile = vi.fn();
+    await renderHls({ onEffectiveProfile });
+
+    const hls = fakeHlsInstances[0];
+    act(() => {
+      hls.trigger("hlsManifestLoaded", {
+        networkDetails: {
+          getResponseHeader: (name: string) =>
+            name === "X-Igloo-Effective-Profile" ? "2160p_16mbps" : null,
+        },
+      });
+    });
+
+    expect(onEffectiveProfile).toHaveBeenCalledWith("2160p_16mbps");
+  });
+
+  it("stays quiet when the manifest response has no effective-profile header", async () => {
+    const onEffectiveProfile = vi.fn();
+    await renderHls({ onEffectiveProfile });
+
+    const hls = fakeHlsInstances[0];
+    act(() => {
+      hls.trigger("hlsManifestLoaded", {
+        networkDetails: { getResponseHeader: () => null },
+      });
+    });
+
+    expect(onEffectiveProfile).not.toHaveBeenCalled();
   });
 });

--- a/web/src/test/watch-room/watch-room-page.test.tsx
+++ b/web/src/test/watch-room/watch-room-page.test.tsx
@@ -5,6 +5,9 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { WatchRoomPage as WatchRoomPageContent } from "@/components/watch-room/WatchRoomPage";
 import { Route as WatchRoomRoute } from "@/routes/_auth/watch-rooms/$id";
 import {
+  HLS_CAPACITY_RETRY_MAX_ATTEMPTS,
+  HLS_SESSION_LOST_MAX_ATTEMPTS,
+  HLS_SESSION_LOST_MIN_INTERVAL_MS,
   MOTION_PLAYER_CHROME_BUTTON_CLASS,
   WATCH_ROOM_SEEK_STEP_SEC,
 } from "@/lib/constants";
@@ -365,6 +368,7 @@ describe("WatchRoomPageContent", () => {
   afterEach(() => {
     globalThis.WebSocket = originalWebSocket;
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("does not send a redundant join message when the websocket opens", async () => {
@@ -1167,6 +1171,87 @@ describe("WatchRoomPageContent", () => {
     expect(props?.src).toContain("/hls/playlist.m3u8");
     expect(typeof props?.onSessionLost).toBe("function");
     expect(typeof props?.onCapacityBusy).toBe("function");
+  });
+
+  it("exhausts the capacity budget across successive reload URLs", async () => {
+    renderRoomPage(buildRoom({ playback_mode: "720p_3mbps" }));
+
+    await screen.findByTestId("video-player");
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+    const socket = FakeWebSocket.instances[0];
+
+    for (let attempt = 1; attempt <= HLS_CAPACITY_RETRY_MAX_ATTEMPTS; attempt++) {
+      act(() => {
+        lastVideoPlayerProps.current?.onCapacityBusy?.(0);
+      });
+      await waitFor(() => {
+        expect(lastVideoPlayerProps.current?.src).toContain(
+          `reload=${attempt}`,
+        );
+      });
+    }
+
+    const exhaustedSrc = lastVideoPlayerProps.current?.src;
+    act(() => {
+      lastVideoPlayerProps.current?.onCapacityBusy?.(0);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "The server is running at its transcoding limit. Try again shortly.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(lastVideoPlayerProps.current?.src).toBe(exhaustedSrc);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0]).toBe(socket);
+    expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+  });
+
+  it("exhausts fragment-loss recovery across successive reload URLs", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    let now = 10_000;
+    nowSpy.mockImplementation(() => now);
+    renderRoomPage(buildRoom({ playback_mode: "720p_3mbps" }));
+
+    await screen.findByTestId("video-player");
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+    const socket = FakeWebSocket.instances[0];
+
+    for (let attempt = 1; attempt <= HLS_SESSION_LOST_MAX_ATTEMPTS; attempt++) {
+      act(() => {
+        lastVideoPlayerProps.current?.onSessionLost?.(30);
+      });
+      await waitFor(() => {
+        expect(lastVideoPlayerProps.current?.src).toContain(
+          `reload=${attempt}`,
+        );
+      });
+      now += HLS_SESSION_LOST_MIN_INTERVAL_MS;
+    }
+
+    const exhaustedSrc = lastVideoPlayerProps.current?.src;
+    act(() => {
+      lastVideoPlayerProps.current?.onSessionLost?.(30);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "The playback session expired. Reload to keep watching.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(lastVideoPlayerProps.current?.src).toBe(exhaustedSrc);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0]).toBe(socket);
+    expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+    nowSpy.mockRestore();
   });
 
   it("leaves HLS recovery off for a direct room", async () => {

--- a/web/src/test/watch-room/watch-room-page.test.tsx
+++ b/web/src/test/watch-room/watch-room-page.test.tsx
@@ -23,11 +23,21 @@ const showSuccessMock = vi.fn();
 type MockVideoPlayerProps = {
   videoRef: { current: HTMLVideoElement | null };
   title: string;
+  src?: string;
+  isHlsSource?: boolean;
   onPlay?: () => void;
   onPause?: () => void;
   onEnded?: () => void;
   onTimeUpdate?: (time: number) => void;
   onDurationChange?: (duration: number) => void;
+  onSessionLost?: (currentTime: number) => void;
+  onCapacityBusy?: (retryAfterSec: number) => void;
+};
+
+// Records what the room actually hands the player, so the recovery wiring can
+// be asserted rather than assumed (audit H9).
+const lastVideoPlayerProps: { current: MockVideoPlayerProps | null } = {
+  current: null,
 };
 
 const mockVideoController = {
@@ -185,15 +195,18 @@ vi.mock("@/lib/toast-helpers", async () => {
 });
 
 vi.mock("@/components/playback/VideoPlayer", () => ({
-  default: (props: MockVideoPlayerProps) => (
-    <video
-      data-testid="video-player"
-      aria-label={`Video player for ${props.title}`}
-      ref={node => {
-        mockVideoController.attach(node, props);
-      }}
-    />
-  ),
+  default: (props: MockVideoPlayerProps) => {
+    lastVideoPlayerProps.current = props;
+    return (
+      <video
+        data-testid="video-player"
+        aria-label={`Video player for ${props.title}`}
+        ref={node => {
+          mockVideoController.attach(node, props);
+        }}
+      />
+    );
+  },
 }));
 
 vi.mock("@/components/playback/ProgressBar", () => ({
@@ -337,6 +350,7 @@ describe("WatchRoomPageContent", () => {
     FakeWebSocket.instances = [];
     FakeWebSocket.autoOpen = true;
     mockVideoController.reset();
+    lastVideoPlayerProps.current = null;
     navigateMock.mockReset();
     useQueryMock.mockReset();
     joinWatchRoomMock.mockReset();
@@ -1139,5 +1153,27 @@ describe("WatchRoomPageContent", () => {
     expect(FakeWebSocket.instances[0]).toBe(firstSocket);
     expect(firstSocket.readyState).toBe(FakeWebSocket.OPEN);
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  // Before this the room passed no recovery props at all, so a fragment 404 or
+  // a capacity 503 went straight to a dead "Stream error" (audit H9).
+  it("wires HLS recovery for a transcoding room", async () => {
+    renderRoomPage(buildRoom({ playback_mode: "720p_3mbps" }));
+
+    await screen.findByTestId("video-player");
+
+    const props = lastVideoPlayerProps.current;
+    expect(props?.isHlsSource).toBe(true);
+    expect(props?.src).toContain("/hls/playlist.m3u8");
+    expect(typeof props?.onSessionLost).toBe("function");
+    expect(typeof props?.onCapacityBusy).toBe("function");
+  });
+
+  it("leaves HLS recovery off for a direct room", async () => {
+    renderRoomPage(buildRoom({ playback_mode: "direct" }));
+
+    await screen.findByTestId("video-player");
+
+    expect(lastVideoPlayerProps.current?.isHlsSource).toBe(false);
   });
 });


### PR DESCRIPTION
Adds `docs/web-hls-playback-audit.md` — the companion to the direct-playback audit, which explicitly excluded HLS manifests, segment generation, FFmpeg encoding, hardware acceleration, session cleanup and hls.js recovery — and fixes the P0 and P1 findings it turned up.

The session layer turned out to be sound: session keys and ownership isolate correctly, the per-user cap and LRU eviction hold, explicit stop tears down in 84 ms, an abandoned session is fully reclaimed, stream mapping is explicit and absolute, the remux IDR preflight works, and hardware resolution runs real runtime probes. **The delivery layer was describing its output instead of measuring it.**

## Fixes

**H1 / H2 — copy-video playlists (critical).** `generateVODPlaylist` synthesized uniform 4 s `#EXTINF` entries and `ceil(duration/4)` of them. Exact for transcodes, which pin keyframes to the segment cadence (measured drift over 300 s: 8 ms), but wrong for stream copy, whose segments split only on source keyframes — 5.40 s mean on one source, 9.24 s on another. The surplus entries 404'd once the session exited cleanly, and the client reads a fragment 404 as a lost session, so remux playback broke near the end of most films while burning its recovery budget. Copy-video now serves FFmpeg's own playlist (`EVENT` while encoding, finalized `VOD` after); a manifest with no published segment yet returns `503` rather than falling back to synthesizing.

**H3 — effective profile.** A `remux` request that fails the safety gate is still served from the `/hls/remux/` path, so a request for a cheap stream copy could silently run a 2160p CPU transcode with the badge still reading "Remux". Two-part fix: `getAvailableModes` no longer offers remux for video the server will refuse to copy (it gated on codec name only, while direct play also required `isBrowserSafeH264`), and the manifest carries `X-Igloo-Effective-Profile`, which drives the badge.

**H4 — subtitles.** Cues carry absolute source timestamps while a rebased session's media timeline starts at zero, so subtitles were offset by the session start on every resume and seek-rebase. The WebVTT endpoint now shifts them via a `start` parameter, keeping one absolute payload per (movie, stream) in the cache — no extra extraction, no cache multiplication.

**H5 — session start.** `-ss` before `-i` is frame-accurate when re-encoding because FFmpeg discards frames up to the target, but it cannot be when copying. So this only ever affected copy-video, which now measures its real start alongside FFmpeg and publishes `X-Igloo-Actual-Start`; on failure it reports nothing and the client keeps its old fallback.

**Also:** watch rooms are wired to the recovery, capacity-retry and keepalive hooks they never had (H9) — they previously had no recovery from exactly the 404s H2 caused; an unsupported browser gets a real error instead of a blank player (H11); and a session is refused when the transcode filesystem is nearly full (H8).

Found while fixing: seeking past the end of a stream makes FFmpeg exit cleanly having written one empty segment under an invalid `#EXT-X-TARGETDURATION:0`. Serving that verbatim would have swapped one bad manifest for another, so a playlist is accepted only once it declares a positive-duration segment.

## Verification

`make check` and `make test-openapi` pass — 618 web tests, all Go packages, lint clean. All server experiments ran against a **copy** of the database on port 8099; the real DB and `./transcode` were never written.

Re-running the experiments that found the bugs:

| Check | Before | After |
| --- | --- | --- |
| Copy-video `#EXTINF` | uniform `4.000000` | identical to FFmpeg's own (`8.466792`, `6.006000`, `10.010000`, …) |
| Advertised segments | 1458 for movie 57; tail 404s | only what exists; **7/7 returned 200** |
| Seek past end of stream | invalid manifest, dead segment URLs | `404 no playable media at this position` |
| `/hls/remux/` on HEVC | `200`, nothing named the transcode | `X-Igloo-Effective-Profile: 2160p_16mbps` |
| Copy-video at `start=600` | client assumed 600 | `X-Igloo-Actual-Start: 591.174`, the keyframe measured in the audit |

**Not verified live:** the subtitle shift end to end over HTTP. Both attempts hit the pre-existing subtitle-extraction timeout on the Samba mount, which reproduces on the unmodified server. Coverage rests on 9 `ShiftWebVTT` unit tests plus handler tests exercising the real HTTP path and cache. Browser confirmation that cues render in sync on resume still needs a browser and stays recorded in the audit's test matrix.

## Trade-off

Copy-video is now seekable only across what FFmpeg has produced, since the playlist no longer claims segments that do not exist. The encoder runs several times faster than realtime and seeks beyond +120 s already rebase the session, so the exposure is a forward seek inside the no-rebase window in a session's first seconds — where the previous behaviour was a blocking wait followed by a `503`.

## Still open

P2 and P3, listed in §23.4 of the audit. **H14** (stream ordinals are not stable across re-scans — `processMovieStreams` deletes and re-inserts with no `UNIQUE(movie_id, stream_index)`, so a re-scan can silently repoint a saved audio/subtitle selection or a room's stored track) is the one worth doing next, while the pre-production rules still allow a schema change without a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HLS playback reliability with playlist readiness polling, session recovery, capacity retry, and byte-range segment support.
  * Added effective-profile and actual-start reporting for more accurate playback labels and seeking.
  * Added subtitle WebVTT cue rebasing with optional `start` support.
* **Bug Fixes**
  * Fixed copy-video playlist timing and seek behavior.
  * Improved handling of unsupported browsers, insufficient storage, unavailable playlists, and invalid subtitle offsets.
  * Tightened playback-mode selection for unsupported video formats.
* **Documentation**
  * Expanded HLS, subtitle timing, operational behavior, and playback audit documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->