### PR TITLE
React Doctor cleanup: clear all errors, verified fixes only

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -37,7 +37,6 @@
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^5.2.0",
         "babel-plugin-react-compiler": "^1.0.0",
-        "baseline-browser-mapping": "^2.11.12",
         "browserslist": "^4.28.7",
         "eslint": "^9.39.5",
         "eslint-plugin-better-tailwindcss": "^4.7.0",
@@ -517,7 +516,7 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.5", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
@@ -1050,8 +1049,6 @@
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "babel-plugin-react-compiler/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.11.5", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 

--- a/web/e2e/motion.spec.ts
+++ b/web/e2e/motion.spec.ts
@@ -94,48 +94,14 @@ async function expectDecorativeAnimationsStopped(page: Page) {
   ).toEqual([]);
 }
 
-async function expectAnnouncementReachable(page: Page, label: string) {
+// The visible heading, status badge, and description carry the page
+// announcement for screen readers; there is deliberately no focusable
+// sr-only span, since a non-interactive tab stop is keyboard noise.
+async function expectSkipLinkWorks(page: Page) {
   await page.keyboard.press("Tab");
   await expect(page.getByRole("link", { name: "Skip to content" })).toBeFocused();
   await page.keyboard.press("Enter");
   await expect(page.getByRole("main")).toBeFocused();
-
-  for (let attempt = 0; attempt < 8; attempt += 1) {
-    await page.keyboard.press("Tab");
-
-    const activeLabel = await page.evaluate(() => {
-      const active = document.activeElement;
-      if (!(active instanceof HTMLElement)) {
-        return "";
-      }
-
-      return active.getAttribute("aria-label") ?? active.textContent?.trim() ?? "";
-    });
-
-    if (activeLabel === label) {
-      break;
-    }
-  }
-
-  const focusedAnnouncement = page.locator(`[aria-label="${label}"]`);
-  await expect(focusedAnnouncement).toBeFocused();
-
-  const bounds = await focusedAnnouncement.evaluate(element => {
-    const rect = element.getBoundingClientRect();
-    return {
-      bottom: rect.bottom,
-      left: rect.left,
-      right: rect.right,
-      top: rect.top,
-      viewportHeight: window.innerHeight,
-      viewportWidth: window.innerWidth,
-    };
-  });
-
-  expect(bounds.left).toBeGreaterThanOrEqual(0);
-  expect(bounds.top).toBeGreaterThanOrEqual(0);
-  expect(bounds.right).toBeLessThanOrEqual(bounds.viewportWidth);
-  expect(bounds.bottom).toBeLessThanOrEqual(bounds.viewportHeight);
 }
 
 test.describe("Reduced motion", () => {
@@ -163,10 +129,7 @@ test.describe("Reduced motion", () => {
       );
       await expectPageHasNoHorizontalScroll(page);
       await expectDecorativeAnimationsStopped(page);
-      await expectAnnouncementReachable(
-        page,
-        `${comingSoonPage.title}. Under Development. ${comingSoonPage.description}`,
-      );
+      await expectSkipLinkWorks(page);
     }
 
     browserIssues.assertClean();

--- a/web/package.json
+++ b/web/package.json
@@ -70,7 +70,6 @@
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^5.2.0",
     "babel-plugin-react-compiler": "^1.0.0",
-    "baseline-browser-mapping": "^2.11.12",
     "browserslist": "^4.28.7",
     "eslint": "^9.39.5",
     "eslint-plugin-better-tailwindcss": "^4.7.0",

--- a/web/src/components/app/AppShell.tsx
+++ b/web/src/components/app/AppShell.tsx
@@ -10,16 +10,16 @@ import { useIsMiniPlayerVisible } from "@/hooks/useIsMiniPlayerVisible";
 import { MINI_PLAYER_CLEARANCE_PADDING_CLASS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
+function handleSkipToContent() {
+  requestAnimationFrame(() => {
+    document.getElementById("main")?.focus();
+  });
+}
+
 export default function AppShell({ children }: PropsWithChildren) {
   // The minimized audio player is a fixed bottom bar; reserve space for it so
   // the last rows of any page stay reachable while music plays.
   const isMiniPlayerVisible = useIsMiniPlayerVisible();
-
-  const handleSkipToContent = () => {
-    requestAnimationFrame(() => {
-      document.getElementById("main")?.focus();
-    });
-  };
 
   return (
     <SidebarProvider>

--- a/web/src/components/app/NotificationBell.tsx
+++ b/web/src/components/app/NotificationBell.tsx
@@ -43,6 +43,10 @@ function notificationTitleLabel(title: string): string {
   return NOTIFICATION_TITLE_LABELS[title] ?? "Notification";
 }
 
+const RELATIVE_TIME_FORMAT = new Intl.RelativeTimeFormat(undefined, {
+  numeric: "auto",
+});
+
 // SQLite timestamps come back as "YYYY-MM-DD HH:MM:SS" in UTC; normalize to an
 // ISO string before parsing so the relative time is computed correctly.
 function formatRelativeTime(timestamp: string): string {
@@ -51,7 +55,7 @@ function formatRelativeTime(timestamp: string): string {
 
   const diffSec = Math.round((parsed - Date.now()) / 1000);
   const abs = Math.abs(diffSec);
-  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const rtf = RELATIVE_TIME_FORMAT;
 
   if (abs < 60) return rtf.format(diffSec, "second");
   if (abs < 3600) return rtf.format(Math.round(diffSec / 60), "minute");

--- a/web/src/components/app/NotificationBell.tsx
+++ b/web/src/components/app/NotificationBell.tsx
@@ -68,17 +68,23 @@ export default function NotificationBell() {
   // on `error === false` before reading the success shape (like every other
   // query consumer). An error envelope surfaces as `showRefreshError`, not a
   // thrown query error.
-  const countQuery = useQuery(unreadNotificationCountQueryOpts());
+  const { data: countEnvelope, isError: countIsError } = useQuery(
+    unreadNotificationCountQueryOpts(),
+  );
   const freshCountData =
-    countQuery.data?.error === false ? countQuery.data.data : undefined;
+    countEnvelope?.error === false ? countEnvelope.data : undefined;
 
   // Only fetch the full list while the panel is open.
-  const listQuery = useQuery({
+  const {
+    data: listEnvelope,
+    isError: listIsError,
+    isLoading: listIsLoading,
+  } = useQuery({
     ...notificationsQueryOpts(),
     enabled: open,
   });
   const freshListData =
-    listQuery.data?.error === false ? listQuery.data.data : undefined;
+    listEnvelope?.error === false ? listEnvelope.data : undefined;
 
   // react-query stores an error envelope as (successful) data, dropping the last
   // good payload. Retain it so a failed refresh keeps showing the previous list
@@ -102,11 +108,11 @@ export default function NotificationBell() {
   const listUnreadCount = open ? listData?.unread_count : undefined;
   const unreadCount = listUnreadCount ?? countUnreadCount;
   const showRefreshError = Boolean(
-    countQuery.isError ||
-      countQuery.data?.error ||
-      (open && (listQuery.isError || listQuery.data?.error)),
+    countIsError ||
+      countEnvelope?.error ||
+      (open && (listIsError || listEnvelope?.error)),
   );
-  const showInitialLoading = listQuery.isLoading && !listQuery.data;
+  const showInitialLoading = listIsLoading && !listEnvelope;
   const showEmptyState = !!listData && notifications.length === 0;
 
   useEffect(() => {

--- a/web/src/components/home/HomeMediaSection.tsx
+++ b/web/src/components/home/HomeMediaSection.tsx
@@ -60,7 +60,6 @@ export default function HomeMediaSection<T>({
 
   return (
     <section
-      role="region"
       aria-labelledby={headingId}
       aria-describedby={sectionSummaryId}
       className={cn("mt-6 md:mt-8", MOTION_SECTION_ENTER_DELAYED_CLASS)}

--- a/web/src/components/movies/CastSection.tsx
+++ b/web/src/components/movies/CastSection.tsx
@@ -1,5 +1,6 @@
 import { User } from "lucide-react";
 import {
+  FOCUS_VISIBLE_RING_CLASS,
   MOTION_MICRO_COLORS_CLASS,
   TMDB_PROFILE_SIZE,
 } from "@/lib/constants";
@@ -33,35 +34,34 @@ export default function CastSection({
       </h2>
 
       <p className="sr-only">
-        Showing {displayedCast.length} of {cast.length} cast members. Use Tab to
-        move between cast cards, or scroll horizontally to see more.
+        Showing {displayedCast.length} of {cast.length} cast members. Scroll
+        horizontally to see more.
       </p>
 
+      {/* Focusable so keyboard users can scroll the horizontal strip; role
+          kept because Tailwind's list-none strips list semantics in Safari. */}
       <ul
-        className="-mx-4 flex scrollbar-thin scrollbar-thumb-primary/50 list-none gap-3 overflow-x-auto px-4 pb-4 sm:-mx-6 sm:gap-4 sm:px-6 lg:-mx-8 lg:px-8"
+        tabIndex={0}
+        className={cn(
+          "-mx-4 flex scrollbar-thin scrollbar-thumb-primary/50 list-none gap-3 overflow-x-auto px-4 pb-4 sm:-mx-6 sm:gap-4 sm:px-6 lg:-mx-8 lg:px-8",
+          FOCUS_VISIBLE_RING_CLASS,
+        )}
         role="list"
         aria-label={`Cast members, ${displayedCast.length} shown`}
       >
-        {displayedCast.map((actor, index) => (
+        {displayedCast.map(actor => (
           <li
             key={actor.id}
             className={cn(
               MOTION_MICRO_COLORS_CLASS,
-              "w-32 shrink-0 overflow-hidden rounded-lg border border-primary/20 bg-muted/50 focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/50 hover:border-primary/40",
+              "w-32 shrink-0 overflow-hidden rounded-lg border border-primary/20 bg-muted/50 hover:border-primary/40",
             )}
           >
-            <article
-              tabIndex={0}
-              role="article"
-              aria-label={`${actor.name} as ${actor.character}`}
-              aria-posinset={index + 1}
-              aria-setsize={displayedCast.length}
-              className="cursor-default outline-hidden"
-            >
+            <article aria-label={`${actor.name} as ${actor.character}`}>
               {actor.profile_path ? (
                 <img
                   src={buildTmdbImageUrl(actor.profile_path, TMDB_PROFILE_SIZE)}
-                  alt={`Photo of ${actor.name}`}
+                  alt={actor.name}
                   className="aspect-2/3 w-full object-cover"
                   loading="lazy"
                 />

--- a/web/src/components/music/MusicianCard.tsx
+++ b/web/src/components/music/MusicianCard.tsx
@@ -47,7 +47,7 @@ export default function MusicianCard({ musician }: MusicianCardProps) {
           {showThumb ? (
             <img
               src={thumbUrl}
-              alt={`Photo of ${name}`}
+              alt={name}
               width={256}
               height={256}
               loading="lazy"

--- a/web/src/components/playback/VideoPlayer.tsx
+++ b/web/src/components/playback/VideoPlayer.tsx
@@ -474,6 +474,9 @@ export default function VideoPlayer({
 
     let cancelled = false;
     const controller = new AbortController();
+    // Cleared in both exits below; `finally` would bail React Compiler out of
+    // the whole component.
+    let timeoutId: number | undefined;
 
     void (async () => {
       try {
@@ -485,19 +488,15 @@ export default function VideoPlayer({
 
         // A stalled manifest connection would otherwise leave native playback
         // sourceless forever; aborting drops into the catch fallback below.
-        const timeoutId = window.setTimeout(
+        timeoutId = window.setTimeout(
           () => controller.abort(),
           HLS_JS_LOAD_TIMEOUT_MS,
         );
-        let response: Response;
-        try {
-          response = await fetch(src, {
-            credentials: "include",
-            signal: controller.signal,
-          });
-        } finally {
-          window.clearTimeout(timeoutId);
-        }
+        const response = await fetch(src, {
+          credentials: "include",
+          signal: controller.signal,
+        });
+        window.clearTimeout(timeoutId);
         await releaseResponseBody(response);
         if (cancelled) return;
 
@@ -520,6 +519,7 @@ export default function VideoPlayer({
           video.src = src;
         }
       } catch {
+        window.clearTimeout(timeoutId);
         if (!cancelled) {
           // Metadata is advisory. Let the native player use its existing
           // loading and error behavior when the preflight itself fails.

--- a/web/src/components/settings/ProfilePinCard.tsx
+++ b/web/src/components/settings/ProfilePinCard.tsx
@@ -54,12 +54,12 @@ export default function ProfilePinCard() {
   const currentPinErrorId = `${currentPinId}-error`;
   const newPinErrorId = `${newPinId}-error`;
 
-  const pinQuery = useQuery({
+  const { data: pinData, isPending: pinPending } = useQuery({
     ...userPinQueryOpts(),
     enabled: hasPin && revealed,
   });
   const revealedPin =
-    pinQuery.data?.error === false ? pinQuery.data.data?.pin : null;
+    pinData?.error === false ? pinData.data?.pin : null;
 
   const showFieldError = (
     field: PinErrorField,
@@ -186,7 +186,7 @@ export default function ProfilePinCard() {
 
   let revealedPinDisplay = "••••";
   if (revealed) {
-    if (pinQuery.isPending) {
+    if (pinPending) {
       revealedPinDisplay = "…";
     } else if (revealedPin) {
       revealedPinDisplay = revealedPin;
@@ -224,9 +224,9 @@ export default function ProfilePinCard() {
             You have not set a profile PIN.
           </p>
         )}
-        {revealed && pinQuery.data?.error && (
+        {revealed && pinData?.error && (
           <p className="text-xs text-destructive" role="alert">
-            {pinQuery.data.message || "Failed to load your PIN."}
+            {pinData.message || "Failed to load your PIN."}
           </p>
         )}
 

--- a/web/src/components/shared/ComingSoon.tsx
+++ b/web/src/components/shared/ComingSoon.tsx
@@ -24,26 +24,12 @@ export default function ComingSoon({
   description = "We're working hard to bring you this feature. Check back soon for updates!",
   icon: Icon = Snowflake,
 }: ComingSoonProps) {
-  // Accessible announcement for screen readers
-  const announcement = `${title}. Under Development. ${description}`;
-
   return (
     <section
       aria-labelledby="coming-soon-title"
       aria-describedby="coming-soon-desc"
       className="flex min-h-[60vh] flex-col items-center justify-center px-4 py-16 text-center"
     >
-      {/* Screen reader announcement - focusable for Tab navigation */}
-      <span
-        tabIndex={0}
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50
-          focus:rounded-md focus:bg-muted focus:px-4 focus:py-2 focus:text-foreground focus:ring-2
-          focus:ring-ring focus:outline-none"
-        aria-label={announcement}
-      >
-        {title} - Under Development
-      </span>
-
       <div className={MOTION_PAGE_ENTER_CLASS}>
         {/* Animated icon container */}
         <div className="relative mx-auto mb-8" aria-hidden="true">

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -78,22 +78,23 @@ function DialogContent({
   )
 }
 
-const DialogFullscreenContent = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal data-slot="dialog-portal">
-    <DialogPrimitive.Content
-      ref={ref}
-      data-slot="dialog-fullscreen-content"
-      className={cn("fixed inset-0 z-50 outline-hidden", className)}
-      {...props}
-    >
-      {children}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
-DialogFullscreenContent.displayName = "DialogFullscreenContent";
+function DialogFullscreenContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogPrimitive.Content
+        data-slot="dialog-fullscreen-content"
+        className={cn("fixed inset-0 z-50 outline-hidden", className)}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -118,18 +119,18 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-const DialogTitle = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    data-slot="dialog-title"
-    className={cn("text-lg leading-none font-semibold", className)}
-    {...props}
-  />
-));
-DialogTitle.displayName = "DialogTitle";
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
 
 function DialogDescription({
   className,

--- a/web/src/components/ui/pagination.tsx
+++ b/web/src/components/ui/pagination.tsx
@@ -11,7 +11,6 @@ import { Button, buttonVariants } from "@/components/ui/button"
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (
     <nav
-      role="navigation"
       aria-label="pagination"
       data-slot="pagination"
       className={cn("mx-auto flex w-full justify-center", className)}

--- a/web/src/components/ui/sidebar-context.tsx
+++ b/web/src/components/ui/sidebar-context.tsx
@@ -13,7 +13,7 @@ export const SidebarContext =
   React.createContext<SidebarContextProps | null>(null)
 
 export function useSidebar() {
-  const context = React.useContext(SidebarContext)
+  const context = React.use(SidebarContext)
   if (!context) {
     throw new Error("useSidebar must be used within a SidebarProvider.")
   }

--- a/web/src/components/watch-room/WatchRooms.tsx
+++ b/web/src/components/watch-room/WatchRooms.tsx
@@ -36,7 +36,6 @@ export default function WatchRooms() {
 
   return (
     <section
-      role="region"
       aria-labelledby="watch-rooms-heading"
       aria-describedby={sectionDescribedBy}
       className={cn("mt-6 md:mt-8", MOTION_SECTION_ENTER_DELAYED_CLASS)}

--- a/web/src/hooks/useTrackLikeToggle.ts
+++ b/web/src/hooks/useTrackLikeToggle.ts
@@ -30,7 +30,7 @@ function setTrackLiked(ids: number[], trackId: number, isLiked: boolean) {
  * source of liked state for track rows and the audio player. Mutations are
  * keyed per track so duplicate controls share their pending state.
  */
-export function useTrackLikeToggle(trackId: number) {
+function useTrackLikeToggle(trackId: number) {
   const queryClient = useQueryClient();
   const key = [LIKED_TRACK_IDS_KEY] as const;
   const mutationKey = [TRACK_LIKE_MUTATION_KEY, trackId] as const;

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -132,7 +132,6 @@ export const YOUTUBE_THUMBNAIL_BASE = "/api/youtube/thumbnails";
 export const TMDB_BACKDROP_SIZE = "w1280";
 export const TMDB_POSTER_SIZE = "w500";
 export const TMDB_PROFILE_SIZE = "w185";
-export const TMDB_LOGO_SIZE = "w92";
 
 // Virtual-list measurements in pixels. These keep virtualized rows stable and
 // must match the rendered heights of TrackItem (p-3 row + two text lines) and
@@ -224,7 +223,6 @@ export const MOVIE_WATCH_PROGRESS_COMPLETION_THRESHOLD = 0.98;
 export const MOVIE_HLS_FORWARD_REBASE_THRESHOLD_SEC = 120;
 /** Delay before the mid-playback buffering spinner appears, to avoid flicker on sub-perceptual stalls. */
 export const MOVIE_BUFFERING_SPINNER_DELAY_MS = 300;
-export const MEDIA_ERR_NETWORK = 2;
 export const MEDIA_ERR_DECODE = 3;
 export const MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
 

--- a/web/src/lib/library-refresh.ts
+++ b/web/src/lib/library-refresh.ts
@@ -1,0 +1,31 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { showActionFailed, showSuccess } from "@/lib/toast-helpers";
+
+/**
+ * Runs a library cache refresh with the shared success/failure toasts. Never
+ * throws, so component handlers can reset their UI state with plain sequential
+ * code instead of a `finally` block (which bails React Compiler out of the
+ * whole component).
+ */
+export async function refreshLibraryWithToasts(
+  queryClient: QueryClient,
+  refresh: (queryClient: QueryClient) => Promise<void>,
+  libraryNoun: "Music" | "Movie",
+): Promise<void> {
+  try {
+    await refresh(queryClient);
+    showSuccess(
+      "Library refreshed",
+      `${libraryNoun} library data is up to date.`,
+    );
+  } catch (error) {
+    console.error(
+      `Failed to refresh ${libraryNoun.toLowerCase()} library:`,
+      error,
+    );
+    showActionFailed(
+      "refresh library",
+      `Unable to refresh the ${libraryNoun.toLowerCase()} library. Please try again.`,
+    );
+  }
+}

--- a/web/src/lib/music-library-cache.ts
+++ b/web/src/lib/music-library-cache.ts
@@ -30,12 +30,6 @@ const MUSIC_LIBRARY_QUERY_KEYS = [
   PLAYLIST_TRACKS_KEY,
 ] as const;
 
-export function invalidateMusicLibraryQueries(queryClient: QueryClient) {
-  MUSIC_LIBRARY_QUERY_KEYS.forEach(key => {
-    void queryClient.invalidateQueries({ queryKey: [key] });
-  });
-}
-
 export async function refreshMusicLibraryCache(queryClient: QueryClient) {
   await Promise.all(
     MUSIC_LIBRARY_QUERY_KEYS.map(async key => {

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -24,12 +24,6 @@ export const THEME_COLORS: Record<Theme, string> = {
   light: tokenHex("light", "--background"),
 };
 
-// Body text on the canvas; mirrors the --foreground tokens and boot.css `color`.
-export const THEME_TEXT_COLORS: Record<Theme, string> = {
-  dark: tokenHex("dark", "--foreground"),
-  light: tokenHex("light", "--foreground"),
-};
-
 /** Reads the stored theme, defaulting to "dark" when absent or invalid. */
 export function getStoredTheme(): Theme {
   try {

--- a/web/src/routes/_auth/movies/index.tsx
+++ b/web/src/routes/_auth/movies/index.tsx
@@ -58,8 +58,8 @@ import {
 } from "@/lib/query-opts";
 import { MoviesLoadError } from "@/components/shared/MoviesLoadError";
 import { isApiFailure } from "@/lib/is-api-failure";
+import { refreshLibraryWithToasts } from "@/lib/library-refresh";
 import { refreshMovieLibraryCache } from "@/lib/movie-library-cache";
-import { showActionFailed, showSuccess } from "@/lib/toast-helpers";
 import { cn } from "@/lib/utils";
 import { scrollWindowToTop } from "@/lib/motion";
 import { focusDialogRestoreTarget } from "@/hooks/useDialogFocusRestore";
@@ -376,19 +376,9 @@ function MoreMenu({
     if (refreshingLibrary) return;
 
     setRefreshingLibrary(true);
-    try {
-      await refreshMovieLibraryCache(queryClient);
-      showSuccess("Library refreshed", "Movie library data is up to date.");
-    } catch (error) {
-      console.error("Failed to refresh movie library:", error);
-      showActionFailed(
-        "refresh library",
-        "Unable to refresh the movie library. Please try again.",
-      );
-    } finally {
-      setRefreshingLibrary(false);
-      setMenuOpen(false);
-    }
+    await refreshLibraryWithToasts(queryClient, refreshMovieLibraryCache, "Movie");
+    setRefreshingLibrary(false);
+    setMenuOpen(false);
   };
 
   return (

--- a/web/src/routes/_auth/music/index.tsx
+++ b/web/src/routes/_auth/music/index.tsx
@@ -32,7 +32,8 @@ import { useContentFadeTransition } from "@/hooks/useContentFadeTransition";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useVirtualizedInfiniteLoader } from "@/hooks/useVirtualizedInfiniteLoader";
 import { useWindowScrollMargin } from "@/hooks/useWindowScrollMargin";
-import { showActionFailed, showSuccess } from "@/lib/toast-helpers";
+import { showActionFailed } from "@/lib/toast-helpers";
+import { refreshLibraryWithToasts } from "@/lib/library-refresh";
 import { refreshMusicLibraryCache } from "@/lib/music-library-cache";
 import LiveAnnouncer from "@/components/shared/LiveAnnouncer";
 import { MoviesLoadError } from "@/components/shared/MoviesLoadError";
@@ -291,19 +292,9 @@ function MoreMenu() {
     if (refreshingLibrary) return;
 
     setRefreshingLibrary(true);
-    try {
-      await refreshMusicLibraryCache(queryClient);
-      showSuccess("Library refreshed", "Music library data is up to date.");
-    } catch (error) {
-      console.error("Failed to refresh music library:", error);
-      showActionFailed(
-        "refresh library",
-        "Unable to refresh the music library. Please try again.",
-      );
-    } finally {
-      setRefreshingLibrary(false);
-      setMenuOpen(false);
-    }
+    await refreshLibraryWithToasts(queryClient, refreshMusicLibraryCache, "Music");
+    setRefreshingLibrary(false);
+    setMenuOpen(false);
   };
   const spotifyAvailable =
     spotifyStatusData?.error === false

--- a/web/src/routes/_auth/music/musician.$id.tsx
+++ b/web/src/routes/_auth/music/musician.$id.tsx
@@ -187,6 +187,19 @@ function MusicianDetailsSkeleton() {
   );
 }
 
+// Format follower count for display
+function formatFollowers(count: number) {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+
+  if (count >= 1_000) {
+    return `${Math.floor(count / 1_000)}K`;
+  }
+
+  return count.toString();
+}
+
 function MusicianDetailsContent({
   musician,
   albums,
@@ -210,19 +223,6 @@ function MusicianDetailsContent({
   // React 19 document metadata - dynamic based on musician
   const pageTitle = `${musician.name} - Igloo`;
   const pageDescription = `Listen to ${musician.name} - ${albums.length} albums, ${tracks.length} tracks in your Igloo music library.`;
-
-  // Format follower count for display
-  const formatFollowers = (count: number) => {
-    if (count >= 1_000_000) {
-      return `${(count / 1_000_000).toFixed(1)}M`;
-    }
-
-    if (count >= 1_000) {
-      return `${Math.floor(count / 1_000)}K`;
-    }
-
-    return count.toString();
-  };
 
   const convertTracksForPlayer = (musicianTracks: MusicianTrackType[]) => {
     return musicianTracks.map((track) =>

--- a/web/src/routes/_auth/music/playlist.$id.tsx
+++ b/web/src/routes/_auth/music/playlist.$id.tsx
@@ -256,9 +256,6 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
     setShowDeleteDialog(true);
   };
 
-  // Page announcement for screen readers
-  const pageAnnouncement = `${playlist.name}. ${track_count} ${track_count === 1 ? "track" : "tracks"}. Total duration: ${formatDuration(duration)}.`;
-
   return (
     <article
       className={cn(
@@ -270,15 +267,6 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
       {/* React 19 Document Metadata */}
       <title>{pageTitle}</title>
       <meta name="description" content={pageDescription} />
-
-      {/* Screen reader announcement */}
-      <span
-        tabIndex={0}
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-muted focus:px-4 focus:py-2 focus:text-foreground focus:ring-2 focus:ring-ring focus:outline-hidden"
-        aria-label={pageAnnouncement}
-      >
-        {playlist.name} - {track_count} tracks
-      </span>
 
       {/* Header section */}
       <header className="mb-8 flex flex-col gap-6 sm:mb-10 sm:gap-8 lg:flex-row">

--- a/web/src/routes/_auth/trailer.tsx
+++ b/web/src/routes/_auth/trailer.tsx
@@ -81,11 +81,15 @@ function TrailerPage() {
 
   const shouldFetchMovie =
     mediaType === "movie" && mediaId != null && mediaId > 0 && !videoKey;
-  const movieQuery = useQuery({
+  const {
+    data,
+    isPending: moviePending,
+    isError: movieIsError,
+    refetch: refetchMovie,
+  } = useQuery({
     ...movieDetailsQueryOpts(mediaId ?? 0),
     enabled: shouldFetchMovie,
   });
-  const data = movieQuery.data;
 
   const media = data?.data?.movie;
   const trailerFromApi = media?.videos?.results?.find(
@@ -349,7 +353,7 @@ function TrailerPage() {
     );
   }
 
-  if (!trailerKey && shouldFetchMovie && movieQuery.isPending) {
+  if (!trailerKey && shouldFetchMovie && moviePending) {
     return (
       <Dialog open onOpenChange={handleDialogOpenChange}>
         <DialogFullscreenContent
@@ -378,7 +382,7 @@ function TrailerPage() {
     );
   }
 
-  if (!trailerKey && (movieQuery.isError || data?.error)) {
+  if (!trailerKey && (movieIsError || data?.error)) {
     return (
       <Dialog open onOpenChange={handleDialogOpenChange}>
         <DialogFullscreenContent
@@ -404,7 +408,7 @@ function TrailerPage() {
               <button
                 type="button"
                 ref={closeButtonRef}
-                onClick={() => void movieQuery.refetch()}
+                onClick={() => void refetchMovie()}
                 className={cn(
                   MOTION_PLAYER_CHROME_BUTTON_CLASS,
                   "inline-flex items-center rounded-full bg-primary px-6 py-3 font-semibold text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden",

--- a/web/src/routes/_auth/trailer.tsx
+++ b/web/src/routes/_auth/trailer.tsx
@@ -63,6 +63,21 @@ export const Route = createFileRoute("/_auth/trailer")({
   component: TrailerPage,
 });
 
+function focusMainAfterNavigation() {
+  window.setTimeout(() => {
+    document.getElementById("main")?.focus({ preventScroll: true });
+  }, 0);
+}
+
+function handleDialogEscapeKeyDown(event: KeyboardEvent) {
+  if (!getFullscreenElement()) {
+    return;
+  }
+
+  event.preventDefault();
+  void exitDocumentFullscreen();
+}
+
 function TrailerPage() {
   const { mediaType, mediaId, videoKey, returnTo } = Route.useSearch();
   const navigate = Route.useNavigate();
@@ -71,7 +86,9 @@ function TrailerPage() {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const [isBrowserFullscreen, setIsBrowserFullscreen] = useState(false);
+  const [isBrowserFullscreen, setIsBrowserFullscreen] = useState(
+    () => !!getFullscreenElement(),
+  );
 
   useEffect(() => {
     pause();
@@ -98,12 +115,6 @@ function TrailerPage() {
   const trailerKey = videoKey ?? trailerFromApi?.key ?? null;
 
   const title = media?.title ? `${media.title} - Trailer` : "Trailer";
-
-  const focusMainAfterNavigation = () => {
-    window.setTimeout(() => {
-      document.getElementById("main")?.focus({ preventScroll: true });
-    }, 0);
-  };
 
   const handleClose = () => {
     void router.navigate({ to: returnTo ?? "/" }).catch(() => {
@@ -142,7 +153,6 @@ function TrailerPage() {
     const onFullscreenChange = () => {
       setIsBrowserFullscreen(!!getFullscreenElement());
     };
-    onFullscreenChange();
     document.addEventListener("fullscreenchange", onFullscreenChange);
     document.addEventListener("webkitfullscreenchange", onFullscreenChange);
     return () => {
@@ -289,15 +299,6 @@ function TrailerPage() {
 
     const focusTarget = closeButtonRef.current ?? containerRef.current;
     focusTarget?.focus({ preventScroll: true });
-  };
-
-  const handleDialogEscapeKeyDown = (event: KeyboardEvent) => {
-    if (!getFullscreenElement()) {
-      return;
-    }
-
-    event.preventDefault();
-    void exitDocumentFullscreen();
   };
 
   if (error) {

--- a/web/src/test/shared/coming-soon.test.tsx
+++ b/web/src/test/shared/coming-soon.test.tsx
@@ -27,6 +27,9 @@ describe("ComingSoon", () => {
     expect(
       screen.queryByText("Photos - Under Development"),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Photos - Under Development"),
+    ).not.toBeInTheDocument();
   });
 
   it("uses the shared entrance class without hidden initial state", () => {

--- a/web/src/test/shared/coming-soon.test.tsx
+++ b/web/src/test/shared/coming-soon.test.tsx
@@ -22,12 +22,11 @@ describe("ComingSoon", () => {
       "Under Development",
     );
 
-    const announcement = screen.getByText("Photos - Under Development");
-    expect(announcement).toHaveAttribute("tabindex", "0");
-    expect(announcement).toHaveAttribute(
-      "aria-label",
-      `Photos. Under Development. ${description}`,
-    );
+    // The heading, status badge, and description carry the announcement; a
+    // separate focusable sr-only span would add a tab stop with no action.
+    expect(
+      screen.queryByText("Photos - Under Development"),
+    ).not.toBeInTheDocument();
   });
 
   it("uses the shared entrance class without hidden initial state", () => {


### PR DESCRIPTION
Works through the react-doctor v0.5.5 report (was: 62/100, 7 errors + 201 warnings). Every flagged site was verified against the code before touching it; this PR fixes the confirmed findings and documents the false positives so future doctor runs don't re-litigate them. After: **0 errors**, 178 issues, 67/100.

## What changed

- **React Compiler bailouts (the 3 performance errors)**: `finally` blocks made the compiler skip VideoPlayer and both library index pages entirely. VideoPlayer now clears its preflight timeout on both exit paths; the two identical `handleRefreshLibrary` handlers were deduplicated into a shared `lib/library-refresh.ts` helper that owns the try/catch at module scope.
- **useQuery destructuring (the 4 bug errors)**: destructured the four whole-object query results (ProfilePinCard, NotificationBell ×2, trailer). Cosmetic at runtime — v5's tracked-property proxy was already field-granular — but keeps the subscription surface explicit.
- **Quick wins**: hoisted the `Intl.RelativeTimeFormat` (was rebuilt per notification per render) and four stateless helpers to module scope; dropped the two leftover `forwardRef` wrappers in `ui/dialog.tsx` (React 19 ref-as-prop, matching the rest of the file); `useSidebar` now uses `React.use`; trailer fullscreen state seeds lazily instead of from a mount effect.
- **Dead code**: deleted `TMDB_LOGO_SIZE`, `MEDIA_ERR_NETWORK`, `THEME_TEXT_COLORS`, `invalidateMusicLibraryQueries` (zero consumers across src/tests/e2e/scripts); un-exported `useTrackLikeToggle` (internal to `useLikeButtonState`); removed the ineffective `baseline-browser-mapping` devDependency pin.
- **A11y quick fixes**: removed the focusable sr-only announcement spans in ComingSoon and playlist details (visible content already carries the information; a non-interactive tab stop is keyboard noise); moved cast-strip focus from individual cards to the scrollable list itself; removed redundant `role="navigation"`/`role="region"`/`role="article"`; alt text no longer says "Photo of". The motion e2e spec's announcement-focus helper was replaced with a skip-link keyboard check to match.

## Verified false positives (left as-is on purpose)

- **Mutation invalidation ×7**: NotificationBell invalidates via the extracted `invalidateNotifications()` helper; QuickConnect polls `[DEVICES_KEY]` at 2s with `staleTime: 0`; the password mutations touch nothing that's cached.
- **Prop-derived useState ×5 + handler-only state**: all are the sanctioned react.dev render-phase adjustment idiom (ProgressBar, AudioPlayer, Header, the settings `syncedSettings` trio) — the values are read during render.
- **VideoPlayer fetch-in-effect**: a native-source lifecycle preflight with AbortController, cancellation flags, and a fallback; not movable to TanStack Query or an event handler.
- **AudioPlayer mediaSession sync / VolumeControl `volumechange` subscription**: correct external-system effects.
- **play.tsx "keyboard bug"**: the playback surface intentionally carries no `role="button"` (in-code audit note; three keyboard paths exist including Space/K).
- **`role="list"` on the flagged lists**: Tailwind preflight strips list semantics in Safari; the explicit role restores them.
- **`ui/label.tsx`**: the primitive receives `htmlFor` at call sites.
- **`renderItem`/`renderGrid` inline calls**: render-prop callbacks, not component declarations — no remount hazard.
- Doctor's config excludes `src/test/**` and `e2e/**`, so its unused-export findings needed (and got) manual verification against those trees.

## Out of scope (deliberate)

- `no-multi-comp` ×68 / `no-giant-component` ×17: single-file routes with autoCodeSplitting is a repo convention; warnings left visible rather than config-suppressed.
- The role-vs-tag ×32 bucket and media captions: reserved for a dedicated a11y pass.
- `useReducer`/`useTransition` conversions (including QuickConnectApproveCard, the strongest candidate): style refactors with no underlying bug.

## Verification

- `make check` (server tests + web lint + vitest + build/typecheck) — green
- Full mocked Playwright e2e suite — green
- `bun run doctor`: errors 7 → 0, issues 208 → 178, score 62 → 67

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved skip-link keyboard navigation and focus behavior.
  * Simplified screen-reader announcements and landmark labeling.
  * Enhanced keyboard access and guidance for horizontally scrolling cast lists.
  * Improved image descriptions for cast and musician artwork.

* **Bug Fixes**
  * Improved library refresh feedback with consistent success and error notifications.
  * Fixed timeout cleanup during video playback checks.
  * Improved fullscreen and navigation focus handling.

* **Tests**
  * Updated accessibility tests for the revised skip-link and announcement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->