### PR TITLE
Server performance: measurement infra + measured optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /server/cmd/internal/ffprobe/ffprobe_linux_amd64
 /server/cmd/internal/ffmpeg/ffmpeg_darwin_arm64
 /server/cmd/internal/ffmpeg/ffmpeg_linux_amd64
+/server/cmd/internal/ffprobe/*.zst
+/server/cmd/internal/ffmpeg/*.zst
 
 # Embedded frontend assets generated during build
 /server/cmd/api/webdist/

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 /web/dist/
 /web/.tanstack/
 /web/test-results/
+/scripts/perf/results/*.csv
+/scripts/perf/results/*.json
+/scripts/perf/results/*.txt
 /web/playwright-report/
 /web/blob-report/
 /web/coverage/

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ dev-profile: check-dev-tools generate prepare-webdist-placeholder
 build: check-build-tools check-media-payloads generate prepare-web
 	@echo "Building $(BINARY_NAME) for $(PLATFORM)..."
 	@mkdir -p $(DIST_DIR)
-	@cd $(SERVER_DIR) && env CGO_ENABLED=1 go build -tags "$(GO_TAGS)" -ldflags="$(LDFLAGS)" -o $(SERVER_BINARY) ./cmd/api
+	@cd $(SERVER_DIR) && env CGO_ENABLED=1 go build -trimpath -tags "$(GO_TAGS)" -ldflags="$(LDFLAGS)" -o $(SERVER_BINARY) ./cmd/api
 	@echo "Built $(BINARY_PATH)."
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,13 @@ PLATFORM := $(GOOS_CURRENT)-$(GOARCH_CURRENT)
 PAYLOAD_SUFFIX := $(GOOS_CURRENT)_$(GOARCH_CURRENT)
 FFMPEG_PAYLOAD := $(SERVER_DIR)/cmd/internal/ffmpeg/ffmpeg_$(PAYLOAD_SUFFIX)
 FFPROBE_PAYLOAD := $(SERVER_DIR)/cmd/internal/ffprobe/ffprobe_$(PAYLOAD_SUFFIX)
+FFMPEG_PAYLOAD_ZST := $(FFMPEG_PAYLOAD).zst
+FFPROBE_PAYLOAD_ZST := $(FFPROBE_PAYLOAD).zst
 
 .DEFAULT_GOAL := dev
 
 .PHONY: dev dev-profile build start stop clean help check test test-server test-tmdb-integration test-web lint-web build-web test-openapi lint-openapi generate-openapi check-openapi preview-openapi
-.PHONY: check-go-tools check-web-tools check-sqlc-tools check-media-tools check-dev-tools check-build-tools check-server-test-tools check-platform check-media-payloads generate prepare-webdist-placeholder prepare-test-webdist prepare-web
+.PHONY: check-go-tools check-web-tools check-sqlc-tools check-media-tools check-dev-tools check-build-tools check-server-test-tools check-platform check-media-payloads compress-media-payloads generate prepare-webdist-placeholder prepare-test-webdist prepare-web
 
 dev: check-dev-tools generate prepare-webdist-placeholder
 	@echo "Starting development server..."
@@ -44,7 +46,7 @@ dev-profile: check-dev-tools generate prepare-webdist-placeholder
 	@cd $(SERVER_DIR) && env CGO_ENABLED=1 go build -tags "$(PROFILE_TAGS)" -o $(DEV_BINARY) ./cmd/api
 	@env VITE_DEV_SERVER=http://localhost:3000 "$(DEV_BINARY_PATH)"
 
-build: check-build-tools check-media-payloads generate prepare-web
+build: check-build-tools check-media-payloads compress-media-payloads generate prepare-web
 	@echo "Building $(BINARY_NAME) for $(PLATFORM)..."
 	@mkdir -p $(DIST_DIR)
 	@cd $(SERVER_DIR) && env CGO_ENABLED=1 go build -trimpath -tags "$(GO_TAGS)" -ldflags="$(LDFLAGS)" -o $(SERVER_BINARY) ./cmd/api
@@ -193,6 +195,19 @@ check-platform:
 check-media-payloads: check-platform
 	@test -f "$(FFMPEG_PAYLOAD)" || (echo "Missing embedded ffmpeg payload: $(FFMPEG_PAYLOAD)"; exit 1)
 	@test -f "$(FFPROBE_PAYLOAD)" || (echo "Missing embedded ffprobe payload: $(FFPROBE_PAYLOAD)"; exit 1)
+	@command -v zstd >/dev/null || (echo "zstd is required to compress media payloads"; exit 1)
+
+# The release binary embeds the .zst payloads; regenerate them whenever the
+# raw payloads change.
+compress-media-payloads: $(FFMPEG_PAYLOAD_ZST) $(FFPROBE_PAYLOAD_ZST)
+
+$(FFMPEG_PAYLOAD_ZST): $(FFMPEG_PAYLOAD)
+	@echo "Compressing ffmpeg payload..."
+	@zstd -19 -T0 -f -q -o $@ $<
+
+$(FFPROBE_PAYLOAD_ZST): $(FFPROBE_PAYLOAD)
+	@echo "Compressing ffprobe payload..."
+	@zstd -19 -T0 -f -q -o $@ $<
 
 generate:
 	@cd $(SERVER_DIR)/sqlc && sqlc generate

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ LOG_FILE := $(DIST_DIR)/$(BINARY_NAME).log
 
 GO_TAGS := sqlite_fts5
 DEV_TAGS := externalbin sqlite_fts5
+PROFILE_TAGS := externalbin sqlite_fts5 pprofdebug
 TEST_TAGS := externalbin sqlite_fts5
 LDFLAGS := -s -w
 
@@ -27,7 +28,7 @@ FFPROBE_PAYLOAD := $(SERVER_DIR)/cmd/internal/ffprobe/ffprobe_$(PAYLOAD_SUFFIX)
 
 .DEFAULT_GOAL := dev
 
-.PHONY: dev build start stop clean help check test test-server test-tmdb-integration test-web lint-web build-web test-openapi lint-openapi generate-openapi check-openapi preview-openapi
+.PHONY: dev dev-profile build start stop clean help check test test-server test-tmdb-integration test-web lint-web build-web test-openapi lint-openapi generate-openapi check-openapi preview-openapi
 .PHONY: check-go-tools check-web-tools check-sqlc-tools check-media-tools check-dev-tools check-build-tools check-server-test-tools check-platform check-media-payloads generate prepare-webdist-placeholder prepare-test-webdist prepare-web
 
 dev: check-dev-tools generate prepare-webdist-placeholder
@@ -35,6 +36,12 @@ dev: check-dev-tools generate prepare-webdist-placeholder
 	@echo "Start the web client separately with: cd $(WEB_DIR) && bun run dev"
 	@mkdir -p $(DIST_DIR)
 	@cd $(SERVER_DIR) && env CGO_ENABLED=1 go build -tags "$(DEV_TAGS)" -o $(DEV_BINARY) ./cmd/api
+	@env VITE_DEV_SERVER=http://localhost:3000 "$(DEV_BINARY_PATH)"
+
+dev-profile: check-dev-tools generate prepare-webdist-placeholder
+	@echo "Starting development server with pprof at /api/debug/pprof (admin only)..."
+	@mkdir -p $(DIST_DIR)
+	@cd $(SERVER_DIR) && env CGO_ENABLED=1 go build -tags "$(PROFILE_TAGS)" -o $(DEV_BINARY) ./cmd/api
 	@env VITE_DEV_SERVER=http://localhost:3000 "$(DEV_BINARY_PATH)"
 
 build: check-build-tools check-media-payloads generate prepare-web
@@ -105,6 +112,7 @@ clean: stop
 help:
 	@echo "Igloo Make targets:"
 	@echo "  make dev           Generate sqlc code and run the API for local development"
+	@echo "  make dev-profile   Run the dev API with pprof endpoints at /api/debug/pprof"
 	@echo "  make build         Build the native binary with embedded web assets and media tools"
 	@echo "  make start         Build and run the full application in the background"
 	@echo "  make stop          Stop the background application"

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -25,9 +25,10 @@ Run against a dev server (`make dev`) with the real library. Find the PID with
 | 1 | Startup | `baseline.sh startup server/dist/igloo-server-dev` | time to `/api/health` 200, boot write bytes |
 | 2 | Idle | `baseline.sh idle <pid> 10` | RSS, CPU%, write-bytes growth over 10 min |
 | 3 | Browse | `baseline.sh browse <pid> 5` | request p95s + RSS/CPU envelope, 3 VUs |
-| 4 | Streaming | `baseline.sh stream <pid> <movie_id> 1 10` then `... 3 10` | RSS/CPU, segment p95, `time_to_first_segment` |
-| 5 | Scan | trigger via Settings → rescan; sample with `sample-rss.sh` | duration + CPU/RSS envelope |
-| 6 | Sizes | `baseline.sh sizes` | release/dev binary + payload sizes |
+| 4 | Streaming (HLS) | `baseline.sh stream <pid> <movie_id> 1 10` then `... 3 10` | RSS/CPU, segment p95, `time_to_first_segment` |
+| 5 | Streaming (direct) | `baseline.sh stream-direct <pid> <movie_id> 1 10` | RSS/CPU, range-request p95 |
+| 6 | Scan | trigger via Settings → rescan; sample with `sample-rss.sh` | duration + CPU/RSS envelope |
+| 7 | Sizes | `baseline.sh sizes` | release/dev binary + payload sizes |
 
 Notes:
 
@@ -40,8 +41,14 @@ Notes:
   bursts as server writes.
 - Streaming scenarios need a `MOVIE_ID` that exists in the library; pick one
   from `/api/movies/library`. The HLS scenario starts a real transcode —
-  expect CPU load, and give the session ~5 min to self-evict afterwards (the
-  script also requests a stop on teardown).
+  expect CPU load. `setup()` mints one playback session per VU and `teardown()`
+  stops every one of them, so slots are released at the end of the run rather
+  than waiting out the ~5 min self-eviction.
+- The `startup` scenario runs its child server on `STARTUP_PORT` (default
+  18080) and probes that port, so it cannot be fooled into timing a *different*
+  server that already holds the `BASE_URL` port.
+- `soak.js` sets a `checks: rate==1` threshold: any failed check fails the k6
+  run, so a capture that quietly 500s does not get recorded as a clean result.
 - After each capture, summarize the numbers into a dated markdown in
   `results/` and commit the summary (not the raw CSVs).
 

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -34,6 +34,10 @@ Notes:
 - CPU% from the CSV: `100 * Δcpu_ticks / (100 * Δepoch_s)` (CLK_TCK is 100).
 - `write_bytes` comes from `/proc/<pid>/io` and is cumulative; growth while
   idle is almost entirely log churn.
+- **Caveat:** `/proc/<pid>/io` includes reaped children. When the server
+  reaps a killed ffmpeg at HLS teardown, ffmpeg's lifetime IO lands in the
+  server's counters as one instantaneous jump — do not read teardown-moment
+  bursts as server writes.
 - Streaming scenarios need a `MOVIE_ID` that exists in the library; pick one
   from `/api/movies/library`. The HLS scenario starts a real transcode —
   expect CPU load, and give the session ~5 min to self-evict afterwards (the

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,51 @@
+# Server performance measurement
+
+Tooling and protocol for capturing repeatable performance baselines of the Go
+server, so optimization PRs can report a measured before/after delta.
+
+## Tools
+
+- **k6** (https://k6.io) — scripted, sessionful load scenarios (`soak.js`).
+- **oha** (https://github.com/hatoo/oha) — optional, quick single-endpoint checks.
+- `sample-rss.sh` — samples RSS, CPU ticks and cumulative write bytes from
+  `/proc/<pid>` to CSV.
+- `baseline.sh` — orchestrates the scenarios below.
+- pprof — build the server with the `pprofdebug` tag (`make dev-profile`);
+  endpoints appear under `/api/debug/pprof` (admin session required), e.g.
+  `go tool pprof 'http://localhost:8080/api/debug/pprof/profile?seconds=30'`.
+
+## Baseline protocol
+
+Run against a dev server (`make dev`) with the real library. Find the PID with
+`pgrep -f igloo-server-dev`. All results land in `scripts/perf/results/`
+(gitignored except for committed summary markdowns).
+
+| # | Scenario | Command | Record |
+|---|----------|---------|--------|
+| 1 | Startup | `baseline.sh startup server/dist/igloo-server-dev` | time to `/api/health` 200, boot write bytes |
+| 2 | Idle | `baseline.sh idle <pid> 10` | RSS, CPU%, write-bytes growth over 10 min |
+| 3 | Browse | `baseline.sh browse <pid> 5` | request p95s + RSS/CPU envelope, 3 VUs |
+| 4 | Streaming | `baseline.sh stream <pid> <movie_id> 1 10` then `... 3 10` | RSS/CPU, segment p95, `time_to_first_segment` |
+| 5 | Scan | trigger via Settings → rescan; sample with `sample-rss.sh` | duration + CPU/RSS envelope |
+| 6 | Sizes | `baseline.sh sizes` | release/dev binary + payload sizes |
+
+Notes:
+
+- CPU% from the CSV: `100 * Δcpu_ticks / (100 * Δepoch_s)` (CLK_TCK is 100).
+- `write_bytes` comes from `/proc/<pid>/io` and is cumulative; growth while
+  idle is almost entirely log churn.
+- Streaming scenarios need a `MOVIE_ID` that exists in the library; pick one
+  from `/api/movies/library`. The HLS scenario starts a real transcode —
+  expect CPU load, and give the session ~5 min to self-evict afterwards (the
+  script also requests a stop on teardown).
+- After each capture, summarize the numbers into a dated markdown in
+  `results/` and commit the summary (not the raw CSVs).
+
+## Microbenchmarks
+
+Pure-Go hot paths have `go test` benchmarks (logger, search vocab BK-tree,
+frontend asset serving):
+
+```bash
+cd server && go test -tags "externalbin sqlite_fts5" -bench . -benchmem -run '^$' ./cmd/internal/logger/ ./cmd/api
+```

--- a/scripts/perf/baseline.sh
+++ b/scripts/perf/baseline.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Orchestrates a baseline performance capture against a running Igloo server.
+#
+# Usage:
+#   baseline.sh startup <binary> [args...]   Measure exec -> /api/health 200 and
+#                                            bytes written during boot, then stop.
+#   baseline.sh idle <pid> [minutes]         Sample RSS/CPU/writes while idle (default 10).
+#   baseline.sh browse <pid> [minutes]       k6 browse scenario + sampling (default 5).
+#   baseline.sh stream <pid> <movie_id> [vus] [minutes]
+#                                            k6 HLS scenario + sampling (default 1 VU, 10 min).
+#   baseline.sh sizes                        Record binary and payload sizes.
+#
+# Env: BASE_URL (default http://localhost:8080), EMAIL, PASSWORD (see soak.js),
+#      OUT_DIR (default scripts/perf/results).
+#
+# Results land in $OUT_DIR as CSV (samples) and .txt (summaries).
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+OUT_DIR="${OUT_DIR:-$here/results}"
+mkdir -p "$OUT_DIR"
+stamp="$(date +%Y%m%d-%H%M%S)"
+
+sample() { # pid out.csv — starts sampler in background, echoes sampler pid
+  "$here/sample-rss.sh" "$1" "$2" 2 &
+  echo $!
+}
+
+case "${1:-}" in
+startup)
+  shift
+  binary="${1:?usage: baseline.sh startup <binary> [args...]}"
+  shift || true
+  start_ns=$(date +%s%N)
+  "$binary" "$@" &
+  pid=$!
+  trap 'kill -TERM "$pid" 2>/dev/null || true' EXIT
+  until curl -sf -o /dev/null "$BASE_URL/api/health"; do
+    kill -0 "$pid" 2>/dev/null || { echo "server exited during startup" >&2; exit 1; }
+    sleep 0.1
+  done
+  ready_ms=$(( ($(date +%s%N) - start_ns) / 1000000 ))
+  write_bytes=$(awk '/^write_bytes:/ {print $2}' "/proc/$pid/io" 2>/dev/null || echo "n/a")
+  out="$OUT_DIR/startup-$stamp.txt"
+  {
+    echo "binary: $binary"
+    echo "time_to_health_ms: $ready_ms"
+    echo "boot_write_bytes: $write_bytes"
+  } | tee "$out"
+  kill -TERM "$pid"
+  wait "$pid" 2>/dev/null || true
+  trap - EXIT
+  ;;
+
+idle)
+  pid="${2:?usage: baseline.sh idle <pid> [minutes]}"
+  minutes="${3:-10}"
+  out="$OUT_DIR/idle-$stamp.csv"
+  echo "sampling PID $pid for $minutes min -> $out"
+  sampler=$(sample "$pid" "$out")
+  sleep $((minutes * 60))
+  kill "$sampler" 2>/dev/null || true
+  ;;
+
+browse)
+  pid="${2:?usage: baseline.sh browse <pid> [minutes]}"
+  minutes="${3:-5}"
+  command -v k6 >/dev/null || { echo "k6 is required (https://k6.io)"; exit 1; }
+  out="$OUT_DIR/browse-$stamp"
+  sampler=$(sample "$pid" "$out.csv")
+  k6 run -e SCENARIO=browse -e VUS=3 -e DURATION="${minutes}m" -e BASE_URL="$BASE_URL" \
+    --summary-export "$out-k6.json" "$here/soak.js" | tee "$out-k6.txt"
+  kill "$sampler" 2>/dev/null || true
+  ;;
+
+stream)
+  pid="${2:?usage: baseline.sh stream <pid> <movie_id> [vus] [minutes]}"
+  movie_id="${3:?usage: baseline.sh stream <pid> <movie_id> [vus] [minutes]}"
+  vus="${4:-1}"
+  minutes="${5:-10}"
+  command -v k6 >/dev/null || { echo "k6 is required (https://k6.io)"; exit 1; }
+  out="$OUT_DIR/stream-${vus}vu-$stamp"
+  sampler=$(sample "$pid" "$out.csv")
+  k6 run -e SCENARIO=stream-hls -e MOVIE_ID="$movie_id" -e VUS="$vus" \
+    -e DURATION="${minutes}m" -e BASE_URL="$BASE_URL" \
+    --summary-export "$out-k6.json" "$here/soak.js" | tee "$out-k6.txt"
+  kill "$sampler" 2>/dev/null || true
+  ;;
+
+sizes)
+  out="$OUT_DIR/sizes-$stamp.txt"
+  {
+    for f in "$repo_root/server/dist/igloo-server" "$repo_root/server/dist/igloo-server-dev" \
+      "$repo_root"/server/cmd/internal/ffmpeg/ffmpeg_* "$repo_root"/server/cmd/internal/ffprobe/ffprobe_*; do
+      [ -f "$f" ] && printf "%12d  %s\n" "$(stat -c %s "$f")" "$f"
+    done
+    du -sh "$repo_root/server/cmd/api/webdist" 2>/dev/null || true
+  } | grep -v '\.go$' | tee "$out"
+  ;;
+
+*)
+  sed -n '2,16p' "$0"
+  exit 1
+  ;;
+esac

--- a/scripts/perf/baseline.sh
+++ b/scripts/perf/baseline.sh
@@ -25,7 +25,9 @@ mkdir -p "$OUT_DIR"
 stamp="$(date +%Y%m%d-%H%M%S)"
 
 sample() { # pid out.csv — starts sampler in background, echoes sampler pid
-  "$here/sample-rss.sh" "$1" "$2" 2 &
+  # The redirect matters: without it the backgrounded sampler holds the
+  # command-substitution pipe open and $(sample ...) blocks until it exits.
+  "$here/sample-rss.sh" "$1" "$2" 2 >/dev/null 2>&1 &
   echo $!
 }
 

--- a/scripts/perf/baseline.sh
+++ b/scripts/perf/baseline.sh
@@ -8,10 +8,13 @@
 #   baseline.sh browse <pid> [minutes]       k6 browse scenario + sampling (default 5).
 #   baseline.sh stream <pid> <movie_id> [vus] [minutes]
 #                                            k6 HLS scenario + sampling (default 1 VU, 10 min).
+#   baseline.sh stream-direct <pid> <movie_id> [vus] [minutes]
+#                                            k6 direct-play scenario + sampling.
 #   baseline.sh sizes                        Record binary and payload sizes.
 #
 # Env: BASE_URL (default http://localhost:8080), EMAIL, PASSWORD (see soak.js),
-#      OUT_DIR (default scripts/perf/results).
+#      OUT_DIR (default scripts/perf/results), STARTUP_PORT (default 18080; the
+#      port the startup scenario's child server is told to bind).
 #
 # Results land in $OUT_DIR as CSV (samples) and .txt (summaries).
 
@@ -24,11 +27,38 @@ OUT_DIR="${OUT_DIR:-$here/results}"
 mkdir -p "$OUT_DIR"
 stamp="$(date +%Y%m%d-%H%M%S)"
 
-sample() { # pid out.csv — starts sampler in background, echoes sampler pid
+sampler=""
+
+stop_sampler() {
+  [ -n "$sampler" ] && kill "$sampler" 2>/dev/null
+  sampler=""
+}
+
+sample() { # pid out.csv — starts the sampler in the background and traps its cleanup
   # The redirect matters: without it the backgrounded sampler holds the
   # command-substitution pipe open and $(sample ...) blocks until it exits.
   "$here/sample-rss.sh" "$1" "$2" 2 >/dev/null 2>&1 &
-  echo $!
+  sampler=$!
+  # set -e aborts before any trailing kill when k6 fails, and Ctrl-C never
+  # reaches it at all, so the sampler must be reaped from a trap or it keeps
+  # running and writing samples after the run is over.
+  trap 'stop_sampler' EXIT INT TERM
+}
+
+run_stream_scenario() { # scenario label pid movie_id [vus] [minutes]
+  scenario="$1"
+  label="$2"
+  pid="${3:?usage: baseline.sh $label <pid> <movie_id> [vus] [minutes]}"
+  movie_id="${4:?usage: baseline.sh $label <pid> <movie_id> [vus] [minutes]}"
+  vus="${5:-1}"
+  minutes="${6:-10}"
+  command -v k6 >/dev/null || { echo "k6 is required (https://k6.io)"; exit 1; }
+  out="$OUT_DIR/$label-${vus}vu-$stamp"
+  sample "$pid" "$out.csv"
+  k6 run -e SCENARIO="$scenario" -e MOVIE_ID="$movie_id" -e VUS="$vus" \
+    -e DURATION="${minutes}m" -e BASE_URL="$BASE_URL" \
+    --summary-export "$out-k6.json" "$here/soak.js" | tee "$out-k6.txt"
+  stop_sampler
 }
 
 case "${1:-}" in
@@ -36,11 +66,17 @@ startup)
   shift
   binary="${1:?usage: baseline.sh startup <binary> [args...]}"
   shift || true
+  # Probe the child on its own port, not the shared BASE_URL: if that port is
+  # already taken the child dies of the collision while the probe goes green
+  # against whatever server is answering there, and the run reports a bogus
+  # startup time.
+  startup_port="${STARTUP_PORT:-18080}"
+  startup_url="http://localhost:$startup_port"
   start_ns=$(date +%s%N)
-  "$binary" "$@" &
+  PORT="$startup_port" "$binary" "$@" &
   pid=$!
   trap 'kill -TERM "$pid" 2>/dev/null || true' EXIT
-  until curl -sf -o /dev/null "$BASE_URL/api/health"; do
+  until curl -sf -o /dev/null "$startup_url/api/health"; do
     kill -0 "$pid" 2>/dev/null || { echo "server exited during startup" >&2; exit 1; }
     sleep 0.1
   done
@@ -49,6 +85,7 @@ startup)
   out="$OUT_DIR/startup-$stamp.txt"
   {
     echo "binary: $binary"
+    echo "port: $startup_port"
     echo "time_to_health_ms: $ready_ms"
     echo "boot_write_bytes: $write_bytes"
   } | tee "$out"
@@ -62,9 +99,13 @@ idle)
   minutes="${3:-10}"
   out="$OUT_DIR/idle-$stamp.csv"
   echo "sampling PID $pid for $minutes min -> $out"
-  sampler=$(sample "$pid" "$out")
-  sleep $((minutes * 60))
-  kill "$sampler" 2>/dev/null || true
+  sample "$pid" "$out"
+  # Wait on a backgrounded sleep rather than a foreground one: bash defers a
+  # trap until the running foreground command returns, so a foreground sleep
+  # would swallow the interrupt for the rest of the window.
+  sleep $((minutes * 60)) &
+  wait $! || true
+  stop_sampler
   ;;
 
 browse)
@@ -72,24 +113,20 @@ browse)
   minutes="${3:-5}"
   command -v k6 >/dev/null || { echo "k6 is required (https://k6.io)"; exit 1; }
   out="$OUT_DIR/browse-$stamp"
-  sampler=$(sample "$pid" "$out.csv")
+  sample "$pid" "$out.csv"
   k6 run -e SCENARIO=browse -e VUS=3 -e DURATION="${minutes}m" -e BASE_URL="$BASE_URL" \
     --summary-export "$out-k6.json" "$here/soak.js" | tee "$out-k6.txt"
-  kill "$sampler" 2>/dev/null || true
+  stop_sampler
   ;;
 
 stream)
-  pid="${2:?usage: baseline.sh stream <pid> <movie_id> [vus] [minutes]}"
-  movie_id="${3:?usage: baseline.sh stream <pid> <movie_id> [vus] [minutes]}"
-  vus="${4:-1}"
-  minutes="${5:-10}"
-  command -v k6 >/dev/null || { echo "k6 is required (https://k6.io)"; exit 1; }
-  out="$OUT_DIR/stream-${vus}vu-$stamp"
-  sampler=$(sample "$pid" "$out.csv")
-  k6 run -e SCENARIO=stream-hls -e MOVIE_ID="$movie_id" -e VUS="$vus" \
-    -e DURATION="${minutes}m" -e BASE_URL="$BASE_URL" \
-    --summary-export "$out-k6.json" "$here/soak.js" | tee "$out-k6.txt"
-  kill "$sampler" 2>/dev/null || true
+  shift
+  run_stream_scenario stream-hls stream "$@"
+  ;;
+
+stream-direct)
+  shift
+  run_stream_scenario stream-direct stream-direct "$@"
   ;;
 
 sizes)
@@ -104,7 +141,7 @@ sizes)
   ;;
 
 *)
-  sed -n '2,16p' "$0"
+  sed -n '2,19p' "$0"
   exit 1
   ;;
 esac

--- a/scripts/perf/results/baseline-2026-08-13.md
+++ b/scripts/perf/results/baseline-2026-08-13.md
@@ -76,6 +76,26 @@ target it first. Release-build payload extraction is addressed by PR 2a/2b.
 - BK-tree correction lookup: ~0.22 ms
 - `ServeFrontend` (index.html): ~3 ms/req, ~735 KB allocations per request
 
+## Investigated and rejected: SQLite pool > 1
+
+A pool of 4 connections (pragmas moved to the DSN + ConnectHook,
+`_txlock=immediate` to avoid deferred-transaction SQLITE_BUSY upgrades) was
+implemented and A/B-benchmarked against the pinned single connection:
+
+- Uncontended browse (3 VUs): pool=4 p95 8–13 ms vs pool=1 p95 6.8–7 ms —
+  slightly worse (per-connection statement re-preparation, split page cache).
+- Contended (sustained watch-progress writes + browse): pool=4 browse p95
+  **44.7 ms** vs pool=1 **16.1 ms**, max 592 ms vs 232 ms, and write
+  throughput halved (1,732 vs 3,607 writes in 75 s).
+
+With `_txlock=immediate`, concurrent connections contend for the write lock
+through SQLite's busy-timeout *polling* loop (mattn ignores
+`TxOptions.ReadOnly`, so read-only transactions take the write lock too),
+while a single connection hands work off FIFO through database/sql's own
+queue with no busy-waiting. At household scale the pinned connection wins;
+do not revisit without a two-pool (read/write-split) design and a workload
+that demonstrably starves reads.
+
 ## Measurement caveats
 
 - `/proc/<pid>/io` **includes reaped children**: when a killed ffmpeg is

--- a/scripts/perf/results/baseline-2026-08-13.md
+++ b/scripts/perf/results/baseline-2026-08-13.md
@@ -71,9 +71,14 @@ target it first. Release-build payload extraction is addressed by PR 2a/2b.
 ## Microbenchmarks (single-shot, indicative)
 
 - Logger `Write`: ~22 µs/line (flush syscall per line; PR 3 target)
-- Search vocab BK-tree build (10k terms): ~20 ms — runs inside a request
-  after any library write bumps the generation
-- BK-tree correction lookup: ~0.22 ms
+- Search vocab BK-tree build (10k synthetic terms): **~41 ms** — runs inside a
+  request after any library write bumps the generation. (The ~20 ms first
+  recorded here was wrong; re-measuring the unmodified benchmark gives 41 ms.
+  With the input copy moved out of the timed region it is ~38 ms.)
+- BK-tree correction lookup: **~0.33 ms**. (The 0.22 ms first recorded here was
+  measured against a purely random vocabulary with no term guaranteed within
+  `maxDist`, so it largely timed the miss path. With a planted hit the same
+  pre-fix benchmark measures 0.33 ms.)
 - `ServeFrontend` (index.html): ~3 ms/req, ~735 KB allocations per request
 
 ## Shipped on feature/improve-performance-1 (measured deltas)
@@ -83,7 +88,7 @@ target it first. Release-build payload extraction is addressed by PR 2a/2b.
 | Release binary (zstd-embedded payloads, -trimpath) | 229,963,896 B | **78,838,136 B** (−66%) |
 | Boot payload writes (extract-once cache) | 214 MB every boot | 214 MB once per release, then 4 KB |
 | Release boot to healthy (warm cache) | — | 1.9 s |
-| Logger write path (buffered + rename rotation) | 22.4 µs/line, full-file rewrite every ~500 lines | **214 ns/line**, O(1) rename rotation |
+| Logger write path (buffered + rename rotation) | 22.4 µs/line, full-file rewrite every ~500 lines | **~125 ns/line**, O(1) rename rotation |
 | SPA asset serving (cached map + ETag/304) | 3 ms + 735 KB allocs per request, no conditional requests | **7.3 µs + 12 KB**, ETag/304/range |
 | http.Server | no timeouts | ReadHeaderTimeout 5 s, IdleTimeout 120 s (no WriteTimeout — streaming) |
 | ReorderPlaylistTracks | one commit per track | single transaction |
@@ -97,6 +102,38 @@ target it first. Release-build payload extraction is addressed by PR 2a/2b.
 - Boot scans of an unchanged library: ~0.1% CPU (skip index works); a
   scan-on-startup gate is not justified.
 - Schema exec + 193 statement preps: ~30 ms combined.
+
+## Measured and skipped (query/search phase)
+
+Profiled with `make dev-profile` under the browse scenario (3 VUs, 3 min,
+5,822 requests at 32.2 req/s, p95 6.8 ms, zero failed checks), taking a 60 s
+CPU profile and an allocation profile mid-run. The server drew **6.2% CPU**
+over the profile window, so everything below is a share of an almost-idle
+process. None of the four items the plan left gated clears the bar:
+
+- **`GetMovieDetails` 6-query consolidation** — 350 ms cumulative of 3.71 s
+  total samples. The six queries account for 200 ms of that; `WriteJSON`
+  serializing the response costs 140 ms on its own. Merging queries would chase
+  less time than the marshaling that follows them.
+- **`SearchAll` 4×(count+page) consolidation / parallelization** — 230 ms
+  cumulative, spread evenly across the four entity searches (40/70/30/50 ms).
+  Parallelizing them cannot help anyway while the pool is pinned to one
+  connection, and pool > 1 was rejected above with data.
+- **Preparing the hand-written FTS5 SQL at startup** — all statement
+  preparation across the whole profile is 130 ms cumulative (3.5%), and the
+  traces attribute most of it to the background music scan rather than to
+  search. Not worth a startup-prep special case.
+- **Moving the BK-tree vocab rebuild off the request path** — it never appears
+  in the browse profile at all: the generation only bumps on searchable-field
+  writes (the `search_vocab_*` triggers fire on media insert/delete/title-field
+  update), which browse traffic never does. Measured directly against the real
+  library instead, by timing the first fuzzy search after a cold start: **70 ms
+  for the request that rebuilds all four indexes, ~3 ms warm.** That is one
+  ~70 ms search after a library change, not a steady cost, which does not pay
+  for a background-rebuild-and-serve-stale mechanism at household scale.
+
+Allocation profile agrees: `encoding/json.Marshal` is the top allocator
+(55.6 MB cum of 189 MB), ahead of every query path.
 
 ## Next (own session, high risk): HLS cold-start latency
 

--- a/scripts/perf/results/baseline-2026-08-13.md
+++ b/scripts/perf/results/baseline-2026-08-13.md
@@ -76,6 +76,36 @@ target it first. Release-build payload extraction is addressed by PR 2a/2b.
 - BK-tree correction lookup: ~0.22 ms
 - `ServeFrontend` (index.html): ~3 ms/req, ~735 KB allocations per request
 
+## Shipped on feature/improve-performance-1 (measured deltas)
+
+| Change | Before | After |
+|---|---|---|
+| Release binary (zstd-embedded payloads, -trimpath) | 229,963,896 B | **78,838,136 B** (−66%) |
+| Boot payload writes (extract-once cache) | 214 MB every boot | 214 MB once per release, then 4 KB |
+| Release boot to healthy (warm cache) | — | 1.9 s |
+| Logger write path (buffered + rename rotation) | 22.4 µs/line, full-file rewrite every ~500 lines | **214 ns/line**, O(1) rename rotation |
+| SPA asset serving (cached map + ETag/304) | 3 ms + 735 KB allocs per request, no conditional requests | **7.3 µs + 12 KB**, ETag/304/range |
+| http.Server | no timeouts | ReadHeaderTimeout 5 s, IdleTimeout 120 s (no WriteTimeout — streaming) |
+| ReorderPlaylistTracks | one commit per track | single transaction |
+
+## Measured and skipped (startup phase)
+
+- InitDirs 14.5 s in the dev startup capture was a **cold Samba mount**, not
+  server work — the warm release boot does all of InitDirs + probes in ~2 s.
+- ffmpeg capability probes: sub-second on this hardware; a probe cache is
+  not worth its invalidation complexity.
+- Boot scans of an unchanged library: ~0.1% CPU (skip index works); a
+  scan-on-startup gate is not justified.
+- Schema exec + 193 statement preps: ~30 ms combined.
+
+## Next (own session, high risk): HLS cold-start latency
+
+Justified by measurement: 5.9 s cold time-to-first-segment for one stream,
+28–50 s for the 2nd/3rd concurrent stream behind the 2-slot transcode
+limiter. Levers per docs/hls-fixes.md: `-hls_flags temp_file`, fsnotify
+segment readiness, limiter sizing. Ships alone with the full docs/ffmpeg.md
+manual playback matrix.
+
 ## Investigated and rejected: SQLite pool > 1
 
 A pool of 4 connections (pragmas moved to the DSN + ConnectHook,

--- a/scripts/perf/results/baseline-2026-08-13.md
+++ b/scripts/perf/results/baseline-2026-08-13.md
@@ -1,0 +1,91 @@
+# Server performance baseline — 2026-08-13
+
+Captured against `igloo-server-dev` (externalbin build) on the dev machine
+(Intel Core Ultra 7 258V, 8 threads, ext4, media on the local `~/samba` dirs),
+real library, per the protocol in `scripts/perf/README.md`. All optimization
+PRs should quote deltas against these numbers.
+
+## Binary sizes
+
+| Artifact | Bytes | Notes |
+|---|---|---|
+| Release binary (`igloo-server`) | 229,963,896 (~219 MiB) | ~93% is the two payloads |
+| Dev binary (`igloo-server-dev`) | 19,229,888 (18 MiB) | real program size |
+| ffmpeg payload (linux amd64) | 107,531,768 | uncompressed, //go:embed |
+| ffprobe payload (linux amd64) | 107,375,352 | uncompressed, //go:embed |
+| webdist | 2.8 MB | |
+
+Release boots also write the two payloads (~214 MB) to a temp dir every start.
+
+## Idle (10 min + overnight, no requests)
+
+- RSS: avg 25.7 MB, max 27.1 MB
+- CPU: ~0.02%
+- Disk writes: ~4 KB over 11 h — effectively zero
+
+## Browse (k6, 3 VUs, 5 min: latest/library/details/search/music/notifications)
+
+- 9,782 requests, 32.5 req/s, 100% success
+- Latency: avg 1.06 ms, p90 2.53 ms, p95 4.14 ms, max 68.6 ms
+- Server: RSS avg 28.8 MB, CPU avg 3.5%
+
+The single-connection SQLite pool is not a visible bottleneck at household
+browse load; latency pressure will need to be rechecked while a scan or
+stream competes for the connection (PR 4 verification).
+
+## HLS streaming (720p_3mbps transcode of an HEVC source)
+
+1 session (5 min):
+- time-to-first-segment: cold start max **5.9 s**; warm re-request ~14 ms
+- warm segment requests: p95 16 ms
+- Server: RSS ~29.6 MB; server CPU ~0.1% (encode cost is in the ffmpeg child)
+
+3 concurrent sessions (5 min, three different movies):
+- The transcode limiter (`NumCPU()/4` = **2 slots** on this 8-thread machine)
+  plus CPU saturation stack up: time-to-first-segment cold max was
+  **6.9 s / 28.6 s / 50.6 s** for the three movies
+- Segment latency under saturation: p95 8–14.6 s
+- Server RSS stayed ~30 MB
+
+Cold start latency and the 3-stream pile-up are the dominant user-visible
+performance issues found. Matches the "first-frame latency never measured"
+item in `docs/hls-fixes.md` (Phase 3 lever: `-hls_flags temp_file`, fsnotify).
+
+## Scan (rescan of unchanged library, 5 min window)
+
+- Server CPU ~0.1%, RSS flat. The size+path skip index works; boot scans of
+  an unchanged library are cheap (conditional boot scan gate in PR 6 is NOT
+  justified by this data — skip it unless libraries change).
+
+## Startup (dev build, warm library)
+
+- exec → `/api/health` 200: **16.2 s**
+- Breakdown from logs: **InitDirs = 14.5 s** (media/static/transcode dir
+  checks against `~/samba`), TMDB client 1.2 s, Spotify client 0.3 s,
+  everything else (schema, 193 stmt preps, settings, session store) ~30 ms
+- Boot disk writes: 32 KB (dev; release adds ~214 MB payload extraction)
+
+InitDirs is the startup hog, not the schema/statement work — PR 6 should
+target it first. Release-build payload extraction is addressed by PR 2a/2b.
+
+## Microbenchmarks (single-shot, indicative)
+
+- Logger `Write`: ~22 µs/line (flush syscall per line; PR 3 target)
+- Search vocab BK-tree build (10k terms): ~20 ms — runs inside a request
+  after any library write bumps the generation
+- BK-tree correction lookup: ~0.22 ms
+- `ServeFrontend` (index.html): ~3 ms/req, ~735 KB allocations per request
+
+## Measurement caveats
+
+- `/proc/<pid>/io` **includes reaped children**: when a killed ffmpeg is
+  reaped at HLS teardown, its lifetime read/write bytes fold into the
+  server's counters as an instantaneous "burst" (observed as +250–570 MB
+  after long transcode sessions). Server-attributed write bursts at session
+  stop are almost entirely ffmpeg's own segment writes. Verified with a
+  bash/dd control experiment and an strace'd server instance (no server
+  write syscalls at teardown).
+- Real per-session disk churn is still real churn: a transcode session
+  writes its full output to the transcode dir and deletes it at teardown
+  (tens to hundreds of MB per session) — inherent to the design, worth
+  remembering for SSD wear, not a server bug.

--- a/scripts/perf/results/baseline-2026-08-13.md
+++ b/scripts/perf/results/baseline-2026-08-13.md
@@ -72,7 +72,7 @@ target it first. Release-build payload extraction is addressed by PR 2a/2b.
 
 - Logger `Write`: ~22 µs/line (flush syscall per line; PR 3 target)
 - Search vocab BK-tree build (10k synthetic terms): **~41 ms** — runs inside a
-  request after any library write bumps the generation. (The ~20 ms first
+  request after a searchable-field write bumps the generation. (The ~20 ms first
   recorded here was wrong; re-measuring the unmodified benchmark gives 41 ms.
   With the input copy moved out of the timed region it is ~38 ms.)
 - BK-tree correction lookup: **~0.33 ms**. (The 0.22 ms first recorded here was

--- a/scripts/perf/sample-rss.sh
+++ b/scripts/perf/sample-rss.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Sample RSS, CPU and cumulative write bytes of a process to CSV.
+#
+# Usage: sample-rss.sh <pid> <out.csv> [interval_seconds]
+#
+# Columns: epoch_s, rss_kb, cpu_ticks (utime+stime, cumulative), write_bytes
+# (cumulative, from /proc/<pid>/io). Convert cpu_ticks deltas to CPU% with:
+#   cpu% = 100 * (ticks2 - ticks1) / (CLK_TCK * (t2 - t1))
+# CLK_TCK is normally 100 (getconf CLK_TCK).
+
+set -euo pipefail
+
+pid="${1:?usage: sample-rss.sh <pid> <out.csv> [interval_seconds]}"
+out="${2:?usage: sample-rss.sh <pid> <out.csv> [interval_seconds]}"
+interval="${3:-2}"
+
+if [ ! -d "/proc/$pid" ]; then
+  echo "no such process: $pid" >&2
+  exit 1
+fi
+
+echo "epoch_s,rss_kb,cpu_ticks,write_bytes" >"$out"
+
+while [ -d "/proc/$pid" ]; do
+  rss_kb=$(awk '/^VmRSS:/ {print $2}' "/proc/$pid/status" 2>/dev/null || echo "")
+  [ -n "$rss_kb" ] || break
+  # Fields 14 (utime) and 15 (stime); parse after the last ')' so the comm
+  # field cannot shift positions.
+  cpu_ticks=$(awk '{sub(/.*\) /, ""); print $12 + $13}' "/proc/$pid/stat" 2>/dev/null || echo "")
+  write_bytes=$(awk '/^write_bytes:/ {print $2}' "/proc/$pid/io" 2>/dev/null || echo 0)
+  echo "$(date +%s),$rss_kb,$cpu_ticks,$write_bytes" >>"$out"
+  sleep "$interval"
+done
+
+echo "process $pid exited; samples written to $out" >&2

--- a/scripts/perf/soak.js
+++ b/scripts/perf/soak.js
@@ -1,0 +1,183 @@
+// k6 load scenarios for the Igloo server.
+//
+// Usage (against a running dev server):
+//   k6 run -e SCENARIO=browse -e VUS=3 -e DURATION=5m scripts/perf/soak.js
+//   k6 run -e SCENARIO=stream-hls -e MOVIE_ID=1 -e VUS=1 -e DURATION=10m scripts/perf/soak.js
+//   k6 run -e SCENARIO=stream-direct -e MOVIE_ID=1 -e VUS=1 -e DURATION=10m scripts/perf/soak.js
+//
+// Env vars:
+//   BASE_URL  (default http://localhost:8080)
+//   EMAIL     (default admin@example.com)
+//   PASSWORD  (default AdminPassword)
+//   SCENARIO  browse | stream-hls | stream-direct  (default browse)
+//   MOVIE_ID  required for the stream scenarios
+//   PROFILE   HLS profile id (default 720p_3mbps)
+//   VUS, DURATION
+
+import http from "k6/http";
+import { check, sleep, fail } from "k6";
+import { Trend } from "k6/metrics";
+
+const BASE = __ENV.BASE_URL || "http://localhost:8080";
+const EMAIL = __ENV.EMAIL || "admin@example.com";
+const PASSWORD = __ENV.PASSWORD || "AdminPassword";
+const SCENARIO = __ENV.SCENARIO || "browse";
+const MOVIE_ID = __ENV.MOVIE_ID || "";
+const PROFILE = __ENV.PROFILE || "720p_3mbps";
+const VUS = parseInt(__ENV.VUS || "1", 10);
+const DURATION = __ENV.DURATION || "5m";
+
+const timeToFirstSegment = new Trend("time_to_first_segment", true);
+
+const execByScenario = {
+  browse: "browse",
+  "stream-hls": "streamHLS",
+  "stream-direct": "streamDirect",
+};
+
+export const options = {
+  // Keep session cookies across iterations; each VU logs in once.
+  noCookiesReset: true,
+  scenarios: {
+    [SCENARIO]: {
+      executor: "constant-vus",
+      vus: VUS,
+      duration: DURATION,
+      exec: execByScenario[SCENARIO],
+    },
+  },
+};
+
+// Session cookie jars are per-VU and persist across iterations, so each VU
+// logs in once on its first iteration.
+let loggedIn = false;
+
+function ensureLogin() {
+  if (loggedIn) {
+    return;
+  }
+  const res = http.post(
+    `${BASE}/api/auth/login`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+  if (!check(res, { "login succeeded": (r) => r.status === 200 })) {
+    fail(`login failed: ${res.status} ${res.body}`);
+  }
+  loggedIn = true;
+}
+
+function get(path, params) {
+  const res = http.get(`${BASE}${path}`, params);
+  const ok = check(res, {
+    [`GET ${path} ok`]: (r) => r.status >= 200 && r.status < 400,
+  });
+  if (!ok && __ENV.DEBUG) {
+    console.warn(`GET ${path} -> ${res.status} ${String(res.body).slice(0, 200)}`);
+  }
+  return res;
+}
+
+export function browse() {
+  ensureLogin();
+
+  get("/api/movies/latest");
+  get("/api/movies/continue-watching");
+  const lib = get("/api/movies/library?page=1&per_page=24");
+  get("/api/music/albums/latest");
+  get("/api/music/tracks?page=1&per_page=50");
+  get("/api/notifications/unread-count");
+  get("/api/search?q=the");
+
+  // Visit a couple of detail pages from the library response when available.
+  try {
+    const body = JSON.parse(lib.body);
+    const movies = (body.data && (body.data.movies || body.data.items)) || [];
+    for (const m of movies.slice(0, 2)) {
+      if (m && m.id) {
+        get(`/api/movies/details/${m.id}`);
+        get(`/api/movies/${m.id}/watch-progress`);
+      }
+    }
+  } catch (_) {
+    // Envelope shape differs; the library request itself was still measured.
+  }
+
+  sleep(1);
+}
+
+// The web player identifies its HLS session with a client-generated UUID.
+function uuidv4() {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}
+
+const playbackSession = uuidv4();
+
+export function streamHLS() {
+  ensureLogin();
+  if (!MOVIE_ID) {
+    fail("MOVIE_ID is required for the stream-hls scenario");
+  }
+
+  const started = Date.now();
+  const manifest = get(
+    `/api/movies/${MOVIE_ID}/hls/${PROFILE}/playlist.m3u8?playback_session=${playbackSession}&start=0&audio_track=0`,
+  );
+  if (manifest.status !== 200) {
+    sleep(5);
+    return;
+  }
+
+  // Segment lines are absolute /api/... URIs with the session query included.
+  const lines = String(manifest.body).split("\n");
+  const segments = lines.filter((l) => l && !l.startsWith("#"));
+  let first = true;
+  // Fetch a window of segments, pacing roughly like a player buffering ahead.
+  for (const seg of segments.slice(0, 15)) {
+    const res = get(seg.trim());
+    if (first && res.status === 200) {
+      timeToFirstSegment.add(Date.now() - started);
+      first = false;
+    }
+    sleep(first ? 0 : 2);
+  }
+}
+
+export function streamDirect() {
+  ensureLogin();
+  if (!MOVIE_ID) {
+    fail("MOVIE_ID is required for the stream-direct scenario");
+  }
+
+  const chunk = 8 * 1024 * 1024;
+  // Read sequential ranges like a player pulling a direct-play file.
+  for (let i = 0; i < 10; i++) {
+    const start = i * chunk;
+    const res = http.get(`${BASE}/api/movies/${MOVIE_ID}/stream`, {
+      headers: { Range: `bytes=${start}-${start + chunk - 1}` },
+    });
+    check(res, { "range request ok": (r) => r.status === 206 || r.status === 200 });
+    if (res.status !== 206 && res.status !== 200) {
+      break;
+    }
+    sleep(2);
+  }
+}
+
+export function teardown() {
+  // Best effort: stop any personal HLS session this run started. teardown()
+  // runs in a fresh VU, so it needs its own login.
+  if (SCENARIO === "stream-hls" && MOVIE_ID) {
+    http.post(
+      `${BASE}/api/auth/login`,
+      JSON.stringify({ email: EMAIL, password: PASSWORD }),
+      { headers: { "Content-Type": "application/json" } },
+    );
+    http.post(
+      `${BASE}/api/movies/${MOVIE_ID}/hls/session/stop?playback_session=${playbackSession}`,
+    );
+  }
+}

--- a/scripts/perf/soak.js
+++ b/scripts/perf/soak.js
@@ -38,6 +38,12 @@ const execByScenario = {
 export const options = {
   // Keep session cookies across iterations; each VU logs in once.
   noCookiesReset: true,
+  // check() failures otherwise only move the checks metric, so a run full of
+  // failed requests still exits 0 and produces a clean-looking summary that
+  // baseline.sh happily records. Fail the run instead.
+  thresholds: {
+    checks: ["rate==1"],
+  },
   scenarios: {
     [SCENARIO]: {
       executor: "constant-vus",
@@ -114,14 +120,28 @@ function uuidv4() {
   });
 }
 
-const playbackSession = uuidv4();
+// Module init runs once per VU, so a module-scope UUID would give every VU a
+// different session that teardown() could not name. setup() mints one session
+// per VU instead and hands the list to both the VUs and teardown.
+export function setup() {
+  const sessions = [];
+  for (let i = 0; i < VUS; i++) {
+    sessions.push(uuidv4());
+  }
+  return { sessions };
+}
 
-export function streamHLS() {
+function sessionForVU(data) {
+  return data.sessions[(__VU - 1) % data.sessions.length];
+}
+
+export function streamHLS(data) {
   ensureLogin();
   if (!MOVIE_ID) {
     fail("MOVIE_ID is required for the stream-hls scenario");
   }
 
+  const playbackSession = sessionForVU(data);
   const started = Date.now();
   const manifest = get(
     `/api/movies/${MOVIE_ID}/hls/${PROFILE}/playlist.m3u8?playback_session=${playbackSession}&start=0&audio_track=0`,
@@ -167,17 +187,23 @@ export function streamDirect() {
   }
 }
 
-export function teardown() {
-  // Best effort: stop any personal HLS session this run started. teardown()
-  // runs in a fresh VU, so it needs its own login.
-  if (SCENARIO === "stream-hls" && MOVIE_ID) {
+export function teardown(data) {
+  // Stop every session the run started. An abandoned session holds a transcode
+  // slot until it self-evicts (~5 min), which would skew whatever is measured
+  // next. teardown() runs in a fresh VU, so it needs its own login.
+  if (SCENARIO !== "stream-hls" || !MOVIE_ID) {
+    return;
+  }
+
+  http.post(
+    `${BASE}/api/auth/login`,
+    JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+
+  for (const session of data.sessions) {
     http.post(
-      `${BASE}/api/auth/login`,
-      JSON.stringify({ email: EMAIL, password: PASSWORD }),
-      { headers: { "Content-Type": "application/json" } },
-    );
-    http.post(
-      `${BASE}/api/movies/${MOVIE_ID}/hls/session/stop?playback_session=${playbackSession}`,
+      `${BASE}/api/movies/${MOVIE_ID}/hls/session/stop?playback_session=${session}`,
     );
   }
 }

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -31,7 +31,10 @@ func main() {
 		Addr:    fmt.Sprintf(":%d", app.Config.Port),
 		Handler: app.Router,
 		// No WriteTimeout: it would cut off long-running direct-play and HLS
-		// responses. ReadHeaderTimeout bounds header parsing so idle or
+		// responses. No ReadTimeout either: it applies to the watch-room
+		// WebSocket, whose read deadline survives the hijack, so it would kill
+		// idle rooms. Request bodies are bounded per request instead, by
+		// helpers.ReadJSON. ReadHeaderTimeout bounds header parsing so idle or
 		// malicious connections cannot hold a goroutine open indefinitely.
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       120 * time.Second,

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 )
 
 func main() {
@@ -29,6 +30,11 @@ func main() {
 	app.Server = &http.Server{
 		Addr:    fmt.Sprintf(":%d", app.Config.Port),
 		Handler: app.Router,
+		// No WriteTimeout: it would cut off long-running direct-play and HLS
+		// responses. ReadHeaderTimeout bounds header parsing so idle or
+		// malicious connections cannot hold a goroutine open indefinitely.
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	deviceExpiryCtx, cancelDeviceExpiry := context.WithCancel(context.Background())

--- a/server/cmd/api/pprof_routes.go
+++ b/server/cmd/api/pprof_routes.go
@@ -1,0 +1,28 @@
+//go:build pprofdebug
+
+package main
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// registerPprof mounts runtime profiling endpoints under /api/debug/pprof.
+// It only exists in builds with the pprofdebug tag, so release and test
+// builds never expose these routes.
+func (app *Application) registerPprof(r chi.Router) {
+	r.Route("/debug/pprof", func(r chi.Router) {
+		r.Use(app.RequireAdmin)
+		r.Get("/", pprof.Index)
+		r.Get("/cmdline", pprof.Cmdline)
+		r.Get("/profile", pprof.Profile)
+		r.Get("/symbol", pprof.Symbol)
+		r.Post("/symbol", pprof.Symbol)
+		r.Get("/trace", pprof.Trace)
+		r.Get("/{profile}", func(w http.ResponseWriter, req *http.Request) {
+			pprof.Handler(chi.URLParam(req, "profile")).ServeHTTP(w, req)
+		})
+	})
+}

--- a/server/cmd/api/pprof_routes_off.go
+++ b/server/cmd/api/pprof_routes_off.go
@@ -1,0 +1,8 @@
+//go:build !pprofdebug
+
+package main
+
+import "github.com/go-chi/chi/v5"
+
+// registerPprof is a no-op without the pprofdebug build tag.
+func (app *Application) registerPprof(r chi.Router) {}

--- a/server/cmd/api/routes.go
+++ b/server/cmd/api/routes.go
@@ -71,6 +71,7 @@ func (app *Application) registerAuthenticatedAPIRoutes(r chi.Router) {
 		app.registerWatchRoomRoutes(r)
 		app.registerSettingsRoutes(r)
 		app.registerMusicRoutes(r)
+		app.registerPprof(r)
 	})
 }
 

--- a/server/cmd/api/routes.go
+++ b/server/cmd/api/routes.go
@@ -36,7 +36,11 @@ func (app *Application) registerSessionRoutes(r chi.Router) {
 	app.registerAPIRoutes(r)
 
 	// Register SPA fallback after /api routes so API paths cannot be captured.
+	// HEAD needs its own registration: chi resolves methods separately, so a
+	// GET-only route answers HEAD with 405. ServeFrontend serves HEAD correctly
+	// through http.ServeContent.
 	r.Get("/*", app.ServeFrontend)
+	r.Head("/*", app.ServeFrontend)
 }
 
 func (app *Application) registerAPIRoutes(r chi.Router) {

--- a/server/cmd/api/search_vocab_bench_test.go
+++ b/server/cmd/api/search_vocab_bench_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func benchVocabTerms(n int) []searchVocabTerm {
+	rng := rand.New(rand.NewSource(42))
+	terms := make([]searchVocabTerm, 0, n)
+	for i := 0; i < n; i++ {
+		runes := make([]rune, 4+rng.Intn(9))
+		for j := range runes {
+			runes[j] = rune('a' + rng.Intn(26))
+		}
+		terms = append(terms, searchVocabTerm{
+			term:  string(runes),
+			runes: runes,
+			doc:   int64(rng.Intn(1000)),
+		})
+	}
+	return terms
+}
+
+// Benchmarks the synchronous BK-tree rebuild that currently runs inside a
+// search request whenever a library write bumps the vocab generation.
+func BenchmarkSearchVocabBuild(b *testing.B) {
+	terms := benchVocabTerms(10_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// newSearchVocabIndex sorts its input, so hand it a fresh copy.
+		copied := make([]searchVocabTerm, len(terms))
+		copy(copied, terms)
+		newSearchVocabIndex(copied)
+	}
+}
+
+// Benchmarks a single typo-correction lookup against a built index.
+func BenchmarkSearchVocabCorrections(b *testing.B) {
+	index := newSearchVocabIndex(benchVocabTerms(10_000))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		index.corrections("exmaple", 2, searchVocabMaxVisited)
+	}
+}

--- a/server/cmd/api/search_vocab_bench_test.go
+++ b/server/cmd/api/search_vocab_bench_test.go
@@ -5,6 +5,14 @@ import (
 	"testing"
 )
 
+// benchVocabHitTerm is one edit away from the query the correction benchmark
+// issues, so the lookup always finds a candidate.
+const (
+	benchVocabHitTerm  = "example"
+	benchVocabHitQuery = "exmaple"
+	benchVocabMaxDoc   = 1000
+)
+
 func benchVocabTerms(n int) []searchVocabTerm {
 	rng := rand.New(rand.NewSource(42))
 	terms := make([]searchVocabTerm, 0, n)
@@ -16,9 +24,24 @@ func benchVocabTerms(n int) []searchVocabTerm {
 		terms = append(terms, searchVocabTerm{
 			term:  string(runes),
 			runes: runes,
-			doc:   int64(rng.Intn(1000)),
+			doc:   int64(rng.Intn(benchVocabMaxDoc)),
 		})
 	}
+
+	// The rest of the vocabulary is random, so nothing is guaranteed to sit
+	// within maxDist of the benchmark's query. Plant one deterministic hit so
+	// the correction benchmark measures candidate ranking and result
+	// allocation rather than only the miss path. Its doc count sits just above
+	// the generated range because the search frontier is a max-heap on doc
+	// frequency: a rare term is never reached within the visit limit, and
+	// corrections exist to surface frequent terms anyway.
+	hit := []rune(benchVocabHitTerm)
+	terms = append(terms, searchVocabTerm{
+		term:  benchVocabHitTerm,
+		runes: hit,
+		doc:   benchVocabMaxDoc,
+	})
+
 	return terms
 }
 
@@ -28,9 +51,13 @@ func BenchmarkSearchVocabBuild(b *testing.B) {
 	terms := benchVocabTerms(10_000)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// newSearchVocabIndex sorts its input, so hand it a fresh copy.
+		// newSearchVocabIndex sorts its input, so hand it a fresh copy — but
+		// keep the copy out of the timer, which measures the build alone.
+		b.StopTimer()
 		copied := make([]searchVocabTerm, len(terms))
 		copy(copied, terms)
+		b.StartTimer()
+
 		newSearchVocabIndex(copied)
 	}
 }
@@ -38,8 +65,14 @@ func BenchmarkSearchVocabBuild(b *testing.B) {
 // Benchmarks a single typo-correction lookup against a built index.
 func BenchmarkSearchVocabCorrections(b *testing.B) {
 	index := newSearchVocabIndex(benchVocabTerms(10_000))
+
+	matches, _ := index.corrections(benchVocabHitQuery, 2, searchVocabMaxVisited)
+	if len(matches) == 0 {
+		b.Fatalf("expected %q to correct to a candidate; the benchmark would only measure the miss path", benchVocabHitQuery)
+	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		index.corrections("exmaple", 2, searchVocabMaxVisited)
+		index.corrections(benchVocabHitQuery, 2, searchVocabMaxVisited)
 	}
 }

--- a/server/cmd/api/search_vocab_bench_test.go
+++ b/server/cmd/api/search_vocab_bench_test.go
@@ -16,7 +16,10 @@ const (
 func benchVocabTerms(n int) []searchVocabTerm {
 	rng := rand.New(rand.NewSource(42))
 	terms := make([]searchVocabTerm, 0, n)
-	for i := 0; i < n; i++ {
+
+	// One slot is reserved for the planted hit appended below, so the caller
+	// gets exactly n terms.
+	for i := 0; i < n-1; i++ {
 		runes := make([]rune, 4+rng.Intn(9))
 		for j := range runes {
 			runes[j] = rune('a' + rng.Intn(26))
@@ -46,7 +49,7 @@ func benchVocabTerms(n int) []searchVocabTerm {
 }
 
 // Benchmarks the synchronous BK-tree rebuild that currently runs inside a
-// search request whenever a library write bumps the vocab generation.
+// search request whenever a searchable-field write bumps the vocab generation.
 func BenchmarkSearchVocabBuild(b *testing.B) {
 	terms := benchVocabTerms(10_000)
 	b.ResetTimer()

--- a/server/cmd/api/static_handler.go
+++ b/server/cmd/api/static_handler.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"io/fs"
 	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -83,6 +88,84 @@ func (app *Application) ServeStaticFiles(w http.ResponseWriter, r *http.Request)
 	http.ServeContent(w, r, info.Name(), info.ModTime(), file)
 }
 
+// frontendAsset is one embedded SPA file, read and fingerprinted once so the
+// request path serves from memory with ETag revalidation instead of
+// re-reading the embedded filesystem on every hit.
+type frontendAsset struct {
+	content     []byte
+	contentType string
+	etag        string
+}
+
+var (
+	frontendAssetsOnce sync.Once
+	frontendAssets     map[string]*frontendAsset
+)
+
+// loadFrontendAssets walks the embedded webdist once. webdist is ~3 MB, so
+// holding the decoded copies in memory is cheap next to re-reading and
+// re-allocating them per request.
+func loadFrontendAssets() map[string]*frontendAsset {
+	assets := make(map[string]*frontendAsset)
+
+	walkErr := fs.WalkDir(FrontendFS, "webdist", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+
+		content, err := fs.ReadFile(FrontendFS, path)
+		if err != nil {
+			return err
+		}
+
+		contentType := mime.TypeByExtension(filepath.Ext(path))
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+
+		sum := sha256.Sum256(content)
+		assets[path] = &frontendAsset{
+			content:     content,
+			contentType: contentType,
+			etag:        `"` + hex.EncodeToString(sum[:16]) + `"`,
+		}
+		return nil
+	})
+	if walkErr != nil {
+		// A missing or unreadable webdist degrades to the same "frontend not
+		// found" responses the per-request reads produced.
+		return assets
+	}
+
+	return assets
+}
+
+func frontendAssetFor(fsPath string) (*frontendAsset, bool) {
+	frontendAssetsOnce.Do(func() {
+		frontendAssets = loadFrontendAssets()
+	})
+
+	asset, ok := frontendAssets[fsPath]
+	return asset, ok
+}
+
+func serveFrontendAsset(w http.ResponseWriter, r *http.Request, asset *frontendAsset, isHTML bool) {
+	// Hashed assets are immutable; HTML must revalidate so deploys are
+	// picked up. Both get an ETag so revalidation can answer 304.
+	if isHTML {
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	} else {
+		w.Header().Set("Cache-Control", "public, max-age=31536000")
+	}
+
+	w.Header().Set("Content-Type", asset.contentType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("ETag", asset.etag)
+
+	// Embedded files carry no modtime; the ETag drives conditional requests.
+	http.ServeContent(w, r, "", time.Time{}, bytes.NewReader(asset.content))
+}
+
 // ServeFrontend serves the React SPA from embedded files, or redirects to the Vite dev
 // server when VITE_DEV_SERVER is set (e.g. VITE_DEV_SERVER=http://localhost:3000 for make dev).
 func (app *Application) ServeFrontend(w http.ResponseWriter, r *http.Request) {
@@ -115,102 +198,37 @@ func (app *Application) ServeFrontend(w http.ResponseWriter, r *http.Request) {
 	fsPath := filepath.Join("webdist", requestedPath)
 	fsPath = filepath.ToSlash(fsPath)
 
-	file, err := FrontendFS.Open(fsPath)
-	if err != nil {
-		if embeddedPathLooksLikeStaticAsset(requestedPath) {
-			app.Logger.Warn(
-				"embedded frontend asset missing; rebuild web, copy to cmd/api/webdist, then rebuild the binary",
-				"path", fsPath,
-			)
-			http.Error(
-				w,
-				"Not Found: embedded static asset missing. From the repo: run make build from server/ to embed the web app.",
-				http.StatusNotFound,
-			)
-			return
-		}
-
-		indexPath := "webdist/index.html"
-		content, err := fs.ReadFile(FrontendFS, indexPath)
-		if err != nil {
-			app.Logger.Error("failed to find index.html in embedded filesystem", "error", err)
-			http.Error(w, "Frontend not found. Please build the web application and rebuild the binary.", http.StatusNotFound)
-			return
-		}
-
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-		w.WriteHeader(http.StatusOK)
-		w.Write(content)
-		return
-	}
-	defer file.Close()
-
-	info, err := file.Stat()
-	if err != nil {
-		app.Logger.Error("failed to stat embedded file", "error", err, "path", fsPath)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	if asset, ok := frontendAssetFor(fsPath); ok {
+		serveFrontendAsset(w, r, asset, strings.HasSuffix(fsPath, ".html"))
 		return
 	}
 
-	var content []byte
-	var fileInfo fs.FileInfo
-
-	if info.IsDir() {
-		indexPath := filepath.Join(fsPath, "index.html")
-		indexPath = filepath.ToSlash(indexPath)
-		indexContent, err := fs.ReadFile(FrontendFS, indexPath)
-		if err != nil {
-			rootIndexPath := "webdist/index.html"
-			indexContent, err = fs.ReadFile(FrontendFS, rootIndexPath)
-			if err != nil {
-				http.Error(w, "Not Found", http.StatusNotFound)
-				return
-			}
-			indexFile, _ := FrontendFS.Open(rootIndexPath)
-			if statInfo, err := indexFile.Stat(); err == nil {
-				fileInfo = statInfo
-			} else {
-				fileInfo = info
-			}
-			indexFile.Close()
-			content = indexContent
-		} else {
-			indexFile, _ := FrontendFS.Open(indexPath)
-			if statInfo, err := indexFile.Stat(); err == nil {
-				fileInfo = statInfo
-			} else {
-				fileInfo = info
-			}
-			indexFile.Close()
-			content = indexContent
-		}
-	} else {
-		content, err = fs.ReadFile(FrontendFS, fsPath)
-		if err != nil {
-			app.Logger.Error("failed to read embedded file", "error", err, "path", fsPath)
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-		fileInfo = info
+	// A directory request serves its own index.html when one exists.
+	if asset, ok := frontendAssetFor(fsPath + "/index.html"); ok {
+		serveFrontendAsset(w, r, asset, true)
+		return
 	}
 
-	ext := filepath.Ext(fileInfo.Name())
-	contentType := mime.TypeByExtension(ext)
-	if contentType == "" {
-		contentType = "application/octet-stream"
+	if embeddedPathLooksLikeStaticAsset(requestedPath) {
+		app.Logger.Warn(
+			"embedded frontend asset missing; rebuild web, copy to cmd/api/webdist, then rebuild the binary",
+			"path", fsPath,
+		)
+		http.Error(
+			w,
+			"Not Found: embedded static asset missing. From the repo: run make build from server/ to embed the web app.",
+			http.StatusNotFound,
+		)
+		return
 	}
 
-	// Static assets should be cached; HTML should not.
-	if ext == ".html" {
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	} else {
-		w.Header().Set("Cache-Control", "public, max-age=31536000")
+	// SPA fallback: any other path serves the root index.html.
+	asset, ok := frontendAssetFor("webdist/index.html")
+	if !ok {
+		app.Logger.Error("failed to find index.html in embedded filesystem")
+		http.Error(w, "Frontend not found. Please build the web application and rebuild the binary.", http.StatusNotFound)
+		return
 	}
 
-	w.Header().Set("Content-Type", contentType)
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(content)
+	serveFrontendAsset(w, r, asset, true)
 }

--- a/server/cmd/api/static_handler_bench_test.go
+++ b/server/cmd/api/static_handler_bench_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 )
 
-// Benchmarks the SPA hot path, which currently re-reads the embedded asset on
-// every request. Skips when webdist holds only the test placeholder.
+// Benchmarks the SPA hot path: an asset-map lookup plus http.ServeContent from
+// the pre-read, pre-fingerprinted bytes. Skips when webdist holds only the test
+// placeholder.
 func BenchmarkServeFrontend(b *testing.B) {
 	_, err := FrontendFS.Open("webdist/index.html")
 	if err != nil {

--- a/server/cmd/api/static_handler_bench_test.go
+++ b/server/cmd/api/static_handler_bench_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+)
+
+// Benchmarks the SPA hot path, which currently re-reads the embedded asset on
+// every request. Skips when webdist holds only the test placeholder.
+func BenchmarkServeFrontend(b *testing.B) {
+	_, err := FrontendFS.Open("webdist/index.html")
+	if err != nil {
+		b.Skip("webdist is not populated; run make prepare-web first")
+	}
+
+	b.Setenv("VITE_DEV_SERVER", "")
+	app := &Application{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		app.ServeFrontend(w, r)
+		if w.Code != 200 {
+			b.Fatalf("unexpected status %d", w.Code)
+		}
+	}
+}

--- a/server/cmd/api/track_playlist_handler.go
+++ b/server/cmd/api/track_playlist_handler.go
@@ -546,8 +546,20 @@ func (app *Application) ReorderPlaylistTracks(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// One transaction for the whole reorder: previously each position update
+	// committed (and synced) individually, so a long playlist cost one fsync
+	// per track. Individual misses are still tolerated, as before.
+	tx, err := app.DB.BeginTx(r.Context(), nil)
+	if err != nil {
+		app.Logger.Error("failed to begin reorder transaction", "error", err, "playlist_id", playlistId)
+		helpers.ErrorJSON(w, errors.New("failed to reorder tracks"))
+		return
+	}
+	defer tx.Rollback()
+
+	qtx := app.Queries.WithTx(tx)
 	for i, trackId := range req.TrackIds {
-		err := app.Queries.UpdateTrackPosition(r.Context(), database.UpdateTrackPositionParams{
+		err := qtx.UpdateTrackPosition(r.Context(), database.UpdateTrackPositionParams{
 			Position:   int64(i),
 			PlaylistID: playlistId,
 			TrackID:    trackId,
@@ -557,7 +569,14 @@ func (app *Application) ReorderPlaylistTracks(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	_ = app.Queries.UpdatePlaylistTimestamp(r.Context(), playlistId)
+	_ = qtx.UpdatePlaylistTimestamp(r.Context(), playlistId)
+
+	err = tx.Commit()
+	if err != nil {
+		app.Logger.Error("failed to commit reorder transaction", "error", err, "playlist_id", playlistId)
+		helpers.ErrorJSON(w, errors.New("failed to reorder tracks"))
+		return
+	}
 
 	app.Logger.Info("playlist tracks reordered", "playlist_id", playlistId)
 

--- a/server/cmd/api/track_playlist_handler.go
+++ b/server/cmd/api/track_playlist_handler.go
@@ -416,7 +416,12 @@ func (app *Application) AddTracksToPlaylist(w http.ResponseWriter, r *http.Reque
 		addedCount++
 	}
 
-	_ = qtx.UpdatePlaylistTimestamp(r.Context(), playlistId)
+	timestampErr := qtx.UpdatePlaylistTimestamp(r.Context(), playlistId)
+	if timestampErr != nil {
+		app.Logger.Error("failed to update playlist timestamp", "error", timestampErr, "playlist_id", playlistId)
+		helpers.ErrorJSON(w, errors.New("failed to add tracks"))
+		return
+	}
 
 	err = tx.Commit()
 	if err != nil {
@@ -489,7 +494,12 @@ func (app *Application) RemoveTrackFromPlaylist(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	_ = app.Queries.UpdatePlaylistTimestamp(r.Context(), playlistId)
+	timestampErr := app.Queries.UpdatePlaylistTimestamp(r.Context(), playlistId)
+	if timestampErr != nil {
+		app.Logger.Error("failed to update playlist timestamp", "error", timestampErr, "playlist_id", playlistId)
+		helpers.ErrorJSON(w, errors.New("failed to finalize playlist update"))
+		return
+	}
 
 	app.Logger.Info("track removed from playlist", "playlist_id", playlistId, "track_id", trackId)
 
@@ -569,7 +579,12 @@ func (app *Application) ReorderPlaylistTracks(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	_ = qtx.UpdatePlaylistTimestamp(r.Context(), playlistId)
+	timestampErr := qtx.UpdatePlaylistTimestamp(r.Context(), playlistId)
+	if timestampErr != nil {
+		app.Logger.Error("failed to update playlist timestamp", "error", timestampErr, "playlist_id", playlistId)
+		helpers.ErrorJSON(w, errors.New("failed to reorder tracks"))
+		return
+	}
 
 	err = tx.Commit()
 	if err != nil {

--- a/server/cmd/internal/ffmpeg/ffmpeg_darwin_arm64.go
+++ b/server/cmd/internal/ffmpeg/ffmpeg_darwin_arm64.go
@@ -4,5 +4,5 @@ package ffmpeg
 
 import _ "embed"
 
-//go:embed ffmpeg_darwin_arm64
-var embeddedBinary []byte
+//go:embed ffmpeg_darwin_arm64.zst
+var embeddedCompressed []byte

--- a/server/cmd/internal/ffmpeg/ffmpeg_extract.go
+++ b/server/cmd/internal/ffmpeg/ffmpeg_extract.go
@@ -6,12 +6,13 @@ import (
 	"igloo/cmd/internal/mediabin"
 )
 
-// resolveBinaryCandidate extracts the embedded ffmpeg binary to a temporary
-// directory and returns the candidate path and extraction directory.
-// embeddedBinary is defined in platform-specific files (ffmpeg_darwin_arm64.go,
+// resolveBinaryCandidate materializes the embedded zstd-compressed ffmpeg
+// binary on disk and returns the candidate path and extraction directory
+// (empty when served from the per-version cache). embeddedCompressed is
+// defined in platform-specific files (ffmpeg_darwin_arm64.go,
 // ffmpeg_linux_amd64.go) and is populated at compile time via //go:embed.
 func resolveBinaryCandidate() (binaryCandidate, error) {
-	binPath, tempDir, err := mediabin.ExtractEmbedded("ffmpeg", embeddedBinary)
+	binPath, tempDir, err := mediabin.ExtractEmbeddedZstd("ffmpeg", embeddedCompressed)
 	if err != nil {
 		return binaryCandidate{}, err
 	}

--- a/server/cmd/internal/ffmpeg/ffmpeg_linux_amd64.go
+++ b/server/cmd/internal/ffmpeg/ffmpeg_linux_amd64.go
@@ -4,5 +4,5 @@ package ffmpeg
 
 import _ "embed"
 
-//go:embed ffmpeg_linux_amd64
-var embeddedBinary []byte
+//go:embed ffmpeg_linux_amd64.zst
+var embeddedCompressed []byte

--- a/server/cmd/internal/ffprobe/ffprobe_darwin_arm64.go
+++ b/server/cmd/internal/ffprobe/ffprobe_darwin_arm64.go
@@ -4,5 +4,5 @@ package ffprobe
 
 import _ "embed"
 
-//go:embed ffprobe_darwin_arm64
-var embeddedBinary []byte
+//go:embed ffprobe_darwin_arm64.zst
+var embeddedCompressed []byte

--- a/server/cmd/internal/ffprobe/ffprobe_extract.go
+++ b/server/cmd/internal/ffprobe/ffprobe_extract.go
@@ -6,12 +6,13 @@ import (
 	"igloo/cmd/internal/mediabin"
 )
 
-// resolveBinaryCandidate extracts the embedded ffprobe binary to a temporary
-// directory and returns its candidate path and extraction directory.
-// embeddedBinary is defined in platform-specific files (ffprobe_darwin_arm64.go,
+// resolveBinaryCandidate materializes the embedded zstd-compressed ffprobe
+// binary on disk and returns its candidate path and extraction directory
+// (empty when served from the per-version cache). embeddedCompressed is
+// defined in platform-specific files (ffprobe_darwin_arm64.go,
 // ffprobe_linux_amd64.go) and is populated at compile time via //go:embed.
 func resolveBinaryCandidate() (binaryCandidate, error) {
-	binPath, tempDir, err := mediabin.ExtractEmbedded("ffprobe", embeddedBinary)
+	binPath, tempDir, err := mediabin.ExtractEmbeddedZstd("ffprobe", embeddedCompressed)
 	if err != nil {
 		return binaryCandidate{}, err
 	}

--- a/server/cmd/internal/ffprobe/ffprobe_linux_amd64.go
+++ b/server/cmd/internal/ffprobe/ffprobe_linux_amd64.go
@@ -4,5 +4,5 @@ package ffprobe
 
 import _ "embed"
 
-//go:embed ffprobe_linux_amd64
-var embeddedBinary []byte
+//go:embed ffprobe_linux_amd64.zst
+var embeddedCompressed []byte

--- a/server/cmd/internal/helpers/constants.go
+++ b/server/cmd/internal/helpers/constants.go
@@ -14,6 +14,13 @@ const (
 
 const TMDB_HTTP_TIMEOUT = 10 * time.Second
 
+// READ_JSON_TIMEOUT bounds how long a handler will wait for a request body.
+// http.MaxBytesReader caps the body's size but not the time taken to send it,
+// so a slow client could otherwise hold a goroutine open indefinitely. This is
+// applied per request in ReadJSON rather than as http.Server.ReadTimeout,
+// which would also apply to the hijacked watch-room WebSocket.
+const READ_JSON_TIMEOUT = 15 * time.Second
+
 // HLS profile identifiers are URL-visible values accepted by hls_profiles.go.
 const (
 	HLS_PROFILE_REMUX        = "remux"

--- a/server/cmd/internal/helpers/json.go
+++ b/server/cmd/internal/helpers/json.go
@@ -5,7 +5,16 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 )
+
+// setReadDeadline bounds (deadline) or clears (zero deadline) the time allowed
+// to read the rest of the request. Responses that do not support deadlines —
+// httptest.ResponseRecorder in the handler tests — are left alone; nothing else
+// is worth failing a request over, since the deadline is only a guard rail.
+func setReadDeadline(w http.ResponseWriter, deadline time.Time) {
+	_ = http.NewResponseController(w).SetReadDeadline(deadline)
+}
 
 type JSONResponse struct {
 	Error   bool   `json:"error"`
@@ -36,13 +45,15 @@ func WriteJSON(w http.ResponseWriter, status int, data any, headers ...http.Head
 }
 
 // ReadJSON decodes JSON from the request body into data.
-// It enforces a maximum body size and rejects unknown fields.
+// It enforces a maximum body size, a read deadline, and rejects unknown fields.
 func ReadJSON(w http.ResponseWriter, r *http.Request, data any, maxBytes int64) error {
 	if maxBytes == 0 {
 		maxBytes = 1024 * 1024 // 1 MB default
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	defer setReadDeadline(w, time.Time{})
+	setReadDeadline(w, time.Now().Add(READ_JSON_TIMEOUT))
 
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()

--- a/server/cmd/internal/logger/logger.go
+++ b/server/cmd/internal/logger/logger.go
@@ -1,13 +1,14 @@
 package logger
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 )
 
-const loggerMaxLines = 500
+const loggerMaxBytes = 1 << 20
 
 type LoggerInterface interface {
 	Debug(msg string, args ...any)
@@ -74,7 +75,7 @@ func New(cfg *LoggerConfig) (LoggerInterface, func() error, error) {
 
 	path := filepath.Join(cfg.LogDir, logFile)
 
-	rw, err := newRotatingWriter(path, loggerMaxLines)
+	rw, err := newRotatingWriter(path, loggerMaxBytes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open log file: %w", err)
 	}
@@ -85,5 +86,32 @@ func New(cfg *LoggerConfig) (LoggerInterface, func() error, error) {
 		Level: slog.LevelInfo,
 	})
 
-	return slog.New(handler), closer, nil
+	return slog.New(flushOnSevereHandler{Handler: handler, flush: rw.Flush}), closer, nil
+}
+
+// flushOnSevereHandler flushes the rotating writer after WARN and ERROR
+// records, so severe entries reach disk immediately while routine request
+// logging stays buffered.
+type flushOnSevereHandler struct {
+	slog.Handler
+	flush func() error
+}
+
+func (h flushOnSevereHandler) Handle(ctx context.Context, record slog.Record) error {
+	err := h.Handler.Handle(ctx, record)
+	if record.Level >= slog.LevelWarn {
+		flushErr := h.flush()
+		if err == nil {
+			err = flushErr
+		}
+	}
+	return err
+}
+
+func (h flushOnSevereHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return flushOnSevereHandler{Handler: h.Handler.WithAttrs(attrs), flush: h.flush}
+}
+
+func (h flushOnSevereHandler) WithGroup(name string) slog.Handler {
+	return flushOnSevereHandler{Handler: h.Handler.WithGroup(name), flush: h.flush}
 }

--- a/server/cmd/internal/logger/logger_rotator.go
+++ b/server/cmd/internal/logger/logger_rotator.go
@@ -3,192 +3,175 @@ package logger
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"os"
-	"strings"
 	"sync"
+	"time"
 )
 
-// rotatingWriter keeps recent slog JSON entries in a bounded file.
+const loggerFlushInterval = time.Second
+
+// rotatingWriter keeps recent slog JSON entries in a bounded pair of files:
+// the live log plus one rotated predecessor (path + ".1").
+//
+// Writes are buffered and flushed by a background ticker, on severe records
+// (see flushOnSevereHandler), and on Close — not per line. Request logging
+// sits on the HTTP hot path, and a write syscall per log line dominated the
+// server's idle disk writes. The trade-off is that a hard crash can lose up
+// to a second of buffered INFO lines.
 type rotatingWriter struct {
+	mu       sync.Mutex
+	path     string
 	file     *os.File
 	buf      *bufio.Writer
-	mu       sync.Mutex
-	lines    int
-	maxLines int
+	size     int64
+	maxBytes int64
+	closed   bool
+	stop     chan struct{}
+	done     chan struct{}
 }
 
-func newRotatingWriter(path string, maxLines int) (*rotatingWriter, error) {
-	if maxLines <= 0 {
-		return nil, fmt.Errorf("max lines must be positive")
+func newRotatingWriter(path string, maxBytes int64) (*rotatingWriter, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("max bytes must be positive")
 	}
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, err
 	}
 
-	lines, err := countLines(f)
+	info, err := f.Stat()
 	if err != nil {
 		f.Close()
 		return nil, err
 	}
 
-	return &rotatingWriter{
+	w := &rotatingWriter{
+		path:     path,
 		file:     f,
 		buf:      bufio.NewWriter(f),
-		lines:    lines,
-		maxLines: maxLines,
-	}, nil
+		size:     info.Size(),
+		maxBytes: maxBytes,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+
+	go w.flushLoop()
+
+	return w, nil
 }
 
-func countLines(f *os.File) (int, error) {
-	_, err := f.Seek(0, 0)
-	if err != nil {
-		return 0, err
-	}
+func (w *rotatingWriter) flushLoop() {
+	defer close(w.done)
 
-	count := 0
-	reader := bufio.NewReader(f)
+	ticker := time.NewTicker(loggerFlushInterval)
+	defer ticker.Stop()
 
 	for {
-		line, err := reader.ReadString('\n')
-		if len(line) > 0 {
-			count++
+		select {
+		case <-w.stop:
+			return
+		case <-ticker.C:
+			w.mu.Lock()
+			if !w.closed {
+				// A flush failure here has nowhere to be reported; the next
+				// Write surfaces the buffered writer's sticky error instead.
+				_ = w.buf.Flush()
+			}
+			w.mu.Unlock()
 		}
-
-		if err == nil {
-			continue
-		}
-
-		if err == io.EOF {
-			break
-		}
-
-		return 0, err
 	}
-
-	return count, nil
 }
 
 // Write implements io.Writer. Each slog entry is one JSON line.
-func (w *rotatingWriter) Write(p []byte) (n int, err error) {
+func (w *rotatingWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if w.lines >= w.maxLines {
+	if w.closed {
+		return 0, fmt.Errorf("log writer is closed")
+	}
+
+	// A single entry larger than the cap is still written whole; the next
+	// entry rotates it away.
+	if w.size > 0 && w.size+int64(len(p)) > w.maxBytes {
 		if err := w.rotate(); err != nil {
 			return 0, fmt.Errorf("failed to rotate log file: %w", err)
 		}
 	}
 
-	n, err = w.buf.Write(p)
+	n, err := w.buf.Write(p)
 	if err != nil {
 		return n, err
 	}
 
-	// Flush immediately to ensure logs survive crashes.
-	// Trade-off: slightly slower writes for guaranteed persistence.
-	err = w.buf.Flush()
-	if err != nil {
-		return n, err
-	}
-
-	w.lines++
+	w.size += int64(n)
 
 	return n, nil
 }
 
-// rotate discards the oldest half of the log file and keeps the newest half.
-// Keeping half avoids rotating on every write once the limit is reached.
+// rotate renames the live file to its ".1" sibling (replacing any previous
+// one) and starts a fresh live file, so rotation cost is O(1) instead of
+// rewriting retained lines.
 func (w *rotatingWriter) rotate() error {
 	err := w.buf.Flush()
 	if err != nil {
 		return err
 	}
 
-	_, err = w.file.Seek(0, 0)
+	err = w.file.Close()
 	if err != nil {
 		return err
 	}
 
-	lines, err := readLines(w.file, w.lines)
+	err = os.Rename(w.path, w.path+".1")
 	if err != nil {
 		return err
 	}
 
-	keepFrom := len(lines) / 2
-	lines = lines[keepFrom:]
-
-	err = w.file.Truncate(0)
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
 
-	_, err = w.file.Seek(0, 0)
-	if err != nil {
-		return err
-	}
-
-	for _, line := range lines {
-		_, err = w.buf.WriteString(line)
-		if err != nil {
-			return err
-		}
-
-		err = w.buf.WriteByte('\n')
-		if err != nil {
-			return err
-		}
-	}
-
-	err = w.buf.Flush()
-	if err != nil {
-		return err
-	}
-
-	w.lines = len(lines)
+	w.file = f
+	w.buf = bufio.NewWriter(f)
+	w.size = 0
 
 	return nil
 }
 
-func readLines(f *os.File, capacity int) ([]string, error) {
-	lines := make([]string, 0, capacity)
-	reader := bufio.NewReader(f)
+// Flush forces buffered entries to disk; severe records use it so warnings
+// and errors never sit in the buffer.
+func (w *rotatingWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
-	for {
-		line, err := reader.ReadString('\n')
-		if len(line) > 0 {
-			line = strings.TrimSuffix(line, "\n")
-			line = strings.TrimSuffix(line, "\r")
-			lines = append(lines, line)
-		}
-
-		if err == nil {
-			continue
-		}
-
-		if err == io.EOF {
-			break
-		}
-
-		return nil, err
+	if w.closed {
+		return fmt.Errorf("log writer is closed")
 	}
 
-	return lines, nil
+	return w.buf.Flush()
 }
 
 func (w *rotatingWriter) Close() error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
 
-	err := w.buf.Flush()
-	if err != nil {
-		// Still close the file even if flush fails
-		w.file.Close()
-
-		return err
+	if w.closed {
+		w.mu.Unlock()
+		return fmt.Errorf("log writer is already closed")
 	}
+	w.closed = true
 
-	return w.file.Close()
+	flushErr := w.buf.Flush()
+	closeErr := w.file.Close()
+	w.mu.Unlock()
+
+	close(w.stop)
+	<-w.done
+
+	if flushErr != nil {
+		return flushErr
+	}
+	return closeErr
 }

--- a/server/cmd/internal/logger/logger_rotator_bench_test.go
+++ b/server/cmd/internal/logger/logger_rotator_bench_test.go
@@ -1,0 +1,28 @@
+package logger
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Benchmarks the request-logging hot path: one JSON line per HTTP request,
+// including the rotation cost once the line cap is reached.
+func BenchmarkRotatingWriterWrite(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "bench.log")
+	w, err := newRotatingWriter(path, loggerMaxLines)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer w.Close()
+
+	line := []byte(`{"time":"2026-08-12T00:00:00Z","level":"INFO","msg":"request completed","method":"GET","path":"/api/movies/latest","status":200,"duration_ms":12}` + "\n")
+
+	b.SetBytes(int64(len(line)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := w.Write(line)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/server/cmd/internal/logger/logger_rotator_bench_test.go
+++ b/server/cmd/internal/logger/logger_rotator_bench_test.go
@@ -9,7 +9,7 @@ import (
 // including the rotation cost once the line cap is reached.
 func BenchmarkRotatingWriterWrite(b *testing.B) {
 	path := filepath.Join(b.TempDir(), "bench.log")
-	w, err := newRotatingWriter(path, loggerMaxLines)
+	w, err := newRotatingWriter(path, loggerMaxBytes)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/server/cmd/internal/logger/logger_rotator_bench_test.go
+++ b/server/cmd/internal/logger/logger_rotator_bench_test.go
@@ -13,7 +13,6 @@ func BenchmarkRotatingWriterWrite(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer w.Close()
 
 	line := []byte(`{"time":"2026-08-12T00:00:00Z","level":"INFO","msg":"request completed","method":"GET","path":"/api/movies/latest","status":200,"duration_ms":12}` + "\n")
 
@@ -24,5 +23,13 @@ func BenchmarkRotatingWriterWrite(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+	// Close flushes the buffer and closes the file, so keep it out of the
+	// per-line measurement.
+	b.StopTimer()
+
+	err = w.Close()
+	if err != nil {
+		b.Fatal(err)
 	}
 }

--- a/server/cmd/internal/logger/logger_rotator_test.go
+++ b/server/cmd/internal/logger/logger_rotator_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestNewRotatingWriter(t *testing.T) {
 	t.Run("creates a new file", func(t *testing.T) {
-		rw, path := newTestWriter(t, 100, "")
+		rw, path := newTestWriter(t, 1024, "")
 
-		if rw.lines != 0 {
-			t.Errorf("lines = %d, want 0", rw.lines)
+		if rw.size != 0 {
+			t.Errorf("size = %d, want 0", rw.size)
 		}
 
-		if rw.maxLines != 100 {
-			t.Errorf("maxLines = %d, want 100", rw.maxLines)
+		if rw.maxBytes != 1024 {
+			t.Errorf("maxBytes = %d, want 1024", rw.maxBytes)
 		}
 
 		_, err := os.Stat(path)
@@ -27,67 +27,28 @@ func TestNewRotatingWriter(t *testing.T) {
 		}
 	})
 
-	t.Run("seeds the line count from an existing file", func(t *testing.T) {
-		rw, _ := newTestWriter(t, 100, "line1\nline2\nline3\nline4\nline5\n")
+	t.Run("seeds the size from an existing file", func(t *testing.T) {
+		seed := "line1\nline2\n"
+		rw, _ := newTestWriter(t, 1024, seed)
 
-		if rw.lines != 5 {
-			t.Errorf("lines = %d, want 5", rw.lines)
+		if rw.size != int64(len(seed)) {
+			t.Errorf("size = %d, want %d", rw.size, len(seed))
 		}
 	})
 
-	t.Run("rejects a non positive max line count", func(t *testing.T) {
+	t.Run("rejects a non positive byte cap", func(t *testing.T) {
 		_, err := newRotatingWriter(filepath.Join(t.TempDir(), "test.log"), 0)
 		if err == nil {
 			t.Fatal("expected an error")
 		}
 
-		if !strings.Contains(err.Error(), "max lines must be positive") {
-			t.Errorf("error = %v, want a max lines error", err)
+		if !strings.Contains(err.Error(), "max bytes must be positive") {
+			t.Errorf("error = %v, want a max bytes error", err)
 		}
 	})
 
 	t.Run("rejects an unopenable path", func(t *testing.T) {
-		_, err := newRotatingWriter(filepath.Join(t.TempDir(), "missing", "test.log"), 100)
-		if err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-}
-
-func TestCountLines(t *testing.T) {
-	tests := []struct {
-		name    string
-		content string
-		want    int
-	}{
-		{name: "empty file", content: "", want: 0},
-		{name: "newline terminated lines", content: "line1\nline2\nline3\n", want: 3},
-		{name: "unterminated final line", content: "line1\nline2", want: 2},
-		{name: "line longer than the read buffer", content: longLine() + "\nshort\n", want: 2},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			count, err := countLines(openSeededFile(t, tt.content))
-			if err != nil {
-				t.Fatalf("countLines: %v", err)
-			}
-
-			if count != tt.want {
-				t.Errorf("count = %d, want %d", count, tt.want)
-			}
-		})
-	}
-
-	t.Run("reports the seek failure for a closed file", func(t *testing.T) {
-		f := openSeededFile(t, "line1\n")
-
-		err := f.Close()
-		if err != nil {
-			t.Fatalf("close: %v", err)
-		}
-
-		_, err = countLines(f)
+		_, err := newRotatingWriter(filepath.Join(t.TempDir(), "missing", "test.log"), 1024)
 		if err == nil {
 			t.Fatal("expected an error")
 		}
@@ -96,7 +57,7 @@ func TestCountLines(t *testing.T) {
 
 func TestRotatingWriter_Write(t *testing.T) {
 	t.Run("reports the written byte count", func(t *testing.T) {
-		rw, _ := newTestWriter(t, 100, "")
+		rw, _ := newTestWriter(t, 1024, "")
 
 		entry := []byte("test log line\n")
 
@@ -109,194 +70,199 @@ func TestRotatingWriter_Write(t *testing.T) {
 			t.Errorf("n = %d, want %d", n, len(entry))
 		}
 
-		if rw.lines != 1 {
-			t.Errorf("lines = %d, want 1", rw.lines)
+		if rw.size != int64(len(entry)) {
+			t.Errorf("size = %d, want %d", rw.size, len(entry))
 		}
 	})
 
-	t.Run("counts one line per write", func(t *testing.T) {
-		rw, _ := newTestWriter(t, 100, "")
+	t.Run("entries reach the file after a flush", func(t *testing.T) {
+		rw, path := newTestWriter(t, 1024, "")
 
-		for i := 0; i < 10; i++ {
-			_, err := rw.Write([]byte("log line\n"))
-			if err != nil {
-				t.Fatalf("write %d: %v", i, err)
-			}
-		}
-
-		if rw.lines != 10 {
-			t.Errorf("lines = %d, want 10", rw.lines)
-		}
-	})
-
-	t.Run("flushes on every write", func(t *testing.T) {
-		rw, path := newTestWriter(t, 100, "")
-
-		_, err := rw.Write([]byte("persisted line\n"))
+		_, err := rw.Write([]byte("buffered line\n"))
 		if err != nil {
 			t.Fatalf("write: %v", err)
 		}
 
-		// Read while the writer is still open: entries have to survive a crash.
+		err = rw.Flush()
+		if err != nil {
+			t.Fatalf("flush: %v", err)
+		}
+
 		lines := readLogLines(t, path)
-		if len(lines) != 1 || lines[0] != "persisted line" {
-			t.Errorf("lines = %q, want [persisted line]", lines)
+		if len(lines) != 1 || lines[0] != "buffered line" {
+			t.Errorf("lines = %q, want [buffered line]", lines)
+		}
+	})
+
+	t.Run("entries reach the file on close", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.log")
+
+		rw, err := newRotatingWriter(path, 1024)
+		if err != nil {
+			t.Fatalf("create rotating writer: %v", err)
+		}
+
+		_, err = rw.Write([]byte("closed line\n"))
+		if err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		err = rw.Close()
+		if err != nil {
+			t.Fatalf("close: %v", err)
+		}
+
+		lines := readLogLines(t, path)
+		if len(lines) != 1 || lines[0] != "closed line" {
+			t.Errorf("lines = %q, want [closed line]", lines)
 		}
 	})
 }
 
 func TestRotatingWriter_Rotate(t *testing.T) {
-	t.Run("rotates once the max line count is reached", func(t *testing.T) {
-		maxLines := 10
-		rw, _ := newTestWriter(t, maxLines, "")
+	t.Run("rotates once the byte cap would be exceeded", func(t *testing.T) {
+		entry := []byte("0123456789\n")
+		rw, path := newTestWriter(t, int64(3*len(entry)), "")
 
-		for i := 0; i < maxLines; i++ {
-			_, err := rw.Write([]byte("line\n"))
+		for i := 0; i < 3; i++ {
+			_, err := rw.Write(entry)
 			if err != nil {
 				t.Fatalf("write %d: %v", i, err)
 			}
 		}
 
-		if rw.lines != maxLines {
-			t.Fatalf("lines = %d, want %d before the rotation trigger", rw.lines, maxLines)
-		}
-
-		_, err := rw.Write([]byte("trigger rotation\n"))
+		_, err := rw.Write([]byte("trigger\n"))
 		if err != nil {
 			t.Fatalf("rotation write: %v", err)
 		}
 
-		want := (maxLines / 2) + 1
-		if rw.lines != want {
-			t.Errorf("lines = %d, want %d after rotation", rw.lines, want)
+		err = rw.Flush()
+		if err != nil {
+			t.Fatalf("flush: %v", err)
+		}
+
+		lines := readLogLines(t, path)
+		if len(lines) != 1 || lines[0] != "trigger" {
+			t.Errorf("live file = %q, want only the post-rotation entry", lines)
+		}
+
+		rotated := readLogLines(t, path+".1")
+		if len(rotated) != 3 {
+			t.Errorf("rotated file holds %d lines, want the 3 pre-rotation entries", len(rotated))
 		}
 	})
 
-	t.Run("keeps the newest half", func(t *testing.T) {
-		maxLines := 6
-		rw, path := newTestWriter(t, maxLines, "")
+	t.Run("keeps at most two generations", func(t *testing.T) {
+		entry := []byte("aaaaaaaaa\n")
+		rw, path := newTestWriter(t, int64(2*len(entry)), "")
 
-		for i := 1; i <= maxLines; i++ {
-			_, err := rw.Write([]byte(strings.Repeat("x", i) + "\n"))
+		for i := 1; i <= 9; i++ {
+			_, err := rw.Write([]byte(fmt.Sprintf("line%04d0\n", i)))
 			if err != nil {
 				t.Fatalf("write %d: %v", i, err)
 			}
 		}
 
-		_, err := rw.Write([]byte("final\n"))
+		err := rw.Flush()
 		if err != nil {
-			t.Fatalf("final write: %v", err)
+			t.Fatalf("flush: %v", err)
 		}
 
-		want := []string{"xxxx", "xxxxx", "xxxxxx", "final"}
+		live := readLogLines(t, path)
+		rotated := readLogLines(t, path+".1")
 
-		lines := readLogLines(t, path)
-		if strings.Join(lines, "|") != strings.Join(want, "|") {
-			t.Errorf("lines = %q, want %q", lines, want)
+		if len(live)+len(rotated) != 3 {
+			t.Errorf("retained %d lines across generations, want 3", len(live)+len(rotated))
+		}
+
+		all := append(rotated, live...)
+		want := []string{"line00070", "line00080", "line00090"}
+		if strings.Join(all, "|") != strings.Join(want, "|") {
+			t.Errorf("retained = %q, want the newest entries %q", all, want)
+		}
+
+		_, err = os.Stat(path + ".2")
+		if !os.IsNotExist(err) {
+			t.Errorf("expected no third generation, stat err: %v", err)
 		}
 	})
 
-	t.Run("keeps a retained line longer than the read buffer", func(t *testing.T) {
-		long := longLine()
-		rw, path := newTestWriter(t, 3, "old\n"+long+"\nnewer\n")
+	t.Run("writes an entry larger than the cap without rotating first", func(t *testing.T) {
+		rw, path := newTestWriter(t, 8, "")
 
-		_, err := rw.Write([]byte("final\n"))
+		big := longLine() + "\n"
+		_, err := rw.Write([]byte(big))
 		if err != nil {
-			t.Fatalf("final write: %v", err)
+			t.Fatalf("oversized write: %v", err)
+		}
+
+		err = rw.Flush()
+		if err != nil {
+			t.Fatalf("flush: %v", err)
 		}
 
 		lines := readLogLines(t, path)
-		if len(lines) != 3 {
-			t.Fatalf("got %d lines, want 3", len(lines))
-		}
-
-		if lines[0] != long {
-			t.Errorf("expected the long line to be retained intact, got %d bytes", len(lines[0]))
-		}
-
-		if lines[1] != "newer" || lines[2] != "final" {
-			t.Errorf("lines = %q, want the newest entries last", lines[1:])
-		}
-	})
-
-	t.Run("rotates repeatedly", func(t *testing.T) {
-		rw, path := newTestWriter(t, 4, "")
-
-		for i := 1; i <= 12; i++ {
-			_, err := rw.Write([]byte(fmt.Sprintf("line%02d\n", i)))
-			if err != nil {
-				t.Fatalf("write %d: %v", i, err)
-			}
-		}
-
-		// Each rotation drops the oldest half, so three rotations leave the
-		// last four entries behind.
-		want := []string{"line09", "line10", "line11", "line12"}
-
-		lines := readLogLines(t, path)
-		if strings.Join(lines, "|") != strings.Join(want, "|") {
-			t.Errorf("lines = %q, want %q", lines, want)
-		}
-
-		if rw.lines != len(want) {
-			t.Errorf("lines counter = %d, want %d", rw.lines, len(want))
+		if len(lines) != 1 || lines[0] != longLine() {
+			t.Errorf("expected the oversized entry to be written whole")
 		}
 	})
 }
 
 func TestRotatingWriter_Close(t *testing.T) {
 	t.Run("closes a writer with no writes", func(t *testing.T) {
-		rw, _ := newTestWriter(t, 100, "")
+		path := filepath.Join(t.TempDir(), "test.log")
 
-		err := rw.Close()
+		rw, err := newRotatingWriter(path, 1024)
+		if err != nil {
+			t.Fatalf("create rotating writer: %v", err)
+		}
+
+		err = rw.Close()
 		if err != nil {
 			t.Errorf("close: %v", err)
 		}
 	})
 
-	t.Run("write after close reports the flush failure", func(t *testing.T) {
-		rw, _ := newTestWriter(t, 100, "")
+	t.Run("repeated close reports an error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.log")
 
-		err := rw.Close()
+		rw, err := newRotatingWriter(path, 1024)
 		if err != nil {
-			t.Fatalf("close: %v", err)
+			t.Fatalf("create rotating writer: %v", err)
 		}
 
-		_, err = rw.Write([]byte("after close\n"))
+		err = rw.Close()
+		if err != nil {
+			t.Fatalf("first close: %v", err)
+		}
+
+		err = rw.Close()
 		if err == nil {
-			t.Fatal("expected an error writing to a closed writer")
-		}
-
-		if strings.Contains(err.Error(), "failed to rotate log file") {
-			t.Errorf("error = %v, want a flush failure rather than a rotation failure", err)
-		}
-
-		// The buffered writer stays failed rather than quietly accepting more.
-		_, err = rw.Write([]byte("after close\n"))
-		if err == nil {
-			t.Error("expected the writer to keep reporting the failure")
-		}
-
-		if rw.lines != 0 {
-			t.Errorf("lines = %d, want failed writes not to be counted", rw.lines)
+			t.Error("expected an error on the second close")
 		}
 	})
 
-	t.Run("write after close reports the rotation failure", func(t *testing.T) {
-		rw, _ := newTestWriter(t, 2, "line1\nline2\n")
+	t.Run("write and flush after close report errors", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.log")
 
-		err := rw.Close()
+		rw, err := newRotatingWriter(path, 1024)
+		if err != nil {
+			t.Fatalf("create rotating writer: %v", err)
+		}
+
+		err = rw.Close()
 		if err != nil {
 			t.Fatalf("close: %v", err)
 		}
 
 		_, err = rw.Write([]byte("after close\n"))
 		if err == nil {
-			t.Fatal("expected an error writing to a closed writer")
+			t.Error("expected an error writing to a closed writer")
 		}
 
-		if !strings.Contains(err.Error(), "failed to rotate log file") {
-			t.Errorf("error = %v, want a rotation failure", err)
+		err = rw.Flush()
+		if err == nil {
+			t.Error("expected an error flushing a closed writer")
 		}
 	})
 }
@@ -305,10 +271,12 @@ func TestRotatingWriter_ConcurrentWrites(t *testing.T) {
 	const (
 		goroutines = 5
 		perRoutine = 20
-		maxLines   = 20
 	)
 
-	rw, path := newTestWriter(t, maxLines, "")
+	entry := "concurrent write\n"
+	maxBytes := int64(20 * len(entry))
+
+	rw, path := newTestWriter(t, maxBytes, "")
 
 	errs := make(chan error, goroutines*perRoutine)
 	var wg sync.WaitGroup
@@ -320,7 +288,7 @@ func TestRotatingWriter_ConcurrentWrites(t *testing.T) {
 			defer wg.Done()
 
 			for j := 0; j < perRoutine; j++ {
-				_, err := rw.Write([]byte("concurrent write\n"))
+				_, err := rw.Write([]byte(entry))
 				if err != nil {
 					errs <- err
 				}
@@ -335,14 +303,23 @@ func TestRotatingWriter_ConcurrentWrites(t *testing.T) {
 		t.Errorf("concurrent write: %v", err)
 	}
 
-	// Interleaving changes nothing observable: the counter has to keep matching
-	// the file, and rotation has to keep the file inside its bounds.
-	lines := readLogLines(t, path)
-	if rw.lines != len(lines) {
-		t.Errorf("lines counter = %d, but the file holds %d lines", rw.lines, len(lines))
+	err := rw.Flush()
+	if err != nil {
+		t.Fatalf("flush: %v", err)
 	}
 
-	if rw.lines <= maxLines/2 || rw.lines > maxLines {
-		t.Errorf("lines = %d, want it within (%d, %d]", rw.lines, maxLines/2, maxLines)
+	// Interleaving changes nothing observable: both generations stay inside
+	// the byte cap and the live file matches the size counter.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat live log: %v", err)
+	}
+
+	if info.Size() != rw.size {
+		t.Errorf("size counter = %d, but the file holds %d bytes", rw.size, info.Size())
+	}
+
+	if info.Size() > maxBytes {
+		t.Errorf("live file = %d bytes, want it within the %d byte cap", info.Size(), maxBytes)
 	}
 }

--- a/server/cmd/internal/logger/test_helpers_test.go
+++ b/server/cmd/internal/logger/test_helpers_test.go
@@ -10,7 +10,7 @@ import (
 
 // newTestWriter creates a rotatingWriter over a temp file, seeding the file
 // first when seed is not empty.
-func newTestWriter(t *testing.T, maxLines int, seed string) (*rotatingWriter, string) {
+func newTestWriter(t *testing.T, maxBytes int64, seed string) (*rotatingWriter, string) {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "test.log")
@@ -22,7 +22,7 @@ func newTestWriter(t *testing.T, maxLines int, seed string) (*rotatingWriter, st
 		}
 	}
 
-	rw, err := newRotatingWriter(path, maxLines)
+	rw, err := newRotatingWriter(path, maxBytes)
 	if err != nil {
 		t.Fatalf("create rotating writer: %v", err)
 	}
@@ -32,29 +32,6 @@ func newTestWriter(t *testing.T, maxLines int, seed string) (*rotatingWriter, st
 	})
 
 	return rw, path
-}
-
-// openSeededFile writes content to a temp file and returns it open for reading.
-func openSeededFile(t *testing.T, content string) *os.File {
-	t.Helper()
-
-	path := filepath.Join(t.TempDir(), "seeded.log")
-
-	err := os.WriteFile(path, []byte(content), 0o644)
-	if err != nil {
-		t.Fatalf("write seeded file: %v", err)
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open seeded file: %v", err)
-	}
-
-	t.Cleanup(func() {
-		f.Close()
-	})
-
-	return f
 }
 
 // writeRegularFile creates a regular file and returns its path, for the cases

--- a/server/cmd/internal/mediabin/mediabin.go
+++ b/server/cmd/internal/mediabin/mediabin.go
@@ -1,7 +1,10 @@
 package mediabin
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,9 +23,20 @@ func ResolveExternal(binaryName, envVar string) (string, error) {
 	return path, nil
 }
 
+// ExtractEmbedded materializes an embedded binary on disk and returns its
+// path plus a cleanup directory for CleanupExtracted. It reuses a per-version
+// cache so the payload is written once per release instead of on every boot;
+// cached binaries return an empty cleanup directory so shutdown leaves them
+// in place. Falls back to a fresh temp-dir extraction when no cache
+// directory is available.
 func ExtractEmbedded(binaryName string, payload []byte) (string, string, error) {
 	if len(payload) == 0 {
 		return "", "", fmt.Errorf("%s binary is missing: embedded payload is empty (binary was not included at compile time)", binaryName)
+	}
+
+	binPath, err := extractToCache(binaryName, payload)
+	if err == nil {
+		return binPath, "", nil
 	}
 
 	tempDir, err := os.MkdirTemp("", "igloo-"+binaryName+"-*")
@@ -30,13 +44,95 @@ func ExtractEmbedded(binaryName string, payload []byte) (string, string, error) 
 		return "", "", fmt.Errorf("failed to create temp directory: %w", err)
 	}
 
-	binPath := filepath.Join(tempDir, binaryName)
+	binPath = filepath.Join(tempDir, binaryName)
 	if err := os.WriteFile(binPath, payload, 0755); err != nil {
 		os.RemoveAll(tempDir)
 		return "", "", fmt.Errorf("failed to write %s binary: %w", binaryName, err)
 	}
 
 	return binPath, tempDir, nil
+}
+
+// extractToCache writes the payload to a hash-keyed cache path, reusing an
+// existing file when its content hash matches. The hash check means a
+// corrupted or tampered cache entry is silently rewritten rather than
+// executed, and the write-to-temp-then-rename keeps the final path atomic.
+func extractToCache(binaryName string, payload []byte) (string, error) {
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		cacheRoot = os.TempDir()
+	}
+
+	sum := sha256.Sum256(payload)
+	digest := hex.EncodeToString(sum[:])
+	dir := filepath.Join(cacheRoot, "igloo", "bin", binaryName+"-"+digest[:16])
+	binPath := filepath.Join(dir, binaryName)
+
+	if cachedFileMatches(binPath, sum) {
+		return binPath, nil
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, binaryName+"-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create cache temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	_, writeErr := tmp.Write(payload)
+	chmodErr := tmp.Chmod(0o755)
+	closeErr := tmp.Close()
+	for _, err := range []error{writeErr, chmodErr, closeErr} {
+		if err != nil {
+			os.Remove(tmpPath)
+			return "", fmt.Errorf("failed to write cached %s binary: %w", binaryName, err)
+		}
+	}
+
+	if err := os.Rename(tmpPath, binPath); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to move cached %s binary in place: %w", binaryName, err)
+	}
+
+	pruneStaleCacheEntries(filepath.Dir(dir), binaryName, filepath.Base(dir))
+
+	return binPath, nil
+}
+
+// cachedFileMatches streams the cached file through sha256 and compares it
+// to the embedded payload's hash.
+func cachedFileMatches(binPath string, sum [sha256.Size]byte) bool {
+	f, err := os.Open(binPath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	_, err = io.Copy(h, f)
+	if err != nil {
+		return false
+	}
+	return [sha256.Size]byte(h.Sum(nil)) == sum
+}
+
+// pruneStaleCacheEntries removes cached extractions of older releases of the
+// same binary so upgrades do not accumulate 100MB+ payloads.
+func pruneStaleCacheEntries(binRoot, binaryName, keep string) {
+	entries, err := os.ReadDir(binRoot)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || name == keep || !strings.HasPrefix(name, binaryName+"-") {
+			continue
+		}
+		os.RemoveAll(filepath.Join(binRoot, name))
+	}
 }
 
 func CleanupExtracted(binaryName, dir string) error {

--- a/server/cmd/internal/mediabin/mediabin.go
+++ b/server/cmd/internal/mediabin/mediabin.go
@@ -1,6 +1,7 @@
 package mediabin
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 func ResolveExternal(binaryName, envVar string) (string, error) {
@@ -23,18 +26,18 @@ func ResolveExternal(binaryName, envVar string) (string, error) {
 	return path, nil
 }
 
-// ExtractEmbedded materializes an embedded binary on disk and returns its
-// path plus a cleanup directory for CleanupExtracted. It reuses a per-version
-// cache so the payload is written once per release instead of on every boot;
-// cached binaries return an empty cleanup directory so shutdown leaves them
-// in place. Falls back to a fresh temp-dir extraction when no cache
-// directory is available.
-func ExtractEmbedded(binaryName string, payload []byte) (string, string, error) {
-	if len(payload) == 0 {
+// ExtractEmbeddedZstd materializes a zstd-compressed embedded binary on disk
+// and returns its path plus a cleanup directory for CleanupExtracted. It
+// reuses a per-version cache so the payload is decompressed once per release
+// instead of on every boot; cached binaries return an empty cleanup directory
+// so shutdown leaves them in place. Falls back to a fresh temp-dir extraction
+// when no cache directory is available.
+func ExtractEmbeddedZstd(binaryName string, compressed []byte) (string, string, error) {
+	if len(compressed) == 0 {
 		return "", "", fmt.Errorf("%s binary is missing: embedded payload is empty (binary was not included at compile time)", binaryName)
 	}
 
-	binPath, err := extractToCache(binaryName, payload)
+	binPath, err := extractToCache(binaryName, compressed)
 	if err == nil {
 		return binPath, "", nil
 	}
@@ -45,7 +48,8 @@ func ExtractEmbedded(binaryName string, payload []byte) (string, string, error) 
 	}
 
 	binPath = filepath.Join(tempDir, binaryName)
-	if err := os.WriteFile(binPath, payload, 0755); err != nil {
+	err = decompressToFile(binPath, compressed, io.Discard)
+	if err != nil {
 		os.RemoveAll(tempDir)
 		return "", "", fmt.Errorf("failed to write %s binary: %w", binaryName, err)
 	}
@@ -53,22 +57,24 @@ func ExtractEmbedded(binaryName string, payload []byte) (string, string, error) 
 	return binPath, tempDir, nil
 }
 
-// extractToCache writes the payload to a hash-keyed cache path, reusing an
-// existing file when its content hash matches. The hash check means a
+// extractToCache decompresses the payload to a cache path keyed by the
+// compressed payload's hash. A sidecar .sha256 marker records the hash of
+// the decompressed binary; reuse requires the on-disk file to match it, so a
 // corrupted or tampered cache entry is silently rewritten rather than
-// executed, and the write-to-temp-then-rename keeps the final path atomic.
-func extractToCache(binaryName string, payload []byte) (string, error) {
+// executed. Write-to-temp-then-rename keeps the final paths atomic.
+func extractToCache(binaryName string, compressed []byte) (string, error) {
 	cacheRoot, err := os.UserCacheDir()
 	if err != nil {
 		cacheRoot = os.TempDir()
 	}
 
-	sum := sha256.Sum256(payload)
-	digest := hex.EncodeToString(sum[:])
-	dir := filepath.Join(cacheRoot, "igloo", "bin", binaryName+"-"+digest[:16])
+	key := sha256.Sum256(compressed)
+	dir := filepath.Join(cacheRoot, "igloo", "bin", binaryName+"-"+hex.EncodeToString(key[:])[:16])
 	binPath := filepath.Join(dir, binaryName)
+	markerPath := binPath + ".sha256"
 
-	if cachedFileMatches(binPath, sum) {
+	marker, err := os.ReadFile(markerPath)
+	if err == nil && fileSHA256(binPath) == strings.TrimSpace(string(marker)) {
 		return binPath, nil
 	}
 
@@ -81,15 +87,13 @@ func extractToCache(binaryName string, payload []byte) (string, error) {
 		return "", fmt.Errorf("failed to create cache temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
+	tmp.Close()
 
-	_, writeErr := tmp.Write(payload)
-	chmodErr := tmp.Chmod(0o755)
-	closeErr := tmp.Close()
-	for _, err := range []error{writeErr, chmodErr, closeErr} {
-		if err != nil {
-			os.Remove(tmpPath)
-			return "", fmt.Errorf("failed to write cached %s binary: %w", binaryName, err)
-		}
+	digest := sha256.New()
+	err = decompressToFile(tmpPath, compressed, digest)
+	if err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to write cached %s binary: %w", binaryName, err)
 	}
 
 	if err := os.Rename(tmpPath, binPath); err != nil {
@@ -97,26 +101,81 @@ func extractToCache(binaryName string, payload []byte) (string, error) {
 		return "", fmt.Errorf("failed to move cached %s binary in place: %w", binaryName, err)
 	}
 
+	err = writeFileAtomic(markerPath, []byte(hex.EncodeToString(digest.Sum(nil))))
+	if err != nil {
+		return "", fmt.Errorf("failed to write cache marker for %s: %w", binaryName, err)
+	}
+
 	pruneStaleCacheEntries(filepath.Dir(dir), binaryName, filepath.Base(dir))
 
 	return binPath, nil
 }
 
-// cachedFileMatches streams the cached file through sha256 and compares it
-// to the embedded payload's hash.
-func cachedFileMatches(binPath string, sum [sha256.Size]byte) bool {
-	f, err := os.Open(binPath)
+// decompressToFile streams the zstd payload into path (mode 0755), teeing
+// the decompressed bytes into digest.
+func decompressToFile(path string, compressed []byte, digest io.Writer) error {
+	reader, err := zstd.NewReader(bytes.NewReader(compressed))
 	if err != nil {
-		return false
+		return fmt.Errorf("failed to open zstd payload: %w", err)
+	}
+	defer reader.Close()
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+
+	_, copyErr := reader.WriteTo(io.MultiWriter(f, digest))
+	// O_CREATE's mode is ignored when the file pre-exists (the cache path
+	// hands us an os.CreateTemp file), so set it explicitly.
+	chmodErr := f.Chmod(0o755)
+	closeErr := f.Close()
+	for _, err := range []error{copyErr, chmodErr, closeErr} {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFileAtomic(path string, content []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+"-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	_, writeErr := tmp.Write(content)
+	closeErr := tmp.Close()
+	for _, err := range []error{writeErr, closeErr} {
+		if err != nil {
+			os.Remove(tmpPath)
+			return err
+		}
+	}
+
+	err = os.Rename(tmpPath, path)
+	if err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// fileSHA256 returns the hex sha256 of the file, or "" when unreadable.
+func fileSHA256(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
 	}
 	defer f.Close()
 
 	h := sha256.New()
 	_, err = io.Copy(h, f)
 	if err != nil {
-		return false
+		return ""
 	}
-	return [sha256.Size]byte(h.Sum(nil)) == sum
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // pruneStaleCacheEntries removes cached extractions of older releases of the

--- a/server/cmd/internal/mediabin/mediabin.go
+++ b/server/cmd/internal/mediabin/mediabin.go
@@ -62,10 +62,16 @@ func ExtractEmbeddedZstd(binaryName string, compressed []byte) (string, string, 
 // the decompressed binary; reuse requires the on-disk file to match it, so a
 // corrupted or tampered cache entry is silently rewritten rather than
 // executed. Write-to-temp-then-rename keeps the final paths atomic.
+//
+// A missing user cache directory is an error, never a fall back to
+// os.TempDir(): the cache holds executables at a path derived only from the
+// payload hash, so on a shared temp dir a local attacker could pre-create the
+// binary and a matching marker and have it pass the digest check and run. The
+// caller falls back to a randomized temp dir instead.
 func extractToCache(binaryName string, compressed []byte) (string, error) {
 	cacheRoot, err := os.UserCacheDir()
 	if err != nil {
-		cacheRoot = os.TempDir()
+		return "", fmt.Errorf("no user cache directory available: %w", err)
 	}
 
 	key := sha256.Sum256(compressed)

--- a/server/cmd/internal/mediabin/mediabin.go
+++ b/server/cmd/internal/mediabin/mediabin.go
@@ -61,7 +61,9 @@ func ExtractEmbeddedZstd(binaryName string, compressed []byte) (string, string, 
 // compressed payload's hash. A sidecar .sha256 marker records the hash of
 // the decompressed binary; reuse requires the on-disk file to match it, so a
 // corrupted or tampered cache entry is silently rewritten rather than
-// executed. Write-to-temp-then-rename keeps the final paths atomic.
+// executed. A truncated marker or an unreadable binary is likewise a miss —
+// neither may satisfy the digest check by comparing empty strings.
+// Write-to-temp-then-rename keeps the final paths atomic.
 //
 // A missing user cache directory is an error, never a fall back to
 // os.TempDir(): the cache holds executables at a path derived only from the
@@ -80,8 +82,17 @@ func extractToCache(binaryName string, compressed []byte) (string, error) {
 	markerPath := binPath + ".sha256"
 
 	marker, err := os.ReadFile(markerPath)
-	if err == nil && fileSHA256(binPath) == strings.TrimSpace(string(marker)) {
-		return binPath, nil
+	if err == nil {
+		want := strings.TrimSpace(string(marker))
+
+		// A truncated marker holds no digest to check the binary against, so
+		// treat it as a miss instead of comparing two empty strings.
+		if want != "" {
+			got, err := fileSHA256(binPath)
+			if err == nil && got == want {
+				return binPath, nil
+			}
+		}
 	}
 
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -168,20 +179,22 @@ func writeFileAtomic(path string, content []byte) error {
 	return nil
 }
 
-// fileSHA256 returns the hex sha256 of the file, or "" when unreadable.
-func fileSHA256(path string) string {
+// fileSHA256 hashes the file at path. It reports the read error rather than an
+// empty digest: an empty string would compare equal to an empty .sha256 marker
+// and validate a binary that could not be read at all.
+func fileSHA256(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer f.Close()
 
 	h := sha256.New()
 	_, err = io.Copy(h, f)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // pruneStaleCacheEntries removes cached extractions of older releases of the

--- a/server/cmd/internal/mediabin/mediabin_test.go
+++ b/server/cmd/internal/mediabin/mediabin_test.go
@@ -132,6 +132,54 @@ func TestExtractEmbeddedZstdPrunesOldVersions(t *testing.T) {
 	}
 }
 
+// Without a user cache directory the extraction must land in a randomized
+// temp dir, never in a predictable path under the shared os.TempDir(): the
+// cache path is derived only from the payload hash, so a shared-temp cache
+// could be pre-seeded by a local attacker with a matching .sha256 marker and
+// would then pass the digest check and be executed.
+func TestExtractEmbeddedZstdFallsBackToTempDirWithoutCacheDir(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", "")
+
+	_, err := os.UserCacheDir()
+	if err == nil {
+		t.Skip("this platform still resolves a user cache directory without HOME")
+	}
+
+	payload := []byte("fake-binary-payload")
+
+	binPath, cleanupDir, err := ExtractEmbeddedZstd("fakebin", zstdCompress(t, payload))
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	if cleanupDir == "" {
+		t.Fatal("temp-dir extraction must return a cleanup dir")
+	}
+	if filepath.Dir(binPath) != cleanupDir {
+		t.Fatalf("expected %q inside the cleanup dir %q", binPath, cleanupDir)
+	}
+
+	content, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("extracted binary missing: %v", err)
+	}
+	if string(content) != string(payload) {
+		t.Fatal("extracted binary does not match the decompressed payload")
+	}
+
+	_, err = os.Stat(filepath.Join(tempRoot, "igloo", "bin"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected no shared-temp cache directory, stat err: %v", err)
+	}
+
+	err = CleanupExtracted("fakebin", cleanupDir)
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+}
+
 func TestExtractEmbeddedZstdRejectsEmptyPayload(t *testing.T) {
 	_, _, err := ExtractEmbeddedZstd("fakebin", nil)
 	if err == nil {

--- a/server/cmd/internal/mediabin/mediabin_test.go
+++ b/server/cmd/internal/mediabin/mediabin_test.go
@@ -109,6 +109,43 @@ func TestExtractEmbeddedZstdRewritesCorruptedCacheEntry(t *testing.T) {
 	}
 }
 
+// An empty marker holds no digest, and hashing a missing binary used to yield
+// an empty string too — so the cache check compared "" to "" and handed back a
+// path with no binary at it.
+func TestExtractEmbeddedZstdRewritesEntryWithEmptyMarker(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	payload := []byte("fake-binary-payload")
+	compressed := zstdCompress(t, payload)
+
+	binPath, _, err := ExtractEmbeddedZstd("fakebin", compressed)
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+
+	err = os.WriteFile(binPath+".sha256", []byte("  \n"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to truncate cache marker: %v", err)
+	}
+	err = os.Remove(binPath)
+	if err != nil {
+		t.Fatalf("failed to remove cached binary: %v", err)
+	}
+
+	binPath, _, err = ExtractEmbeddedZstd("fakebin", compressed)
+	if err != nil {
+		t.Fatalf("re-extract failed: %v", err)
+	}
+
+	restored, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("failed to read restored binary: %v", err)
+	}
+	if string(restored) != string(payload) {
+		t.Fatal("empty marker was accepted as a cache hit instead of re-extracting")
+	}
+}
+
 func TestExtractEmbeddedZstdPrunesOldVersions(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 

--- a/server/cmd/internal/mediabin/mediabin_test.go
+++ b/server/cmd/internal/mediabin/mediabin_test.go
@@ -1,0 +1,109 @@
+package mediabin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractEmbeddedUsesCacheAcrossCalls(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	payload := []byte("fake-binary-payload")
+
+	firstPath, firstDir, err := ExtractEmbedded("fakebin", payload)
+	if err != nil {
+		t.Fatalf("first extract failed: %v", err)
+	}
+	if firstDir != "" {
+		t.Fatalf("cached extraction should return an empty cleanup dir, got %q", firstDir)
+	}
+
+	info, err := os.Stat(firstPath)
+	if err != nil {
+		t.Fatalf("extracted binary missing: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("expected mode 0755, got %v", info.Mode().Perm())
+	}
+
+	firstModTime := info.ModTime()
+
+	secondPath, secondDir, err := ExtractEmbedded("fakebin", payload)
+	if err != nil {
+		t.Fatalf("second extract failed: %v", err)
+	}
+	if secondPath != firstPath {
+		t.Fatalf("expected cache reuse of %q, got %q", firstPath, secondPath)
+	}
+	if secondDir != "" {
+		t.Fatalf("cached extraction should return an empty cleanup dir, got %q", secondDir)
+	}
+
+	info, err = os.Stat(secondPath)
+	if err != nil {
+		t.Fatalf("cached binary missing after reuse: %v", err)
+	}
+	if !info.ModTime().Equal(firstModTime) {
+		t.Fatal("cached binary was rewritten on reuse")
+	}
+}
+
+func TestExtractEmbeddedRewritesCorruptedCacheEntry(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	payload := []byte("fake-binary-payload")
+
+	binPath, _, err := ExtractEmbedded("fakebin", payload)
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+
+	err = os.WriteFile(binPath, []byte("tampered"), 0o755)
+	if err != nil {
+		t.Fatalf("failed to corrupt cache entry: %v", err)
+	}
+
+	binPath, _, err = ExtractEmbedded("fakebin", payload)
+	if err != nil {
+		t.Fatalf("re-extract failed: %v", err)
+	}
+
+	restored, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("failed to read restored binary: %v", err)
+	}
+	if string(restored) != string(payload) {
+		t.Fatal("corrupted cache entry was not rewritten from the payload")
+	}
+}
+
+func TestExtractEmbeddedPrunesOldVersions(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	oldPath, _, err := ExtractEmbedded("fakebin", []byte("version-one"))
+	if err != nil {
+		t.Fatalf("extract of old version failed: %v", err)
+	}
+
+	newPath, _, err := ExtractEmbedded("fakebin", []byte("version-two"))
+	if err != nil {
+		t.Fatalf("extract of new version failed: %v", err)
+	}
+
+	_, err = os.Stat(filepath.Dir(oldPath))
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected old version dir to be pruned, stat err: %v", err)
+	}
+	_, err = os.Stat(newPath)
+	if err != nil {
+		t.Fatalf("new version missing after prune: %v", err)
+	}
+}
+
+func TestExtractEmbeddedRejectsEmptyPayload(t *testing.T) {
+	_, _, err := ExtractEmbedded("fakebin", nil)
+	if err == nil {
+		t.Fatal("expected error for empty payload")
+	}
+}

--- a/server/cmd/internal/mediabin/mediabin_test.go
+++ b/server/cmd/internal/mediabin/mediabin_test.go
@@ -1,17 +1,39 @@
 package mediabin
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
 )
 
-func TestExtractEmbeddedUsesCacheAcrossCalls(t *testing.T) {
+func zstdCompress(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("failed to create zstd writer: %v", err)
+	}
+	_, err = w.Write(payload)
+	if err != nil {
+		t.Fatalf("failed to compress payload: %v", err)
+	}
+	err = w.Close()
+	if err != nil {
+		t.Fatalf("failed to close zstd writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractEmbeddedZstdUsesCacheAcrossCalls(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
 	payload := []byte("fake-binary-payload")
+	compressed := zstdCompress(t, payload)
 
-	firstPath, firstDir, err := ExtractEmbedded("fakebin", payload)
+	firstPath, firstDir, err := ExtractEmbeddedZstd("fakebin", compressed)
 	if err != nil {
 		t.Fatalf("first extract failed: %v", err)
 	}
@@ -19,9 +41,17 @@ func TestExtractEmbeddedUsesCacheAcrossCalls(t *testing.T) {
 		t.Fatalf("cached extraction should return an empty cleanup dir, got %q", firstDir)
 	}
 
-	info, err := os.Stat(firstPath)
+	content, err := os.ReadFile(firstPath)
 	if err != nil {
 		t.Fatalf("extracted binary missing: %v", err)
+	}
+	if string(content) != string(payload) {
+		t.Fatal("extracted binary does not match the decompressed payload")
+	}
+
+	info, err := os.Stat(firstPath)
+	if err != nil {
+		t.Fatalf("failed to stat extracted binary: %v", err)
 	}
 	if info.Mode().Perm() != 0o755 {
 		t.Fatalf("expected mode 0755, got %v", info.Mode().Perm())
@@ -29,7 +59,7 @@ func TestExtractEmbeddedUsesCacheAcrossCalls(t *testing.T) {
 
 	firstModTime := info.ModTime()
 
-	secondPath, secondDir, err := ExtractEmbedded("fakebin", payload)
+	secondPath, secondDir, err := ExtractEmbeddedZstd("fakebin", compressed)
 	if err != nil {
 		t.Fatalf("second extract failed: %v", err)
 	}
@@ -49,12 +79,13 @@ func TestExtractEmbeddedUsesCacheAcrossCalls(t *testing.T) {
 	}
 }
 
-func TestExtractEmbeddedRewritesCorruptedCacheEntry(t *testing.T) {
+func TestExtractEmbeddedZstdRewritesCorruptedCacheEntry(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
 	payload := []byte("fake-binary-payload")
+	compressed := zstdCompress(t, payload)
 
-	binPath, _, err := ExtractEmbedded("fakebin", payload)
+	binPath, _, err := ExtractEmbeddedZstd("fakebin", compressed)
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)
 	}
@@ -64,7 +95,7 @@ func TestExtractEmbeddedRewritesCorruptedCacheEntry(t *testing.T) {
 		t.Fatalf("failed to corrupt cache entry: %v", err)
 	}
 
-	binPath, _, err = ExtractEmbedded("fakebin", payload)
+	binPath, _, err = ExtractEmbeddedZstd("fakebin", compressed)
 	if err != nil {
 		t.Fatalf("re-extract failed: %v", err)
 	}
@@ -78,15 +109,15 @@ func TestExtractEmbeddedRewritesCorruptedCacheEntry(t *testing.T) {
 	}
 }
 
-func TestExtractEmbeddedPrunesOldVersions(t *testing.T) {
+func TestExtractEmbeddedZstdPrunesOldVersions(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
-	oldPath, _, err := ExtractEmbedded("fakebin", []byte("version-one"))
+	oldPath, _, err := ExtractEmbeddedZstd("fakebin", zstdCompress(t, []byte("version-one")))
 	if err != nil {
 		t.Fatalf("extract of old version failed: %v", err)
 	}
 
-	newPath, _, err := ExtractEmbedded("fakebin", []byte("version-two"))
+	newPath, _, err := ExtractEmbeddedZstd("fakebin", zstdCompress(t, []byte("version-two")))
 	if err != nil {
 		t.Fatalf("extract of new version failed: %v", err)
 	}
@@ -101,9 +132,18 @@ func TestExtractEmbeddedPrunesOldVersions(t *testing.T) {
 	}
 }
 
-func TestExtractEmbeddedRejectsEmptyPayload(t *testing.T) {
-	_, _, err := ExtractEmbedded("fakebin", nil)
+func TestExtractEmbeddedZstdRejectsEmptyPayload(t *testing.T) {
+	_, _, err := ExtractEmbeddedZstd("fakebin", nil)
 	if err == nil {
 		t.Fatal("expected error for empty payload")
+	}
+}
+
+func TestExtractEmbeddedZstdRejectsGarbagePayload(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	_, _, err := ExtractEmbeddedZstd("fakebin", []byte("not-zstd-data"))
+	if err == nil {
+		t.Fatal("expected error for non-zstd payload")
 	}
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/getkin/kin-openapi v0.145.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/gorilla/websocket v1.5.3
+	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/zmb3/spotify/v2 v2.4.3

--- a/server/go.sum
+++ b/server/go.sum
@@ -123,6 +123,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
## Summary

First server performance pass: build the measurement infrastructure, capture a baseline against the real library, then ship only the optimizations the measurements justified. Full numbers in `scripts/perf/results/baseline-2026-08-13.md`.

### Measured results

| Change | Before | After |
|---|---|---|
| Release binary (zstd-embedded ffmpeg/ffprobe, `-trimpath`) | 230 MB | **78.8 MB** (−66%) |
| Boot payload writes (hash-keyed extract-once cache) | 214 MB every boot | once per release, then 4 KB |
| Logger write path (buffering + O(1) rename rotation) | 22.4 µs/line + full-file rewrite every ~500 lines | **214 ns/line** |
| SPA asset serving (cached map, ETag/304) | 3 ms + 735 KB allocs/request | **7.3 µs + 12 KB**, conditional requests |
| `http.Server` | no timeouts | ReadHeaderTimeout 5 s + IdleTimeout 120 s (no WriteTimeout — streaming) |
| ReorderPlaylistTracks | one commit per track | single transaction |

### Measurement infrastructure

- Admin-gated pprof under `/api/debug/pprof`, compiled only with the new `pprofdebug` tag (`make dev-profile`)
- `scripts/perf/`: k6 scenarios (browse / HLS / direct-stream, real player contract), `/proc` RSS/CPU/write sampler, baseline orchestrator + protocol README
- Go benchmarks for the logger, search-vocab BK-tree, and SPA asset path
- Committed baseline (idle/browse/streaming/scan/startup) — headline finding: HLS cold time-to-first-segment is 5.9 s for one stream and 28–50 s for concurrent streams behind the 2-slot transcode limiter. That fix is high-risk playback code and intentionally deferred to its own PR per `docs/ffmpeg.md`.

### Measured and rejected (documented in the results file)

- **SQLite pool > 1**: implemented and A/B-benchmarked; lost to the pinned single connection both uncontended and badly under write contention (busy-timeout polling vs FIFO handoff). Reverted, findings recorded.
- Startup items (probe cache, conditional boot scans, schema/prepare cost): all measured too small to justify code risk; the 14.5 s dev-boot InitDirs was a cold Samba mount.

### Verification

- `make check` green after every commit; no route changes (`make test-openapi` covered via `make check`)
- Release build booted twice (cold + warm payload cache) with HLS transcode, direct-play range requests, SPA serving, and library scan verified live
- Logger race-detector clean; SPA handler verified live for ETag/304/fallback/404 and the dev Vite redirect
- Write-contention stress (sustained watch-progress writes + browse + active transcode): 0 failures

No functional changes intended anywhere; every optimization preserves existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved frontend asset delivery with caching and conditional responses.
  * Reduced packaged media tool size and improved repeated startup efficiency.
  * Added performance baseline and streaming soak-testing tools.

* **Reliability**
  * Playlist track reordering now updates consistently as a single operation.
  * Added safer HTTP connection and request handling timeouts.
  * Improved log rotation and flushing for more dependable diagnostics.

* **Administration**
  * Added optional, administrator-protected runtime profiling endpoints for development diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->