### PR TITLE
fix(quick-connect): accept formatted codes and generate them uniformly

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10853,7 +10853,7 @@
           "code": {
             "type": "string",
             "maxLength": 32,
-            "description": "The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored."
+            "description": "The six-character code shown on the device. Case-insensitive; surrounding whitespace is trimmed, and spaces, tabs and dashes are ignored anywhere in the code."
           },
           "secret": {
             "type": "string"
@@ -10993,7 +10993,7 @@
           "code": {
             "type": "string",
             "maxLength": 32,
-            "description": "The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored."
+            "description": "The six-character code shown on the device. Case-insensitive; surrounding whitespace is trimmed, and spaces, tabs and dashes are ignored anywhere in the code."
           }
         },
         "additionalProperties": false

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10796,6 +10796,35 @@
         },
         "additionalProperties": false
       },
+      "QuickConnectInitiateData": {
+        "type": "object",
+        "required": [
+          "code",
+          "secret",
+          "expires_in_seconds",
+          "poll_interval_seconds"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 6,
+            "pattern": "^[ABCDEFGHJKMNPQRSTUVWXYZ2-9]{6}$",
+            "description": "The only value to display to the user; they enter it in the web app to approve the device. Always six uppercase characters drawn from an alphabet that omits I, L, O, 0 and 1 so it stays unambiguous on a TV screen."
+          },
+          "secret": {
+            "type": "string",
+            "description": "Device-held secret required to redeem the code. Never shown to the user: keep it in memory and send it back in the redeem request body."
+          },
+          "expires_in_seconds": {
+            "type": "integer"
+          },
+          "poll_interval_seconds": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      },
       "QuickConnectInitiateEnvelope": {
         "allOf": [
           {
@@ -10808,30 +10837,7 @@
             ],
             "properties": {
               "data": {
-                "type": "object",
-                "required": [
-                  "code",
-                  "secret",
-                  "expires_in_seconds",
-                  "poll_interval_seconds"
-                ],
-                "properties": {
-                  "code": {
-                    "type": "string",
-                    "description": "Short code to show the user; entered in the web app to approve the device."
-                  },
-                  "secret": {
-                    "type": "string",
-                    "description": "Device-held secret required to redeem the code. Never shown to the user."
-                  },
-                  "expires_in_seconds": {
-                    "type": "integer"
-                  },
-                  "poll_interval_seconds": {
-                    "type": "integer"
-                  }
-                },
-                "additionalProperties": false
+                "$ref": "#/components/schemas/QuickConnectInitiateData"
               }
             }
           }
@@ -10845,7 +10851,9 @@
         ],
         "properties": {
           "code": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 32,
+            "description": "The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored."
           },
           "secret": {
             "type": "string"
@@ -10894,6 +10902,29 @@
         },
         "additionalProperties": false
       },
+      "QuickConnectRedeemData": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved"
+            ]
+          },
+          "token": {
+            "type": "string",
+            "description": "Bearer device token. Present only when status is approved; returned exactly once. Store it; never display it."
+          },
+          "device": {
+            "$ref": "#/components/schemas/Device"
+          }
+        },
+        "additionalProperties": false
+      },
       "QuickConnectRedeemEnvelope": {
         "allOf": [
           {
@@ -10906,27 +10937,7 @@
             ],
             "properties": {
               "data": {
-                "type": "object",
-                "required": [
-                  "status"
-                ],
-                "properties": {
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "pending",
-                      "approved"
-                    ]
-                  },
-                  "token": {
-                    "type": "string",
-                    "description": "Bearer device token. Present only when status is approved; returned exactly once."
-                  },
-                  "device": {
-                    "$ref": "#/components/schemas/Device"
-                  }
-                },
-                "additionalProperties": false
+                "$ref": "#/components/schemas/QuickConnectRedeemData"
               }
             }
           }
@@ -10980,7 +10991,9 @@
         ],
         "properties": {
           "code": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 32,
+            "description": "The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored."
           }
         },
         "additionalProperties": false

--- a/server/cmd/api/quick_connect.go
+++ b/server/cmd/api/quick_connect.go
@@ -236,16 +236,33 @@ func (b *QuickConnectBroker) purgeExpiredLocked() {
 }
 
 func generateQuickConnectCode() (string, error) {
+	// 256 is not a multiple of the alphabet length, so plain modulo would make
+	// the first 256%len symbols more likely. Bytes at or above the largest
+	// whole multiple are rejected instead, which keeps every symbol equally
+	// likely at the cost of redrawing ~3% of the time.
+	unbiasedLimit := 256 - (256 % len(quickConnectCodeAlphabet))
+
+	code := make([]byte, 0, quickConnectCodeLength)
 	buf := make([]byte, quickConnectCodeLength)
-	_, err := rand.Read(buf)
-	if err != nil {
-		return "", err
+
+	for len(code) < quickConnectCodeLength {
+		_, err := rand.Read(buf)
+		if err != nil {
+			return "", err
+		}
+
+		for _, v := range buf {
+			if int(v) >= unbiasedLimit {
+				continue
+			}
+
+			code = append(code, quickConnectCodeAlphabet[int(v)%len(quickConnectCodeAlphabet)])
+			if len(code) == quickConnectCodeLength {
+				break
+			}
+		}
 	}
 
-	code := make([]byte, quickConnectCodeLength)
-	for i, v := range buf {
-		code[i] = quickConnectCodeAlphabet[int(v)%len(quickConnectCodeAlphabet)]
-	}
 	return string(code), nil
 }
 

--- a/server/cmd/api/quick_connect_handler.go
+++ b/server/cmd/api/quick_connect_handler.go
@@ -229,8 +229,21 @@ func (app *Application) issueDeviceToken(w http.ResponseWriter, r *http.Request,
 	return token, device, true
 }
 
+// normalizeQuickConnectCode accepts a code the way a person reads it off a
+// screen: any casing, and with the spacing or dashes a client may use to make
+// it legible. Only separators are dropped. Removing every character outside the
+// alphabet would let a mistyped "ABC2340" collapse into a valid code.
 func normalizeQuickConnectCode(code string) string {
-	return strings.ToUpper(strings.TrimSpace(code))
+	stripSeparators := func(r rune) rune {
+		isSeparator := r == ' ' || r == '\t' || r == '-'
+		if isSeparator {
+			return -1
+		}
+
+		return r
+	}
+
+	return strings.Map(stripSeparators, strings.ToUpper(strings.TrimSpace(code)))
 }
 
 func deviceResponseMap(id int64, name, platform string, appVersion sql.NullString, createdAt, lastUsedAt string, isCurrent bool) map[string]any {

--- a/server/cmd/api/quick_connect_handler_test.go
+++ b/server/cmd/api/quick_connect_handler_test.go
@@ -638,3 +638,62 @@ func TestQuickConnectBroker_RejectsWhenAtCapacity(t *testing.T) {
 		t.Fatalf("initiate after expiry: %v", err)
 	}
 }
+
+func TestGenerateQuickConnectCode_UsesAlphabetAndLength(t *testing.T) {
+	const samples = 2000
+
+	seen := make(map[rune]bool, len(quickConnectCodeAlphabet))
+
+	for i := 0; i < samples; i++ {
+		code, err := generateQuickConnectCode()
+		if err != nil {
+			t.Fatalf("generate #%d: %v", i+1, err)
+		}
+
+		if len(code) != quickConnectCodeLength {
+			t.Fatalf("code %q length = %d, want %d", code, len(code), quickConnectCodeLength)
+		}
+
+		for _, symbol := range code {
+			if !strings.ContainsRune(quickConnectCodeAlphabet, symbol) {
+				t.Fatalf("code %q contains %q, which is outside the alphabet", code, symbol)
+			}
+
+			seen[symbol] = true
+		}
+	}
+
+	// Rejection sampling must still be able to reach every symbol; a sampling
+	// bug that drops the tail of the alphabet shows up here.
+	for _, symbol := range quickConnectCodeAlphabet {
+		if !seen[symbol] {
+			t.Fatalf("symbol %q never generated across %d codes", symbol, samples)
+		}
+	}
+}
+
+func TestNormalizeQuickConnectCode(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "lowercase", input: "xk4t7p", want: "XK4T7P"},
+		{name: "surrounding whitespace", input: "  XK4T7P\n", want: "XK4T7P"},
+		{name: "internal spaces", input: "XK4 T7P", want: "XK4T7P"},
+		{name: "dashes", input: "xk4-t7p", want: "XK4T7P"},
+		{name: "tabs", input: "XK4\tT7P", want: "XK4T7P"},
+		// Only separators are dropped, so a mistyped code cannot collapse into
+		// a valid one by losing characters the alphabet excludes.
+		{name: "keeps excluded characters", input: "abc2340", want: "ABC2340"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeQuickConnectCode(test.input)
+			if got != test.want {
+				t.Fatalf("normalizeQuickConnectCode(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}

--- a/web/src/components/settings/QuickConnectApproveCard.tsx
+++ b/web/src/components/settings/QuickConnectApproveCard.tsx
@@ -21,6 +21,20 @@ import type {
 
 const CODE_LENGTH = 6;
 
+// The server draws codes from an alphabet without I, L, O, 0 or 1 so they stay
+// unambiguous on a TV screen. Anything else can only ever 404, and each lookup
+// spends one of the account's ten approval attempts per five minutes.
+const CODE_PATTERN = /^[ABCDEFGHJKMNPQRSTUVWXYZ2-9]{6}$/;
+
+// Accepts the code however it arrives — typed, or pasted with the spacing a
+// device may use to make it legible. The server normalizes the same way.
+function normalizeCode(value: string) {
+  return value
+    .replace(/[\s-]/g, "")
+    .toUpperCase()
+    .slice(0, CODE_LENGTH);
+}
+
 // After approval the device row only appears once the device polls again;
 // stop watching for it after this long and show a softer confirmation.
 const WAIT_FOR_DEVICE_MS = 30_000;
@@ -203,13 +217,19 @@ export default function QuickConnectApproveCard() {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const trimmed = code.trim().toUpperCase();
-    if (trimmed.length !== CODE_LENGTH) {
+    if (code.length !== CODE_LENGTH) {
       setError(`Enter the ${CODE_LENGTH}-character code shown on your device.`);
       return;
     }
 
-    lookupMutation.mutate(trimmed);
+    if (!CODE_PATTERN.test(code)) {
+      setError(
+        "Codes never contain I, L, O, 0 or 1. Check the code on your device.",
+      );
+      return;
+    }
+
+    lookupMutation.mutate(code);
   };
 
   const handleBack = () => {
@@ -247,10 +267,9 @@ export default function QuickConnectApproveCard() {
                 id={codeId}
                 value={code}
                 onChange={e => {
-                  setCode(e.target.value.toUpperCase());
+                  setCode(normalizeCode(e.target.value));
                   setError(null);
                 }}
-                maxLength={CODE_LENGTH}
                 autoComplete="off"
                 autoCapitalize="characters"
                 spellCheck={false}
@@ -269,6 +288,7 @@ export default function QuickConnectApproveCard() {
               </Button>
             </div>
             <p id={codeDescriptionId} className="text-xs text-muted-foreground">
+              {CODE_LENGTH} characters, never containing I, L, O, 0 or 1.
               You&apos;ll see which device is asking before it gets signed in.
             </p>
             {error && (
@@ -328,7 +348,7 @@ export default function QuickConnectApproveCard() {
                 type="button"
                 variant="accent"
                 disabled={approveMutation.isPending}
-                onClick={() => approveMutation.mutate(code.trim().toUpperCase())}
+                onClick={() => approveMutation.mutate(code)}
                 className="w-full sm:w-auto"
               >
                 {approveMutation.isPending ? "Approving..." : "Approve device"}

--- a/web/src/components/settings/QuickConnectApproveCard.tsx
+++ b/web/src/components/settings/QuickConnectApproveCard.tsx
@@ -27,12 +27,13 @@ const CODE_LENGTH = 6;
 const CODE_PATTERN = /^[ABCDEFGHJKMNPQRSTUVWXYZ2-9]{6}$/;
 
 // Accepts the code however it arrives — typed, or pasted with the spacing a
-// device may use to make it legible. The server normalizes the same way.
+// device may use to make it legible. The server drops spaces, tabs and dashes;
+// this also drops the non-breaking spaces a rendered code can be copied with,
+// which only ever makes a paste succeed that the server would have accepted
+// anyway. Every other character is kept so a mistyped one reaches validation
+// instead of being silently dropped into a code the user never entered.
 function normalizeCode(value: string) {
-  return value
-    .replace(/[\s-]/g, "")
-    .toUpperCase()
-    .slice(0, CODE_LENGTH);
+  return value.replace(/[\s-]/g, "").toUpperCase();
 }
 
 // After approval the device row only appears once the device polls again;

--- a/web/src/test/settings/quick-connect-card.test.tsx
+++ b/web/src/test/settings/quick-connect-card.test.tsx
@@ -267,6 +267,36 @@ describe("QuickConnectApproveCard", () => {
     expect(input).toHaveAttribute("aria-describedby", error.id);
   });
 
+  it("accepts a pasted code that carries whitespace or dashes", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const input = screen.getByRole("textbox", { name: "Quick Connect code" });
+    await user.click(input);
+    await user.paste(" xk4-t7p ");
+    expect(input).toHaveValue("XK4T7P");
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(lookupQuickConnectMock).toHaveBeenCalledWith("XK4T7P");
+  });
+
+  it("rejects characters the code alphabet excludes without calling the API", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const input = screen.getByRole("textbox", { name: "Quick Connect code" });
+    await user.type(input, "XK40OP");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(lookupQuickConnectMock).not.toHaveBeenCalled();
+
+    const error = await screen.findByRole("alert");
+    expect(error).toHaveTextContent("Codes never contain I, L, O, 0 or 1");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", error.id);
+  });
+
   it("shows an actionable message when the looked-up code is invalid or expired", async () => {
     lookupQuickConnectMock.mockResolvedValue({
       error: true,

--- a/web/src/test/settings/quick-connect-card.test.tsx
+++ b/web/src/test/settings/quick-connect-card.test.tsx
@@ -281,6 +281,41 @@ describe("QuickConnectApproveCard", () => {
     expect(lookupQuickConnectMock).toHaveBeenCalledWith("XK4T7P");
   });
 
+  it("keeps a trailing invalid character instead of truncating it away", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const input = screen.getByRole("textbox", { name: "Quick Connect code" });
+    await user.click(input);
+    await user.paste("XK4T7P!");
+    expect(input).toHaveValue("XK4T7P!");
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    // Dropping the stray character would submit a code the user never entered
+    // and spend one of the ten approval attempts allowed per five minutes.
+    expect(lookupQuickConnectMock).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Enter the 6-character code",
+    );
+  });
+
+  it("accepts a code pasted with non-breaking spaces", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    // A code copied out of rendered markup can carry U+00A0 rather than a
+    // plain space, and unlike a newline the input keeps it.
+    const input = screen.getByRole("textbox", { name: "Quick Connect code" });
+    await user.click(input);
+    await user.paste("XK4 T7P");
+    expect(input).toHaveValue("XK4T7P");
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(lookupQuickConnectMock).toHaveBeenCalledWith("XK4T7P");
+  });
+
   it("rejects characters the code alphabet excludes without calling the API", async () => {
     const user = userEvent.setup();
     renderCard();

--- a/web/src/types/openapi.gen.ts
+++ b/web/src/types/openapi.gen.ts
@@ -3375,7 +3375,7 @@ export interface components {
             data: components["schemas"]["QuickConnectInitiateData"];
         };
         QuickConnectRedeemRequest: {
-            /** @description The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored. */
+            /** @description The six-character code shown on the device. Case-insensitive; surrounding whitespace is trimmed, and spaces, tabs and dashes are ignored anywhere in the code. */
             code: string;
             secret: string;
         };
@@ -3409,7 +3409,7 @@ export interface components {
             data: components["schemas"]["QuickConnectLookupData"];
         };
         QuickConnectApproveRequest: {
-            /** @description The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored. */
+            /** @description The six-character code shown on the device. Case-insensitive; surrounding whitespace is trimmed, and spaces, tabs and dashes are ignored anywhere in the code. */
             code: string;
         };
         DeviceLoginRequest: {

--- a/web/src/types/openapi.gen.ts
+++ b/web/src/types/openapi.gen.ts
@@ -3363,17 +3363,19 @@ export interface components {
             platform?: string;
             app_version?: string;
         };
+        QuickConnectInitiateData: {
+            /** @description The only value to display to the user; they enter it in the web app to approve the device. Always six uppercase characters drawn from an alphabet that omits I, L, O, 0 and 1 so it stays unambiguous on a TV screen. */
+            code: string;
+            /** @description Device-held secret required to redeem the code. Never shown to the user: keep it in memory and send it back in the redeem request body. */
+            secret: string;
+            expires_in_seconds: number;
+            poll_interval_seconds: number;
+        };
         QuickConnectInitiateEnvelope: components["schemas"]["JsonSuccess"] & {
-            data: {
-                /** @description Short code to show the user; entered in the web app to approve the device. */
-                code: string;
-                /** @description Device-held secret required to redeem the code. Never shown to the user. */
-                secret: string;
-                expires_in_seconds: number;
-                poll_interval_seconds: number;
-            };
+            data: components["schemas"]["QuickConnectInitiateData"];
         };
         QuickConnectRedeemRequest: {
+            /** @description The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored. */
             code: string;
             secret: string;
         };
@@ -3388,14 +3390,15 @@ export interface components {
             /** @description True when the request was authenticated with this device's token. Always false in the device-list response, which is session-only. */
             is_current: boolean;
         };
+        QuickConnectRedeemData: {
+            /** @enum {string} */
+            status: "pending" | "approved";
+            /** @description Bearer device token. Present only when status is approved; returned exactly once. Store it; never display it. */
+            token?: string;
+            device?: components["schemas"]["Device"];
+        };
         QuickConnectRedeemEnvelope: components["schemas"]["JsonSuccess"] & {
-            data: {
-                /** @enum {string} */
-                status: "pending" | "approved";
-                /** @description Bearer device token. Present only when status is approved; returned exactly once. */
-                token?: string;
-                device?: components["schemas"]["Device"];
-            };
+            data: components["schemas"]["QuickConnectRedeemData"];
         };
         QuickConnectLookupData: {
             device_name: string;
@@ -3406,6 +3409,7 @@ export interface components {
             data: components["schemas"]["QuickConnectLookupData"];
         };
         QuickConnectApproveRequest: {
+            /** @description The six-character code shown on the device. Case-insensitive; surrounding whitespace, spaces and dashes are ignored. */
             code: string;
         };
         DeviceLoginRequest: {


### PR DESCRIPTION
## Context

Investigating a report that Igloo generates a long quick-connect code while the `/settings/account` input accepts only a few characters. **That mismatch does not exist** — the code is six characters on both sides (`quickConnectCodeLength = 6`, `CODE_LENGTH = 6`).

The long value in `POST /api/quick-connect/initiate` is `secret`: 32 random bytes base64url (~43 chars), device-held, hashed server-side, and required at redeem so someone who merely reads the code off a screen cannot redeem it. The report came from an external device client, which is displaying `data.secret` (or the `igd_…` token) rather than `data.code`. This PR tightens the parts of the flow that made that easy to get wrong, plus the real defects found during the review.

Reviewed and left alone: the two-value code/secret design, constant-time secret comparison, `Consume` only after the device row commits, the 5-minute TTL and lazy purge, the 1000-code ceiling, lookup sharing approve's 10-per-5-min bucket, and SHA-256-only token storage.

## Changes

**Server**
- `generateQuickConnectCode` used `byte % 31`, biasing `A`–`H` ~12.5% high (256 = 8×31 + 8). Now rejection-samples bytes ≥ 248.
- `normalizeQuickConnectCode` strips spaces, tabs and dashes in addition to case. Separators only — dropping arbitrary out-of-alphabet characters would let a mistyped `ABC2340` collapse into a valid code.

**Web** (`QuickConnectApproveCard.tsx`)
- One `normalizeCode` replaces three divergent inline transforms (`onChange`, submit, approve).
- Removed `maxLength={6}`, which truncated *before* the JS handler ran and made a pasted `" XK4T7P"` fail its own length check.
- Added a charset check so `I`, `L`, `O`, `0`, `1` are rejected client-side rather than spending one of the account's ten 5-minute lookup attempts on a guaranteed 404; the field hint now states the length and excluded characters.

**OpenAPI**
- Pin the code's length and alphabet on the initiate response; document the lenient request parsing without a pattern (the contract test deliberately sends lowercase).
- Extract `QuickConnectInitiateData` / `QuickConnectRedeemData` — both envelopes inlined their `data`, violating `docs/openapi-maintenance.md` and leaking an index signature into the generated TS. Regenerated `openapi.gen.ts`.

## Testing

`make check` passes in full (`test-openapi`, `check-openapi`, `test-server`, `lint-web`, `test-web` — 645 tests, `build-web`), plus `bun run test:e2e:device-lifecycle`.

New coverage: Go tests for the generator's charset/length and a table-driven `normalizeQuickConnectCode` test; web tests for formatted paste and charset rejection.

Chrome DevTools MCP against the mocked stack confirmed end to end: `XK40OP` rejected with `aria-invalid="true"` + `role="alert"` wired to `aria-describedby` and **no** `/lookup` request; `" 9c6-73d "` normalized to `9C673D`; Enter-key submit moved focus to the confirm heading; approve → device redeemed → "Living Room TV is connected". Console clean.

**Not covered:** validation ran against the mocked stack, not a real library (the claude-in-chrome extension was unavailable and a live pass would have needed a temp admin in the real DB). `web/e2e/quick-connect.spec.ts` is live-server only and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Connect codes now use a clear, six-character format that excludes ambiguous characters.
  * Codes can be entered with spaces, tabs, or dashes and are automatically normalized.
  * Added clearer guidance for code formatting, validation, expiration, polling, and secret handling.

* **Bug Fixes**
  * Improved code generation for more evenly distributed codes.
  * Added specific validation feedback when unsupported or ambiguous characters are entered.

* **Tests**
  * Added coverage for code generation, normalization, validation, pasted codes, and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->