### PR TITLE
React Doctor follow-up: fix the four verified findings, suppress nothing

### DIFF
--- a/web/src/components/home/MoviesInTheaters.tsx
+++ b/web/src/components/home/MoviesInTheaters.tsx
@@ -11,7 +11,7 @@ export default function MoviesInTheaters() {
 
   let movies: TheaterMovieType[] = [];
   if (data && !data.error) {
-    movies = [...data.data.movies].sort((a, b) => {
+    movies = data.data.movies.toSorted((a, b) => {
       const dateA = new Date(a.release_date).getTime();
       const dateB = new Date(b.release_date).getTime();
 

--- a/web/src/components/settings/QuickConnectApproveCard.tsx
+++ b/web/src/components/settings/QuickConnectApproveCard.tsx
@@ -83,9 +83,12 @@ export default function QuickConnectApproveCard() {
   const [error, setError] = useState<string | null>(null);
   const [pendingDevice, setPendingDevice] =
     useState<QuickConnectLookupType | null>(null);
-  const [knownDeviceIds, setKnownDeviceIds] = useState<number[] | null>(null);
-  const [waitDeadline, setWaitDeadline] = useState<number | null>(null);
   const [connectedName, setConnectedName] = useState<string | null>(null);
+
+  // Read only inside the devices query's refetchInterval callback, never
+  // rendered — refs keep them current without re-rendering the card.
+  const knownDeviceIdsRef = useRef<number[] | null>(null);
+  const waitDeadlineRef = useRef<number | null>(null);
 
   const codeInputRef = useRef<HTMLInputElement | null>(null);
   const stepHeadingRef = useRef<HTMLHeadingElement | null>(null);
@@ -156,8 +159,8 @@ export default function QuickConnectApproveCard() {
       }
 
       setError(null);
-      setKnownDeviceIds(baselineDeviceIds);
-      setWaitDeadline(Date.now() + WAIT_FOR_DEVICE_MS);
+      knownDeviceIdsRef.current = baselineDeviceIds;
+      waitDeadlineRef.current = Date.now() + WAIT_FOR_DEVICE_MS;
       setStep("waiting");
     },
     onError: () => {
@@ -187,9 +190,9 @@ export default function QuickConnectApproveCard() {
         return 2000;
       }
 
-      const currentKnownDeviceIds = knownDeviceIds;
+      const currentKnownDeviceIds = knownDeviceIdsRef.current;
       if (currentKnownDeviceIds === null) {
-        setKnownDeviceIds(devices.map(device => device.id));
+        knownDeviceIdsRef.current = devices.map(device => device.id);
         return 2000;
       }
 
@@ -205,6 +208,7 @@ export default function QuickConnectApproveCard() {
         return false;
       }
 
+      const waitDeadline = waitDeadlineRef.current;
       if (waitDeadline !== null && Date.now() > waitDeadline) {
         setConnectedName(null);
         setStep("done");
@@ -242,8 +246,8 @@ export default function QuickConnectApproveCard() {
   const handleReset = () => {
     setCode("");
     setPendingDevice(null);
-    setKnownDeviceIds([]);
-    setWaitDeadline(null);
+    knownDeviceIdsRef.current = [];
+    waitDeadlineRef.current = null;
     setConnectedName(null);
     setError(null);
     setStep("enter");

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -591,15 +591,13 @@ function SidebarMenuSkeleton({
 }) {
   // Use stable ID to derive a deterministic width between 50% to 90%
   const id = React.useId()
-  const width = React.useMemo(() => {
-    // Create a simple hash from the id to get a stable "random" value
-    let hash = 0
-    for (let i = 0; i < id.length; i++) {
-      hash = ((hash << 5) - hash) + id.charCodeAt(i)
-      hash = hash & hash // Convert to 32bit integer
-    }
-    return `${Math.abs(hash % 40) + 50}%`
-  }, [id])
+  // Create a simple hash from the id to get a stable "random" value
+  let hash = 0
+  for (let i = 0; i < id.length; i++) {
+    hash = ((hash << 5) - hash) + id.charCodeAt(i)
+    hash = hash & hash // Convert to 32bit integer
+  }
+  const width = `${Math.abs(hash % 40) + 50}%`
 
   return (
     <div

--- a/web/src/routes/_auth/movies/$id/play.tsx
+++ b/web/src/routes/_auth/movies/$id/play.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, useState } from "react";
+import { useRef, useEffect, useState } from "react";
 import {
   createFileRoute,
   redirect,
@@ -209,10 +209,21 @@ function PlayMoviePage() {
     streamWindowKey: string;
     profile: string;
   } | null>(null);
-  const playbackSessionId = useMemo(
-    () => getOrCreateMovieHlsPlaybackSessionId(movieId),
-    [movieId],
-  );
+  // State rather than useMemo: the getter writes sessionStorage and mints a
+  // fresh random id when storage is unavailable, so a discarded memo cache
+  // could change the session id mid-playback. State guarantees identity;
+  // the render-phase reset re-seeds it when navigating to another movie.
+  const [playbackSession, setPlaybackSession] = useState(() => ({
+    movieId,
+    id: getOrCreateMovieHlsPlaybackSessionId(movieId),
+  }));
+  if (playbackSession.movieId !== movieId) {
+    setPlaybackSession({
+      movieId,
+      id: getOrCreateMovieHlsPlaybackSessionId(movieId),
+    });
+  }
+  const playbackSessionId = playbackSession.id;
   const [chapterAnnouncement, setChapterAnnouncement] =
     useState<ChapterAnnouncement>({
       key: 0,

--- a/web/src/test/shared/motion-contracts.test.ts
+++ b/web/src/test/shared/motion-contracts.test.ts
@@ -222,8 +222,14 @@ describe("motion contracts", () => {
     expect(MOTION_PLAYER_CHROME_BUTTON_CLASS).toBe(MOTION_MICRO_CONTROL_CLASS);
     expect(MOTION_PAGE_ENTER_CLASS).toContain("motion-reduce:animate-none");
     expect(MOTION_PAGE_ENTER_CLASS).toContain("motion-reduce:translate-y-0");
+    expect(MOTION_PAGE_ENTER_CLASS).toContain(
+      durationClass(MOTION_DURATION_PAGE_MS),
+    );
     expect(MOTION_SECTION_ENTER_CLASS).toContain(
       "motion-reduce:animate-none",
+    );
+    expect(MOTION_SECTION_ENTER_CLASS).toContain(
+      durationClass(MOTION_DURATION_STANDARD_MS),
     );
     expect(MOTION_SECTION_ENTER_DELAYED_CLASS).toContain("delay-75");
     expect(MOTION_SECTION_ENTER_DELAYED_CLASS).toContain(

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "useDefineForClassFields": true,
     "lib": [
-      "ES2022",
+      "ES2023",
       "DOM",
       "DOM.Iterable"
     ],

--- a/web/tsconfig.test.json
+++ b/web/tsconfig.test.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "useDefineForClassFields": true,
     "lib": [
-      "ES2022",
+      "ES2023",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
## Summary

Full triage of the 178 react-doctor findings remaining after #107, with every urgent-category finding verified against the code before acting. Only four survived as true positives; all are fixed here. **No warnings were suppressed** — no disable comments, no doctor.config changes — so every remaining finding stays visible for future passes. Doctor count: 178 → 173.

### Fixes

- **QuickConnectApproveCard**: `knownDeviceIds`/`waitDeadline` are read only inside the devices query's `refetchInterval` callback, so they now live in refs instead of state — the card no longer re-renders on every poll tick.
- **movies/$id/play**: the HLS playback-session id moves from `useMemo` to lazy `useState` with a movieId-keyed render-phase reset. The getter writes sessionStorage and mints a fresh random id when storage is unavailable, so a discarded memo cache could rotate the session id mid-playback; state guarantees the identity. (React-doctor suggested deleting the memo, which would have caused exactly that bug.)
- **sidebar**: the skeleton-width hash `useMemo` is unwrapped — React Compiler already caches it.
- **MoviesInTheaters**: `[...movies].sort()` → `toSorted()`, with tsconfig app/test targets bumped ES2022 → ES2023 to admit it (Vite already builds `esnext`, so no runtime change).
- **motion-contracts test**: `MOTION_DURATION_PAGE_MS` was only asserted against its own literal while `duration-300` in `MOTION_PAGE_ENTER_CLASS` drifted unchecked; the page tier (and the section tier's standard duration) are now pinned via `durationClass()` like their siblings.

### Verified false positives (left visible, not suppressed)

- Mutation-invalidation ×7: invalidation happens via the `invalidateNotifications()` helper, deliberate `[DEVICES_KEY]` polling, or the mutations touch nothing cached.
- Derived-useState ×7 / state-in-handlers (rest): React's documented render-phase adjustment pattern and keyed form drafts, all read during render.
- fetch-in-effect (aborted manifest preflight), event-in-effect ×3 (mediaSession/`volumechange` sync, post-commit focus), await-in-loop (bounded retry), useTransition-loading (media buffering flag).
- All 40 accessibility flags: deliberate patterns, largely adjudicated in b436a940 (Safari `role="list"`, scrollable-region tab stop, icon-placeholder `role="img"`, keyboard-handled fullscreen overlay, dynamic subtitle tracks, shadcn Label primitive).
- Unused-export flags: doctor.config excludes `src/test/**`/`e2e/**`, so test-consumed exports look dead (`MOTION_DURATION_STANDARD_MS` is even used in `theme.ts`).
- Structural rules (giant-component, multi-comp, prefer-useReducer, boolean-props): deferred refactors, out of scope.

## Test plan

- [x] `bun run lint` (zero warnings)
- [x] `bun run test` — 664/664 (includes the 13 QuickConnect card tests and the strengthened motion contracts)
- [x] `bun run build` (typechecks the ES2023 bump)
- [x] e2e: movies + movie-player suites, 10/10 (exercises the playbackSessionId path); quick-connect pairing spec self-skips without a real instance, as designed
- [x] `bun run doctor` — 178 → 173, no new findings, suppression comments unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)