### PR TITLE
Show certification on the in-theaters movie details page

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -264,6 +264,24 @@ stamps `data-variant`/`data-size`.
   icons/images get `aria-hidden="true"`/`alt=""`; cards carry a full
   `aria-label` ("Play Uncut Gems 2019"); toggles use `aria-pressed`; nav uses
   `aria-current`; sections use `role="region" aria-labelledby`.
+- **`aria-label` only where the role supports it**: `aria-label` names elements
+  whose role accepts a name from the author — buttons, links, inputs, `role="list"`,
+  regions, dialogs. It does **not** reliably name `<li>` (`role="listitem"`),
+  `<time>`, or plain `<span>`/`<div>`; browsers and screen readers inconsistently
+  ignore it there. For those, put the spoken text *in the content* as an `sr-only`
+  span and mark the visually-formatted value `aria-hidden="true"`
+  (`MovieDetailsMetadataChips` pattern):
+
+  ```tsx
+  <li>
+    <Star aria-hidden="true" />
+    <span className="sr-only">Critic rating: 8.5 out of 10</span>
+    <span aria-hidden="true">8.5</span>
+  </li>
+  ```
+
+  Never leave a non-interactive element whose only content is `aria-hidden` —
+  assistive tech lands on an empty node.
 
 ---
 

--- a/web/e2e/movie-details.spec.ts
+++ b/web/e2e/movie-details.spec.ts
@@ -424,7 +424,8 @@ test("movie details page renders the mocked success path from the movies index",
   await expect(metadataRow).toContainText("PG-13");
   await expect(metadataRow).toContainText("2 hr 6 min");
   await expect(metadataRow).toContainText("July 4, 2024");
-  const runtime = metadataRow.getByLabel("Runtime: 2 hours 6 minutes");
+  await expect(metadataRow).toContainText("Runtime: 2 hours 6 minutes");
+  const runtime = metadataRow.locator('time[datetime="PT126M"]');
   await expect(runtime).toHaveAttribute("datetime", "PT126M");
 
   const playLink = page.getByRole("link", { name: "Play" });

--- a/web/src/components/movies/MovieDetailsMetadataChips.tsx
+++ b/web/src/components/movies/MovieDetailsMetadataChips.tsx
@@ -34,11 +34,14 @@ export default function MovieDetailsMetadataChips({
       aria-label="Movie details"
     >
       {tmdbVoteAverage != null && tmdbVoteAverage > 0 && (
-        <li
-          aria-label={`TMDB user score: ${tmdbVoteAverage.toFixed(1)} out of 10`}
-        >
+        <li>
           <Badge variant="outline" className={OVER_MEDIA_BADGE_CLASS}>
-            <span className="text-white/70">TMDB</span>
+            <span className="sr-only">
+              {`TMDB user score: ${tmdbVoteAverage.toFixed(1)} out of 10`}
+            </span>
+            <span aria-hidden="true" className="text-white/70">
+              TMDB
+            </span>
             <span aria-hidden="true" className="font-semibold">
               {tmdbVoteAverage.toFixed(1)}
             </span>
@@ -48,37 +51,43 @@ export default function MovieDetailsMetadataChips({
       {criticRating != null && criticRating > 0 && (
         <li
           className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 font-bold ${criticRatingClass(criticRating)}`}
-          aria-label={`Critic rating: ${criticRating.toFixed(1)} out of 10`}
         >
           <Star className="size-3.5 fill-current" aria-hidden="true" />
+          <span className="sr-only">
+            {`Critic rating: ${criticRating.toFixed(1)} out of 10`}
+          </span>
           <span aria-hidden="true">{criticRating.toFixed(1)}</span>
         </li>
       )}
       {audienceRating != null && audienceRating > 0 && (
         <li
           className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 font-bold ${audienceRatingClass(audienceRating)}`}
-          aria-label={`Audience rating: ${audienceRating.toFixed(1)} out of 10`}
         >
           <Users className="size-3.5 fill-current" aria-hidden="true" />
+          <span className="sr-only">
+            {`Audience rating: ${audienceRating.toFixed(1)} out of 10`}
+          </span>
           <span aria-hidden="true">{audienceRating.toFixed(1)}</span>
         </li>
       )}
       {certificationLabel && (
-        <li aria-label={`Rated ${certificationLabel}`}>
+        <li>
           <Badge
             variant="outline"
             className={`${OVER_MEDIA_BADGE_CLASS} font-semibold`}
           >
+            <span className="sr-only">{`Rated ${certificationLabel}`}</span>
             <span aria-hidden="true">{certificationLabel}</span>
           </Badge>
         </li>
       )}
       {capabilityBadges?.map(badge => (
-        <li key={badge.label} aria-label={badge.description}>
+        <li key={badge.label}>
           <Badge
             variant="outline"
             className={`${OVER_MEDIA_BADGE_CLASS} font-semibold`}
           >
+            <span className="sr-only">{badge.description}</span>
             <span aria-hidden="true">{badge.label}</span>
           </Badge>
         </li>
@@ -86,10 +95,10 @@ export default function MovieDetailsMetadataChips({
       {runtime && (
         <li className="flex items-center gap-1.5 text-white/80">
           <Clock className="size-4" aria-hidden="true" />
-          <time
-            dateTime={runTimeMins != null ? `PT${runTimeMins}M` : undefined}
-            aria-label={`Runtime: ${spokenRuntime ?? runtime}`}
-          >
+          <time dateTime={runTimeMins != null ? `PT${runTimeMins}M` : undefined}>
+            <span className="sr-only">
+              {`Runtime: ${spokenRuntime ?? runtime}`}
+            </span>
             <span aria-hidden="true">{runtime}</span>
           </time>
         </li>

--- a/web/src/components/movies/MovieDetailsMetadataChips.tsx
+++ b/web/src/components/movies/MovieDetailsMetadataChips.tsx
@@ -64,12 +64,12 @@ export default function MovieDetailsMetadataChips({
         </li>
       )}
       {certificationLabel && (
-        <li>
+        <li aria-label={`Rated ${certificationLabel}`}>
           <Badge
             variant="outline"
             className={`${OVER_MEDIA_BADGE_CLASS} font-semibold`}
           >
-            {certificationLabel}
+            <span aria-hidden="true">{certificationLabel}</span>
           </Badge>
         </li>
       )}

--- a/web/src/lib/tmdb-certification.ts
+++ b/web/src/lib/tmdb-certification.ts
@@ -1,0 +1,33 @@
+import type { MovieDetailsType } from "@/types";
+
+/**
+ * Picks the parental certification (PG, PG-13, R, ...) out of a TMDB
+ * `release_dates` payload. Prefers the US certification; otherwise falls back to
+ * the first non-empty certification from any country. Returns null when none is
+ * available.
+ *
+ * Mirrors the server's `TmdbMovie.Certification()` so in-theaters movies read the
+ * same as library movies.
+ */
+export function pickTmdbCertification(
+  releaseDates: MovieDetailsType["release_dates"] | undefined,
+): string | null {
+  let firstCert: string | null = null;
+
+  for (const result of releaseDates?.results ?? []) {
+    for (const entry of result.release_dates ?? []) {
+      const cert = entry.certification.trim();
+      if (cert === "") {
+        continue;
+      }
+      if (result.iso_3166_1 === "US") {
+        return cert;
+      }
+      if (firstCert === null) {
+        firstCert = cert;
+      }
+    }
+  }
+
+  return firstCert;
+}

--- a/web/src/routes/_auth/movies/in-theaters.$id.tsx
+++ b/web/src/routes/_auth/movies/in-theaters.$id.tsx
@@ -8,6 +8,7 @@ import {
   TMDB_POSTER_SIZE,
 } from "@/lib/constants";
 import { buildTmdbImageUrl } from "@/lib/tmdb-image-url";
+import { pickTmdbCertification } from "@/lib/tmdb-certification";
 import {
   formatRuntimeMinutes,
   prepareYouTubeExtrasForDisplay,
@@ -156,6 +157,7 @@ function MovieDetailsContent({ movie }: { movie: MovieDetailsType }) {
     : `Watch ${movie.title} in your Igloo media library.`;
 
   const runtime = formatRuntimeMinutes(movie.runtime);
+  const certificationLabel = pickTmdbCertification(movie.release_dates);
 
   const trailer = movie.videos?.results?.find(
     v => v.type === "Trailer" && v.site === "YouTube",
@@ -206,7 +208,7 @@ function MovieDetailsContent({ movie }: { movie: MovieDetailsType }) {
           <MovieDetailsMetadataChips
             criticRating={null}
             audienceRating={null}
-            certificationLabel={null}
+            certificationLabel={certificationLabel}
             runtime={runtime}
             runTimeMins={movie.runtime ?? null}
             releaseDateStr={releaseDateStr}

--- a/web/src/test/lib/tmdb-certification.test.ts
+++ b/web/src/test/lib/tmdb-certification.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { pickTmdbCertification } from "@/lib/tmdb-certification";
+import type { MovieDetailsType } from "@/types";
+
+type ReleaseDates = MovieDetailsType["release_dates"];
+
+function releaseDates(results: ReleaseDates["results"]): ReleaseDates {
+  return { results };
+}
+
+describe("pickTmdbCertification", () => {
+  it("prefers the US certification over earlier countries", () => {
+    const value = pickTmdbCertification(
+      releaseDates([
+        { iso_3166_1: "DE", release_dates: [{ certification: "16" }] },
+        { iso_3166_1: "US", release_dates: [{ certification: "PG-13" }] },
+      ]),
+    );
+
+    expect(value).toBe("PG-13");
+  });
+
+  it("falls back to the first non-empty certification when there is no US entry", () => {
+    const value = pickTmdbCertification(
+      releaseDates([
+        { iso_3166_1: "FR", release_dates: [{ certification: "" }] },
+        { iso_3166_1: "GB", release_dates: [{ certification: "15" }] },
+        { iso_3166_1: "DE", release_dates: [{ certification: "16" }] },
+      ]),
+    );
+
+    expect(value).toBe("15");
+  });
+
+  it("skips empty and whitespace-only certifications, including for the US", () => {
+    const value = pickTmdbCertification(
+      releaseDates([
+        { iso_3166_1: "US", release_dates: [{ certification: "   " }] },
+        { iso_3166_1: "GB", release_dates: [{ certification: "  12A  " }] },
+      ]),
+    );
+
+    expect(value).toBe("12A");
+  });
+
+  it("returns the trimmed US certification", () => {
+    const value = pickTmdbCertification(
+      releaseDates([
+        { iso_3166_1: "US", release_dates: [{ certification: "  R  " }] },
+      ]),
+    );
+
+    expect(value).toBe("R");
+  });
+
+  it("returns null when no certification is available", () => {
+    expect(pickTmdbCertification(undefined)).toBeNull();
+    expect(pickTmdbCertification(releaseDates(null))).toBeNull();
+    expect(pickTmdbCertification(releaseDates([]))).toBeNull();
+    expect(
+      pickTmdbCertification(
+        releaseDates([{ iso_3166_1: "US", release_dates: null }]),
+      ),
+    ).toBeNull();
+    expect(
+      pickTmdbCertification(
+        releaseDates([{ iso_3166_1: "US", release_dates: [] }]),
+      ),
+    ).toBeNull();
+  });
+});

--- a/web/src/test/movies/movie-details-metadata-chips.test.tsx
+++ b/web/src/test/movies/movie-details-metadata-chips.test.tsx
@@ -37,6 +37,20 @@ describe("MovieDetailsMetadataChips", () => {
     ).toBeInTheDocument();
   });
 
+  it("gives the certification chip a spoken accessible name", () => {
+    render(
+      <MovieDetailsMetadataChips
+        {...baseProps}
+        certificationLabel="PG-13"
+        runtime={null}
+        runTimeMins={null}
+      />,
+    );
+
+    expect(screen.getByLabelText("Rated PG-13")).toBeInTheDocument();
+    expect(screen.getByText("PG-13")).toBeInTheDocument();
+  });
+
   it("renders capability badges with accessible descriptions", () => {
     render(
       <MovieDetailsMetadataChips

--- a/web/src/test/movies/movie-details-metadata-chips.test.tsx
+++ b/web/src/test/movies/movie-details-metadata-chips.test.tsx
@@ -20,7 +20,7 @@ describe("MovieDetailsMetadataChips", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Runtime: 1 hr 56 min")).toBeInTheDocument();
+    expect(screen.getByText("Runtime: 1 hr 56 min")).toBeInTheDocument();
   });
 
   it("uses spoken runtime in the accessible label when minutes are available", () => {
@@ -32,12 +32,10 @@ describe("MovieDetailsMetadataChips", () => {
       />,
     );
 
-    expect(
-      screen.getByLabelText("Runtime: 1 hour 56 minutes"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Runtime: 1 hour 56 minutes")).toBeInTheDocument();
   });
 
-  it("gives the certification chip a spoken accessible name", () => {
+  it("exposes the certification to assistive tech as list item content", () => {
     render(
       <MovieDetailsMetadataChips
         {...baseProps}
@@ -47,7 +45,7 @@ describe("MovieDetailsMetadataChips", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Rated PG-13")).toBeInTheDocument();
+    expect(screen.getByText("Rated PG-13")).toBeInTheDocument();
     expect(screen.getByText("PG-13")).toBeInTheDocument();
   });
 
@@ -72,7 +70,7 @@ describe("MovieDetailsMetadataChips", () => {
       "7.1 surround sound audio",
       "Subtitles available",
     ]) {
-      expect(screen.getByLabelText(description)).toBeInTheDocument();
+      expect(screen.getByText(description)).toBeInTheDocument();
     }
     expect(screen.getByText("4K")).toBeInTheDocument();
     expect(screen.getByText("CC")).toBeInTheDocument();

--- a/web/src/test/movies/movie-details-route.test.tsx
+++ b/web/src/test/movies/movie-details-route.test.tsx
@@ -447,7 +447,9 @@ describe("movie details route motion", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("1 hr 56 min")).toBeInTheDocument();
 
-    const runtime = screen.getByLabelText("Runtime: 1 hour 56 minutes");
+    const runtime = screen
+      .getByText("Runtime: 1 hour 56 minutes")
+      .closest("time");
     expect(runtime).toHaveAttribute("datetime", "PT116M");
 
     const wrappers = getDetailMotionWrappers(container);


### PR DESCRIPTION
## What

The in-theaters movie details page (`/movies/in-theaters/$id`) rendered the shared `MovieDetailsMetadataChips` with `certificationLabel` hardcoded to `null`, so PG / PG-13 / R never appeared — unlike the library movie details page.

## How

`GET /api/tmdb/movies/{id}` already returns the full TMDB `release_dates` tree (the server fetches it with `append_to_response=credits,videos,release_dates`), so the label is derived **client-side**. The API response is deliberately left untouched because the TV client already consumes these endpoints.

New helper `web/src/lib/tmdb-certification.ts` mirrors the server's `TmdbMovie.Certification()` rule that the library scanner uses: prefer the US certification, else the first non-empty one from any country, else none.

The home "In Theaters" cards are unchanged — TMDB `now_playing` does not return `release_dates` at all.

## Testing

- `make check` passes (server tests, eslint, 82 web test files / 670 tests, build+typecheck).
- New unit test `web/src/test/lib/tmdb-certification.test.ts` covers US preference, non-US fallback, empty/whitespace certifications, and the null/undefined payload shapes.
- Verified live against a real instance: Moana renders `PG`, Evil Dead Burn renders `R`, styled identically to the library details page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movie details now display certification ratings from available release information.
  * Certification selection prioritizes US ratings and falls back to other available regions.
* **Accessibility**
  * Certification chips now provide clearer descriptions for assistive technologies while avoiding duplicate announcements.
* **Bug Fixes**
  * Empty or whitespace-only certification values are ignored, preventing blank ratings from appearing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->