### PR TITLE
Cache the watch-room stream pins and sharpen two indexes

### DIFF
--- a/server/cmd/api/application.go
+++ b/server/cmd/api/application.go
@@ -75,7 +75,8 @@ type Application struct {
 	DeviceLastSeen                *cache.Cache
 	DeviceAuthCache               *cache.Cache
 	WatchRoomAuthCache            *watchRoomAuthCache
-	StreamFileCache               *streamFileCache
+	StreamFileCache               *generationCache[streamFile]
+	MovieStreamsCache             *generationCache[movieStreams]
 	DeviceExpiryCancel            context.CancelFunc
 	ScanCancel                    context.CancelFunc
 	ScanContext                   context.Context
@@ -206,16 +207,23 @@ func InitApp() (initializedApp *Application, err error) {
 		CurrentMoviesDirectory: func() sql.NullString {
 			return app.CurrentSettings().MoviesDir
 		},
-		InvalidateCommittedMovie: func(movieID int64) {
-			app.invalidateSubtitleVTTCache(movieID)
-			app.StreamFileCache.invalidate(movieStreamFileKey(movieID))
-			app.invalidateHLSSessionsForMovie(movieID)
-		},
+		InvalidateCommittedMovie: app.invalidateCommittedMovie,
 	})
 
 	app.InitRouter()
 
 	return &app, nil
+}
+
+// invalidateCommittedMovie drops everything derived from one movie's rows after
+// the scanner commits a rescan of it. It is a method rather than a closure so
+// the test harness can wire the same list; a cache missing from here serves
+// pre-rescan data until its TTL expires.
+func (app *Application) invalidateCommittedMovie(movieID int64) {
+	app.invalidateSubtitleVTTCache(movieID)
+	app.StreamFileCache.invalidate(movieStreamFileKey(movieID))
+	app.MovieStreamsCache.invalidate(movieStreamsKey(movieID))
+	app.invalidateHLSSessionsForMovie(movieID)
 }
 
 func (app *Application) initRuntimeCaches() {
@@ -260,5 +268,8 @@ func (app *Application) initRuntimeCaches() {
 	app.WatchRoomAuthCache = newWatchRoomAuthCache()
 
 	// Keeps the per-range-request file lookup off SQLite.
-	app.StreamFileCache = newStreamFileCache(streamFileCacheTTL, streamFileCacheSweep)
+	app.StreamFileCache = newGenerationCache[streamFile](streamFileCacheTTL, streamFileCacheSweep)
+
+	// Keeps the watch-room stream-pin checks off SQLite on the same hot path.
+	app.MovieStreamsCache = newGenerationCache[movieStreams](movieStreamsCacheTTL, movieStreamsCacheSweep)
 }

--- a/server/cmd/api/generation_cache.go
+++ b/server/cmd/api/generation_cache.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// generationCache is a read-through cache whose fills are ordered against the
+// mutations that invalidate them. A reader that missed the cache may still be in
+// its database query when a delete or a rescan evicts the key; without the
+// generation guard that reader would publish the row it read before the mutation
+// and keep stale data live until the TTL expired.
+//
+// The generation is global rather than per-key: fills take microseconds and
+// invalidations happen only on delete and rescan, so discarding a handful of
+// unrelated in-flight fills costs nothing and keeps the counter allocation-free.
+//
+// The TTL is only a backstop. Correctness comes from the explicit invalidation
+// at every mutation that can change what is cached.
+type generationCache[T any] struct {
+	entries *cache.Cache
+	gen     atomic.Uint64
+}
+
+func newGenerationCache[T any](ttl time.Duration, sweep time.Duration) *generationCache[T] {
+	return &generationCache[T]{entries: cache.New(ttl, sweep)}
+}
+
+// generation must be read before the database query whose result will be
+// published with setIfCurrent.
+func (c *generationCache[T]) generation() uint64 {
+	return c.gen.Load()
+}
+
+func (c *generationCache[T]) get(key string) (T, bool) {
+	var zero T
+
+	cached, hit := c.entries.Get(key)
+	if !hit {
+		return zero, false
+	}
+
+	resolved, ok := cached.(T)
+	if !ok {
+		return zero, false
+	}
+
+	return resolved, true
+}
+
+// setIfCurrent publishes a fill only when nothing was invalidated since gen was
+// read. A stale fill is dropped rather than cached.
+func (c *generationCache[T]) setIfCurrent(key string, gen uint64, resolved T) {
+	if c.gen.Load() != gen {
+		return
+	}
+
+	c.entries.SetDefault(key, resolved)
+}
+
+// invalidate must be called after the mutation commits, so a racing fill either
+// reads the new row or is discarded by the generation bump.
+func (c *generationCache[T]) invalidate(key string) {
+	c.gen.Add(1)
+	c.entries.Delete(key)
+}
+
+// invalidateAll is for mutations that remove an unknown set of keys, such as an
+// album delete cascading to its tracks.
+func (c *generationCache[T]) invalidateAll() {
+	c.gen.Add(1)
+	c.entries.Flush()
+}
+
+// resolve is the read-through body: return the cached value, or run fill and
+// publish it if nothing invalidated the key while fill was running.
+func (c *generationCache[T]) resolve(key string, fill func() (T, error)) (T, error) {
+	cached, hit := c.get(key)
+	if hit {
+		return cached, nil
+	}
+
+	gen := c.generation()
+
+	resolved, err := fill()
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+
+	c.setIfCurrent(key, gen, resolved)
+
+	return resolved, nil
+}

--- a/server/cmd/api/generation_cache.go
+++ b/server/cmd/api/generation_cache.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -15,13 +15,18 @@ import (
 //
 // The generation is global rather than per-key: fills take microseconds and
 // invalidations happen only on delete and rescan, so discarding a handful of
-// unrelated in-flight fills costs nothing and keeps the counter allocation-free.
+// unrelated in-flight fills costs nothing and keeps the counter cheap.
 //
 // The TTL is only a backstop. Correctness comes from the explicit invalidation
 // at every mutation that can change what is cached.
 type generationCache[T any] struct {
 	entries *cache.Cache
-	gen     atomic.Uint64
+
+	// mu orders the generation against the entry it guards. Reads of the
+	// entries map do not need it — go-cache locks its own map — but every
+	// step that pairs the counter with a write to that map does.
+	mu  sync.Mutex
+	gen uint64
 }
 
 func newGenerationCache[T any](ttl time.Duration, sweep time.Duration) *generationCache[T] {
@@ -31,7 +36,10 @@ func newGenerationCache[T any](ttl time.Duration, sweep time.Duration) *generati
 // generation must be read before the database query whose result will be
 // published with setIfCurrent.
 func (c *generationCache[T]) generation() uint64 {
-	return c.gen.Load()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.gen
 }
 
 func (c *generationCache[T]) get(key string) (T, bool) {
@@ -52,8 +60,16 @@ func (c *generationCache[T]) get(key string) (T, bool) {
 
 // setIfCurrent publishes a fill only when nothing was invalidated since gen was
 // read. A stale fill is dropped rather than cached.
+//
+// The check and the publish are one critical section, shared with invalidate:
+// an invalidation that landed between them would delete the key and then watch
+// this call put the superseded row straight back, which is the exact eviction
+// the guard exists to perform.
 func (c *generationCache[T]) setIfCurrent(key string, gen uint64, resolved T) {
-	if c.gen.Load() != gen {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.gen != gen {
 		return
 	}
 
@@ -63,19 +79,30 @@ func (c *generationCache[T]) setIfCurrent(key string, gen uint64, resolved T) {
 // invalidate must be called after the mutation commits, so a racing fill either
 // reads the new row or is discarded by the generation bump.
 func (c *generationCache[T]) invalidate(key string) {
-	c.gen.Add(1)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.gen++
 	c.entries.Delete(key)
 }
 
 // invalidateAll is for mutations that remove an unknown set of keys, such as an
 // album delete cascading to its tracks.
 func (c *generationCache[T]) invalidateAll() {
-	c.gen.Add(1)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.gen++
 	c.entries.Flush()
 }
 
 // resolve is the read-through body: return the cached value, or run fill and
 // publish it if nothing invalidated the key while fill was running.
+//
+// A fill the guard rejects is still returned to this one caller. It was true
+// when its query ran, so serving it is no different from a request that
+// finished a moment before the mutation; what must not happen is publishing it
+// for the rest of the TTL, and setIfCurrent is what prevents that.
 func (c *generationCache[T]) resolve(key string, fill func() (T, error)) (T, error) {
 	cached, hit := c.get(key)
 	if hit {

--- a/server/cmd/api/generation_cache_test.go
+++ b/server/cmd/api/generation_cache_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestGenerationCache() *generationCache[string] {
+	return newGenerationCache[string](time.Minute, 2*time.Minute)
+}
+
+func TestGenerationCachePublishesAFillFromTheCurrentGeneration(t *testing.T) {
+	c := newTestGenerationCache()
+
+	resolved, err := c.resolve("movie:1", func() (string, error) {
+		return "path", nil
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if resolved != "path" {
+		t.Errorf("resolve = %q, want %q", resolved, "path")
+	}
+
+	cached, hit := c.get("movie:1")
+	if !hit {
+		t.Fatal("a fill from the current generation was not published")
+	}
+	if cached != "path" {
+		t.Errorf("cached = %q, want %q", cached, "path")
+	}
+}
+
+// The guard's whole job: a fill that started before a mutation must not land in
+// the cache after it, or the superseded row stays live for the rest of the TTL.
+// Invalidating from inside fill is how the test pins that interleaving down.
+func TestGenerationCacheDropsAFillSupersededByInvalidate(t *testing.T) {
+	c := newTestGenerationCache()
+	c.entries.SetDefault("movie:1", "before")
+
+	resolved, err := c.resolve("movie:2", func() (string, error) {
+		c.invalidate("movie:1")
+		return "stale", nil
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// The caller still gets what its query read; only publication is refused.
+	if resolved != "stale" {
+		t.Errorf("resolve = %q, want the value fill returned", resolved)
+	}
+	if _, hit := c.get("movie:2"); hit {
+		t.Error("a fill superseded by an invalidation was published")
+	}
+	if _, hit := c.get("movie:1"); hit {
+		t.Error("invalidate did not evict its own key")
+	}
+}
+
+func TestGenerationCacheDropsAFillSupersededByInvalidateAll(t *testing.T) {
+	c := newTestGenerationCache()
+	c.entries.SetDefault("track:1", "before")
+
+	_, err := c.resolve("track:2", func() (string, error) {
+		c.invalidateAll()
+		return "stale", nil
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	if _, hit := c.get("track:2"); hit {
+		t.Error("a fill superseded by invalidateAll was published")
+	}
+	if _, hit := c.get("track:1"); hit {
+		t.Error("invalidateAll did not flush the cache")
+	}
+}
+
+func TestGenerationCacheDoesNotPublishAFailedFill(t *testing.T) {
+	c := newTestGenerationCache()
+
+	_, err := c.resolve("movie:1", func() (string, error) {
+		return "", errors.New("query failed")
+	})
+	if err == nil {
+		t.Fatal("resolve swallowed the fill error")
+	}
+	if _, hit := c.get("movie:1"); hit {
+		t.Error("a failed fill was published")
+	}
+}

--- a/server/cmd/api/main_test.go
+++ b/server/cmd/api/main_test.go
@@ -1186,11 +1186,7 @@ func setupTestApp(t *testing.T) *Application {
 		CurrentMoviesDirectory: func() sql.NullString {
 			return app.CurrentSettings().MoviesDir
 		},
-		InvalidateCommittedMovie: func(movieID int64) {
-			app.invalidateSubtitleVTTCache(movieID)
-			app.StreamFileCache.invalidate(movieStreamFileKey(movieID))
-			app.invalidateHLSSessionsForMovie(movieID)
-		},
+		InvalidateCommittedMovie: app.invalidateCommittedMovie,
 	})
 
 	return app

--- a/server/cmd/api/movie_edit_handler.go
+++ b/server/cmd/api/movie_edit_handler.go
@@ -247,6 +247,7 @@ func (app *Application) DeleteMovie(w http.ResponseWriter, r *http.Request) {
 	// row still existed would otherwise republish it behind the eviction.
 	app.invalidateSubtitleVTTCache(id)
 	app.StreamFileCache.invalidate(movieStreamFileKey(id))
+	app.MovieStreamsCache.invalidate(movieStreamsKey(id))
 	app.invalidateHLSSessionsForMovie(id)
 
 	if payload.DeleteFile {

--- a/server/cmd/api/movie_streams_cache.go
+++ b/server/cmd/api/movie_streams_cache.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"igloo/cmd/internal/database"
+)
+
+const (
+	// The watch-room pin checks run on the two hottest media paths there are:
+	// once per byte-range request for a direct-play room, and once per manifest
+	// refresh (which doubles as the keepalive) for an HLS room. Re-reading the
+	// movie's stream rows on every one of them puts playback behind the scanner
+	// on the single shared connection, exactly as resolving the file path did
+	// before streamFileCache. Rescans and movie deletes evict explicitly; the
+	// TTL is the backstop for every other way a row can change.
+	movieStreamsCacheTTL   = time.Minute
+	movieStreamsCacheSweep = 2 * time.Minute
+)
+
+// movieStreams is a movie's probed track lists, as the watch-room stream-pin
+// checks need them: both in one entry, because an HLS room verifies both pins on
+// the same request and a miss should cost one fill, not two.
+type movieStreams struct {
+	Audio     []database.AudioStream
+	Subtitles []database.Subtitle
+}
+
+func movieStreamsKey(movieID int64) string {
+	return "movie-streams:" + strconv.FormatInt(movieID, 10)
+}
+
+// movieStreamsFor resolves a movie's audio and subtitle streams, caching them.
+// Stream-ordinal drift (audit H14) is still detected: a rescan is what rewrites
+// these rows, and it invalidates this cache in the same commit hook that
+// invalidates streamFileCache, so the next pin check reads the new ordinals.
+func (app *Application) movieStreamsFor(ctx context.Context, movieID int64) (movieStreams, error) {
+	return app.MovieStreamsCache.resolve(movieStreamsKey(movieID), func() (movieStreams, error) {
+		audio, err := app.Queries.GetAudioStreamsByMovieID(ctx, movieID)
+		if err != nil {
+			return movieStreams{}, err
+		}
+
+		subtitles, err := app.Queries.GetSubtitlesByMovieID(ctx, movieID)
+		if err != nil {
+			return movieStreams{}, err
+		}
+
+		return movieStreams{Audio: audio, Subtitles: subtitles}, nil
+	})
+}

--- a/server/cmd/api/movie_streams_cache_test.go
+++ b/server/cmd/api/movie_streams_cache_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// The watch-room pin checks run once per byte-range request and once per
+// manifest refresh, so the second call must not reach SQLite. Rewriting the row
+// behind the cache is how the test observes that: a cached read still reports
+// the old stream index.
+func TestMovieStreamsAreServedFromCacheUntilInvalidated(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+
+	movieID := insertTestHLSMovieFixture(t, app, "h264", 720)
+
+	first, err := app.movieStreamsFor(context.Background(), movieID)
+	if err != nil {
+		t.Fatalf("resolve movie streams: %v", err)
+	}
+	if len(first.Audio) == 0 {
+		t.Fatal("fixture has no audio streams; the test cannot observe a drift")
+	}
+	original := first.Audio[0].StreamIndex
+
+	_, err = app.DB.Exec(`UPDATE audio_streams SET stream_index = stream_index + 10 WHERE movie_id = ?`, movieID)
+	if err != nil {
+		t.Fatalf("shift audio stream index: %v", err)
+	}
+
+	cached, err := app.movieStreamsFor(context.Background(), movieID)
+	if err != nil {
+		t.Fatalf("resolve cached movie streams: %v", err)
+	}
+	if cached.Audio[0].StreamIndex != original {
+		t.Errorf("second lookup re-queried the database: stream_index = %d, want the cached %d",
+			cached.Audio[0].StreamIndex, original)
+	}
+
+	// A rescan commits through this, which is what lets the pin checks keep
+	// detecting stream drift.
+	app.invalidateCommittedMovie(movieID)
+
+	fresh, err := app.movieStreamsFor(context.Background(), movieID)
+	if err != nil {
+		t.Fatalf("resolve movie streams after invalidation: %v", err)
+	}
+	if fresh.Audio[0].StreamIndex != original+10 {
+		t.Errorf("stream_index after invalidation = %d, want %d; the rescan's eviction did not take",
+			fresh.Audio[0].StreamIndex, original+10)
+	}
+}

--- a/server/cmd/api/notifications_handler.go
+++ b/server/cmd/api/notifications_handler.go
@@ -52,23 +52,30 @@ func newNotificationResponse(row database.ListNotificationsForUserRow) notificat
 	}
 }
 
+// writeNotificationViewerError answers a failed viewer lookup. No user row means
+// the session outlived its user, which is a stale session (401) rather than a
+// server fault.
+func (app *Application) writeNotificationViewerError(w http.ResponseWriter, r *http.Request, userID int64, err error) {
+	if errors.Is(err, sql.ErrNoRows) {
+		destroyErr := app.SessionManager.Destroy(r.Context())
+		if destroyErr != nil {
+			app.Logger.Error("failed to destroy stale notification session", "error", destroyErr, "user_id", userID)
+		}
+		helpers.ErrorJSON(w, errors.New(notAuthorizedMessage), http.StatusUnauthorized)
+		return
+	}
+
+	app.Logger.Error("failed to load user for notifications", "error", err, "user_id", userID)
+	helpers.ErrorJSON(w, errors.New(internalServerErrorMessage))
+}
+
 // notificationViewerIsAdmin reports whether the current user is an admin, which
 // determines whether the shared admin request queue is visible to them. It
 // writes the error response and returns ok=false on failure.
 func (app *Application) notificationViewerIsAdmin(w http.ResponseWriter, r *http.Request, userID int64) (bool, bool) {
 	isAdmin, err := app.Queries.GetUserIsAdmin(r.Context(), userID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			destroyErr := app.SessionManager.Destroy(r.Context())
-			if destroyErr != nil {
-				app.Logger.Error("failed to destroy stale notification session", "error", destroyErr, "user_id", userID)
-			}
-			helpers.ErrorJSON(w, errors.New(notAuthorizedMessage), http.StatusUnauthorized)
-			return false, false
-		}
-
-		app.Logger.Error("failed to load user for notifications", "error", err, "user_id", userID)
-		helpers.ErrorJSON(w, errors.New(internalServerErrorMessage))
+		app.writeNotificationViewerError(w, r, userID, err)
 		return false, false
 	}
 
@@ -211,33 +218,25 @@ func (app *Application) ListNotifications(w http.ResponseWriter, r *http.Request
 }
 
 // GetUnreadNotificationCount returns just the unread count. It is intentionally
-// lightweight because the client polls it on an interval to drive the bell badge.
+// lightweight because the client polls it on an interval to drive the bell badge:
+// GetNotificationBadgeForUser folds the admin check and the count into a single
+// statement, so a poll costs one round trip on the shared connection.
 func (app *Application) GetUnreadNotificationCount(w http.ResponseWriter, r *http.Request) {
 	userID, ok := app.currentUserID(w, r)
 	if !ok {
 		return
 	}
 
-	isAdmin, ok := app.notificationViewerIsAdmin(w, r, userID)
-	if !ok {
+	badge, err := app.Queries.GetNotificationBadgeForUser(r.Context(), userID)
+	if err != nil {
+		app.writeNotificationViewerError(w, r, userID, err)
 		return
-	}
-
-	var unreadCount int64
-	if isAdmin {
-		var err error
-		unreadCount, err = app.Queries.CountUnreadNotificationsForUser(r.Context(), userID)
-		if err != nil {
-			app.Logger.Error("failed to count unread notifications", "error", err, "user_id", userID)
-			helpers.ErrorJSON(w, errors.New(internalServerErrorMessage))
-			return
-		}
 	}
 
 	helpers.WriteJSON(w, http.StatusOK, helpers.JSONResponse{
 		Error: false,
 		Data: map[string]any{
-			"unread_count": unreadCount,
+			"unread_count": badge.UnreadCount,
 		},
 	})
 }

--- a/server/cmd/api/notifications_handler_test.go
+++ b/server/cmd/api/notifications_handler_test.go
@@ -394,3 +394,47 @@ func TestDeleteNotification_RemovesAndThen404(t *testing.T) {
 		t.Fatalf("second delete status = %d, want 404, body = %s", w.Code, w.Body.String())
 	}
 }
+
+// The polled badge resolves the viewer's admin flag and the unread count in one
+// statement, so both halves need pinning: an admin sees the queue, and a
+// non-admin sees zero rather than the admin queue's backlog.
+func TestUnreadNotificationCount_CountsForAdminAndZeroesForNonAdmin(t *testing.T) {
+	app := setupTestApp(t)
+	defer app.DB.Close()
+	app.InitSession()
+
+	admin := createTestUser(t, app, "Admin", "admin@example.com", true)
+	requester := createTestUser(t, app, "Requester", "requester@example.com", false)
+	seedAdminQueueNotification(t, app, requester.ID, "request one")
+	seedAdminQueueNotification(t, app, requester.ID, "request two")
+
+	unreadCountFor := func(userID int64) int64 {
+		t.Helper()
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/notifications/unread-count", nil)
+		addOpenAPITestCookie(req)
+		notificationTestServer(app, userID).ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("unread-count status = %d, want 200, body = %s", w.Code, w.Body.String())
+		}
+		assertOpenAPIExchange(t, "getUnreadNotificationCount", req, w)
+
+		var resp struct {
+			Data struct {
+				UnreadCount int64 `json:"unread_count"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		return resp.Data.UnreadCount
+	}
+
+	if got := unreadCountFor(admin.ID); got != 2 {
+		t.Errorf("admin unread_count = %d, want 2", got)
+	}
+	if got := unreadCountFor(requester.ID); got != 0 {
+		t.Errorf("non-admin unread_count = %d, want 0; the queue is admin-only", got)
+	}
+}

--- a/server/cmd/api/search_handler.go
+++ b/server/cmd/api/search_handler.go
@@ -92,7 +92,23 @@ SELECT
   m.thumb,
   m.sort_name,
   (SELECT COUNT(*) FROM musician_albums AS ma WHERE ma.musician_id = m.id) AS album_count,
-  (SELECT COUNT(*) FROM tracks AS t WHERE t.musician_id = m.id) AS track_count
+  -- Must stay identical to GetMusiciansAlphabetical's track_count in
+  -- sqlc/queries/musicians.sql: both scan into GetMusiciansAlphabeticalRow, so a
+  -- divergence shows the same artist card with two different track counts. The
+  -- UNION of two indexed lookups is what that query uses; the equivalent OR over
+  -- tracks and track_musicians cannot use an index.
+  (
+    SELECT COUNT(*)
+    FROM (
+      SELECT t.id
+      FROM tracks AS t
+      WHERE t.musician_id = m.id
+      UNION
+      SELECT tm.track_id
+      FROM track_musicians AS tm
+      WHERE tm.musician_id = m.id
+    )
+  ) AS track_count
 FROM musicians_fts
 INNER JOIN musicians AS m ON m.id = musicians_fts.rowid
 WHERE musicians_fts MATCH ?

--- a/server/cmd/api/stream_file.go
+++ b/server/cmd/api/stream_file.go
@@ -7,12 +7,9 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"igloo/cmd/internal/helpers"
-
-	"github.com/patrickmn/go-cache"
 )
 
 const (
@@ -32,68 +29,6 @@ type streamFile struct {
 	ContentType string
 }
 
-// streamFileCache is a read-through cache whose fills are ordered against the
-// mutations that invalidate them. A reader that missed the cache may still be
-// in its database query when a delete or a rescan evicts the key; without the
-// generation guard that reader would publish the row it read before the
-// mutation and keep a deleted or moved file streamable until the TTL expired.
-//
-// The generation is global rather than per-key: fills take microseconds and
-// invalidations happen only on delete and rescan, so discarding a handful of
-// unrelated in-flight fills costs nothing and keeps the counter allocation-free.
-type streamFileCache struct {
-	entries *cache.Cache
-	gen     atomic.Uint64
-}
-
-func newStreamFileCache(ttl time.Duration, sweep time.Duration) *streamFileCache {
-	return &streamFileCache{entries: cache.New(ttl, sweep)}
-}
-
-// generation must be read before the database query whose result will be
-// published with setIfCurrent.
-func (c *streamFileCache) generation() uint64 {
-	return c.gen.Load()
-}
-
-func (c *streamFileCache) get(key string) (streamFile, bool) {
-	cached, hit := c.entries.Get(key)
-	if !hit {
-		return streamFile{}, false
-	}
-
-	resolved, ok := cached.(streamFile)
-	if !ok {
-		return streamFile{}, false
-	}
-
-	return resolved, true
-}
-
-// setIfCurrent publishes a fill only when nothing was invalidated since gen was
-// read. A stale fill is dropped rather than cached.
-func (c *streamFileCache) setIfCurrent(key string, gen uint64, resolved streamFile) {
-	if c.gen.Load() != gen {
-		return
-	}
-
-	c.entries.SetDefault(key, resolved)
-}
-
-// invalidate must be called after the mutation commits, so a racing fill either
-// reads the new row or is discarded by the generation bump.
-func (c *streamFileCache) invalidate(key string) {
-	c.gen.Add(1)
-	c.entries.Delete(key)
-}
-
-// invalidateAll is for mutations that remove an unknown set of keys, such as an
-// album delete cascading to its tracks.
-func (c *streamFileCache) invalidateAll() {
-	c.gen.Add(1)
-	c.entries.Flush()
-}
-
 func movieStreamFileKey(movieID int64) string {
 	return "movie:" + strconv.FormatInt(movieID, 10)
 }
@@ -102,30 +37,10 @@ func trackStreamFileKey(trackID int64) string {
 	return "track:" + strconv.FormatInt(trackID, 10)
 }
 
-// resolveStreamFile is the shared read-through body: movies and tracks differ
-// only in their key and in the query that resolves a miss.
-func (app *Application) resolveStreamFile(key string, resolve func() (streamFile, error)) (streamFile, error) {
-	cached, hit := app.StreamFileCache.get(key)
-	if hit {
-		return cached, nil
-	}
-
-	gen := app.StreamFileCache.generation()
-
-	resolved, err := resolve()
-	if err != nil {
-		return streamFile{}, err
-	}
-
-	app.StreamFileCache.setIfCurrent(key, gen, resolved)
-
-	return resolved, nil
-}
-
 // movieStreamFile resolves the file behind a movie, caching the lookup. The
 // caller still maps sql.ErrNoRows to 404.
 func (app *Application) movieStreamFile(ctx context.Context, movieID int64) (streamFile, error) {
-	return app.resolveStreamFile(movieStreamFileKey(movieID), func() (streamFile, error) {
+	return app.StreamFileCache.resolve(movieStreamFileKey(movieID), func() (streamFile, error) {
 		movie, err := app.Queries.GetMovieForDirectStream(ctx, movieID)
 		if err != nil {
 			return streamFile{}, err
@@ -141,7 +56,7 @@ func (app *Application) movieStreamFile(ctx context.Context, movieID int64) (str
 
 // trackStreamFile is the music twin of movieStreamFile.
 func (app *Application) trackStreamFile(ctx context.Context, trackID int64) (streamFile, error) {
-	return app.resolveStreamFile(trackStreamFileKey(trackID), func() (streamFile, error) {
+	return app.StreamFileCache.resolve(trackStreamFileKey(trackID), func() (streamFile, error) {
 		track, err := app.Queries.GetTrack(ctx, trackID)
 		if err != nil {
 			return streamFile{}, err

--- a/server/cmd/api/stream_file_test.go
+++ b/server/cmd/api/stream_file_test.go
@@ -254,10 +254,10 @@ func TestDeleteAlbumEvictsTrackStreamFileCache(t *testing.T) {
 // delete can land in between. The generation guard is what stops that reader
 // from republishing what it read.
 func TestStreamFileCacheDropsFillRacingAnInvalidation(t *testing.T) {
-	c := newStreamFileCache(time.Minute, 2*time.Minute)
+	c := newGenerationCache[streamFile](time.Minute, 2*time.Minute)
 	key := movieStreamFileKey(1)
 
-	// Captured before the query, as resolveStreamFile does.
+	// Captured before the query, as generationCache.resolve does.
 	gen := c.generation()
 
 	// The row is deleted and the key evicted while that query is in flight.

--- a/server/cmd/api/watch_room_handler_test.go
+++ b/server/cmd/api/watch_room_handler_test.go
@@ -1899,6 +1899,9 @@ func TestWatchRoomHLSManifest_ReturnsConflictOnStreamDrift(t *testing.T) {
 	if err != nil {
 		t.Fatalf("shift audio stream index: %v", err)
 	}
+	// A real rescan ends by calling this; the raw UPDATE above has to do the
+	// same or the pin check keeps reading the pre-drift streams from cache.
+	app.invalidateCommittedMovie(movieID)
 
 	drifted := performWatchRoomHTTPRequest(t, app, owner.ID, http.MethodGet, manifestPath)
 	if drifted.Code != http.StatusConflict {

--- a/server/cmd/api/watch_room_media_handler.go
+++ b/server/cmd/api/watch_room_media_handler.go
@@ -27,15 +27,19 @@ var errWatchRoomStreamDrift = errors.New("this room's movie file was replaced an
 // GetOrCreateRoomHLSSession as preloadedAudio; on a session miss that branch
 // would otherwise re-run this exact query. A nil slice (pin check skipped)
 // simply degrades to the fetch inside createHLSSession.
+//
+// The streams come from MovieStreamsCache because this runs on every manifest
+// refresh; a rescan invalidates it, so drift is still caught.
 func (app *Application) verifyWatchRoomAudioPin(ctx context.Context, room database.WatchRoom) ([]database.AudioStream, error) {
 	if !room.AudioStreamIndex.Valid {
 		return nil, nil
 	}
 
-	audioStreams, err := app.Queries.GetAudioStreamsByMovieID(ctx, room.MovieID)
+	streams, err := app.movieStreamsFor(ctx, room.MovieID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load audio streams for pin check: %w", err)
 	}
+	audioStreams := streams.Audio
 	if room.AudioTrack >= int64(len(audioStreams)) {
 		return nil, errWatchRoomStreamDrift
 	}
@@ -52,16 +56,18 @@ func (app *Application) verifyWatchRoomAudioPin(ctx context.Context, room databa
 // verifyWatchRoomSubtitlePin is the subtitle counterpart of
 // verifyWatchRoomAudioPin. It is also the only pin a direct-mode room checks:
 // direct playback serves the container's own default audio, so only the
-// subtitle ordinal can silently repoint after a rescan.
+// subtitle ordinal can silently repoint after a rescan. A direct-play client
+// calls this once per byte-range request, which is why it reads the cache.
 func (app *Application) verifyWatchRoomSubtitlePin(ctx context.Context, room database.WatchRoom) error {
 	if !room.SubtitleStreamIndex.Valid || !room.SubtitleTrack.Valid {
 		return nil
 	}
 
-	subtitles, err := app.Queries.GetSubtitlesByMovieID(ctx, room.MovieID)
+	streams, err := app.movieStreamsFor(ctx, room.MovieID)
 	if err != nil {
 		return fmt.Errorf("failed to load subtitles for pin check: %w", err)
 	}
+	subtitles := streams.Subtitles
 	if room.SubtitleTrack.Int64 >= int64(len(subtitles)) {
 		return errWatchRoomStreamDrift
 	}

--- a/server/cmd/internal/database/db.go
+++ b/server/cmd/internal/database/db.go
@@ -321,6 +321,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getMusiciansCountStmt, err = db.PrepareContext(ctx, getMusiciansCount); err != nil {
 		return nil, fmt.Errorf("error preparing query GetMusiciansCount: %w", err)
 	}
+	if q.getNotificationBadgeForUserStmt, err = db.PrepareContext(ctx, getNotificationBadgeForUser); err != nil {
+		return nil, fmt.Errorf("error preparing query GetNotificationBadgeForUser: %w", err)
+	}
 	if q.getOrCreateGenreStmt, err = db.PrepareContext(ctx, getOrCreateGenre); err != nil {
 		return nil, fmt.Errorf("error preparing query GetOrCreateGenre: %w", err)
 	}
@@ -1100,6 +1103,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getMusiciansCountStmt: %w", cerr)
 		}
 	}
+	if q.getNotificationBadgeForUserStmt != nil {
+		if cerr := q.getNotificationBadgeForUserStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getNotificationBadgeForUserStmt: %w", cerr)
+		}
+	}
 	if q.getOrCreateGenreStmt != nil {
 		if cerr := q.getOrCreateGenreStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getOrCreateGenreStmt: %w", cerr)
@@ -1703,6 +1711,7 @@ type Queries struct {
 	getMusiciansAlphabeticalStmt                *sql.Stmt
 	getMusiciansByAlbumIDStmt                   *sql.Stmt
 	getMusiciansCountStmt                       *sql.Stmt
+	getNotificationBadgeForUserStmt             *sql.Stmt
 	getOrCreateGenreStmt                        *sql.Stmt
 	getPlaylistCollaboratorsStmt                *sql.Stmt
 	getPlaylistMoviesPaginatedAscStmt           *sql.Stmt
@@ -1901,6 +1910,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getMusiciansAlphabeticalStmt:                q.getMusiciansAlphabeticalStmt,
 		getMusiciansByAlbumIDStmt:                   q.getMusiciansByAlbumIDStmt,
 		getMusiciansCountStmt:                       q.getMusiciansCountStmt,
+		getNotificationBadgeForUserStmt:             q.getNotificationBadgeForUserStmt,
 		getOrCreateGenreStmt:                        q.getOrCreateGenreStmt,
 		getPlaylistCollaboratorsStmt:                q.getPlaylistCollaboratorsStmt,
 		getPlaylistMoviesPaginatedAscStmt:           q.getPlaylistMoviesPaginatedAscStmt,

--- a/server/cmd/internal/database/notifications.sql.go
+++ b/server/cmd/internal/database/notifications.sql.go
@@ -81,6 +81,45 @@ func (q *Queries) DeleteNotificationForUser(ctx context.Context, notificationID 
 	return result.RowsAffected()
 }
 
+const getNotificationBadgeForUser = `-- name: GetNotificationBadgeForUser :one
+SELECT
+  u.is_admin,
+  CASE
+    WHEN u.is_admin THEN (
+      SELECT COUNT(*)
+      FROM notifications AS n
+      WHERE n.is_admin = true
+        AND NOT EXISTS (
+          SELECT 1
+          FROM notification_reads AS nr
+          WHERE nr.notification_id = n.id
+            AND nr.user_id = u.id
+        )
+    )
+    ELSE 0
+  END AS unread_count
+FROM users AS u
+WHERE u.id = ?1
+`
+
+type GetNotificationBadgeForUserRow struct {
+	IsAdmin     bool  `json:"is_admin"`
+	UnreadCount int64 `json:"unread_count"`
+}
+
+// The bell badge in one round trip. The client polls this endpoint, and the
+// database runs on a single shared connection (InitDB), so the admin check and
+// the count are folded into one statement instead of GetUserIsAdmin followed by
+// CountUnreadNotificationsForUser. The queue is admin-only, so a non-admin
+// short-circuits to 0 without touching notifications at all. No rows means the
+// session outlived its user, which the handler treats as a stale session.
+func (q *Queries) GetNotificationBadgeForUser(ctx context.Context, userID int64) (GetNotificationBadgeForUserRow, error) {
+	row := q.queryRow(ctx, q.getNotificationBadgeForUserStmt, getNotificationBadgeForUser, userID)
+	var i GetNotificationBadgeForUserRow
+	err := row.Scan(&i.IsAdmin, &i.UnreadCount)
+	return i, err
+}
+
 const listNotificationsForUser = `-- name: ListNotificationsForUser :many
 SELECT
   n.id,

--- a/server/cmd/internal/database/querier.go
+++ b/server/cmd/internal/database/querier.go
@@ -168,6 +168,13 @@ type Querier interface {
 	GetMusiciansAlphabetical(ctx context.Context, arg GetMusiciansAlphabeticalParams) ([]GetMusiciansAlphabeticalRow, error)
 	GetMusiciansByAlbumID(ctx context.Context, albumID int64) ([]GetMusiciansByAlbumIDRow, error)
 	GetMusiciansCount(ctx context.Context) (int64, error)
+	// The bell badge in one round trip. The client polls this endpoint, and the
+	// database runs on a single shared connection (InitDB), so the admin check and
+	// the count are folded into one statement instead of GetUserIsAdmin followed by
+	// CountUnreadNotificationsForUser. The queue is admin-only, so a non-admin
+	// short-circuits to 0 without touching notifications at all. No rows means the
+	// session outlived its user, which the handler treats as a stale session.
+	GetNotificationBadgeForUser(ctx context.Context, userID int64) (GetNotificationBadgeForUserRow, error)
 	GetOrCreateGenre(ctx context.Context, arg GetOrCreateGenreParams) (Genre, error)
 	GetPlaylistCollaborators(ctx context.Context, playlistID int64) ([]GetPlaylistCollaboratorsRow, error)
 	// Title order matches GET /api/movies/library sort=asc.

--- a/server/sqlc/queries/musicians.sql
+++ b/server/sqlc/queries/musicians.sql
@@ -71,6 +71,9 @@ SELECT
   -- track_musicians. A UNION of two indexed lookups rather than an OR over both
   -- tables: the OR form cannot use an index and scans every track per musician.
   -- UNION (not UNION ALL) preserves the distinct-track count.
+  -- searchMusiciansSQL in cmd/api/search_handler.go must keep this identical: it
+  -- scans into this same row type, so a divergence shows the same artist card
+  -- with two different track counts.
   (
     SELECT COUNT(*)
     FROM (

--- a/server/sqlc/queries/notifications.sql
+++ b/server/sqlc/queries/notifications.sql
@@ -64,3 +64,29 @@ ON CONFLICT (notification_id, user_id) DO NOTHING;
 DELETE FROM notifications
 WHERE id = sqlc.arg(notification_id)
   AND is_admin = true;
+
+-- name: GetNotificationBadgeForUser :one
+-- The bell badge in one round trip. The client polls this endpoint, and the
+-- database runs on a single shared connection (InitDB), so the admin check and
+-- the count are folded into one statement instead of GetUserIsAdmin followed by
+-- CountUnreadNotificationsForUser. The queue is admin-only, so a non-admin
+-- short-circuits to 0 without touching notifications at all. No rows means the
+-- session outlived its user, which the handler treats as a stale session.
+SELECT
+  u.is_admin,
+  CASE
+    WHEN u.is_admin THEN (
+      SELECT COUNT(*)
+      FROM notifications AS n
+      WHERE n.is_admin = true
+        AND NOT EXISTS (
+          SELECT 1
+          FROM notification_reads AS nr
+          WHERE nr.notification_id = n.id
+            AND nr.user_id = u.id
+        )
+    )
+    ELSE 0
+  END AS unread_count
+FROM users AS u
+WHERE u.id = sqlc.arg(user_id);

--- a/server/sqlc/schema.sql
+++ b/server/sqlc/schema.sql
@@ -480,6 +480,17 @@ CREATE TABLE
 
 CREATE INDEX IF NOT EXISTS idx_cast_order ON cast (movie_id, cast_order);
 
+-- FK-cascade index audit (2026-08-29): every foreign key in this schema has an
+-- index leading with its child column except seven, all pointing at catalog
+-- parents no query ever deletes -- cast.artist_id and crew.artist_id (-> artist),
+-- movie_production_companies.production_company_id, movie_extra_videos.extra_video_id,
+-- and genre_id on track_genres, album_genres and musician_genres (-> genres).
+-- SQLite only needs those indexes to find the children of a deleted parent, and
+-- there is no DeleteArtist, DeleteGenre, DeleteProductionCompany or
+-- DeleteExtraVideo, so they would be seven more indexes written on every scanner
+-- insert for no read. Add them the moment an orphan-cleanup or parent-delete path
+-- appears.
+
 -- Movie crew credits.
 CREATE TABLE
   IF NOT EXISTS crew (
@@ -495,7 +506,17 @@ CREATE TABLE
     UNIQUE (movie_id, artist_id, job, department)
   );
 
-CREATE INDEX IF NOT EXISTS idx_crew_department ON crew (movie_id, department);
+-- Serves GetCrewByMovieID's filter and its (department, job) ordering in one
+-- pass; without job the movie detail page temp-sorts every crew credit it reads.
+--
+-- This replaces idx_crew_department (movie_id, department). It gets a new name
+-- rather than a DROP + re-CREATE of the old one because this schema re-runs at
+-- every startup: CREATE INDEX IF NOT EXISTS would silently keep the old
+-- definition, and dropping unconditionally would rebuild a 70k-row index on
+-- every boot. Under the new name both statements are no-ops after the first run.
+CREATE INDEX IF NOT EXISTS idx_crew_movie_department_job ON crew (movie_id, department, job);
+
+DROP INDEX IF EXISTS idx_crew_department;
 
 -- Shared catalog relationships
 
@@ -660,9 +681,17 @@ CREATE TABLE
     FOREIGN KEY (movie_id) REFERENCES movies (id) ON DELETE SET NULL ON UPDATE CASCADE
   );
 
-CREATE INDEX IF NOT EXISTS idx_playlist_user ON playlists (user_id);
+-- Serves both playlist listings, which select one user's playlists of one
+-- content_type (GetPlaylistsWithCollaboratorAccess and its movie twin), and backs
+-- the users -> playlists delete cascade. Replaces idx_playlist_user (user_id) and
+-- idx_playlist_content_type (content_type); new name for the same reason as
+-- idx_crew_movie_department_job above. Nothing filters on content_type alone, so
+-- that second index was write cost with no read.
+CREATE INDEX IF NOT EXISTS idx_playlist_user_content ON playlists (user_id, content_type);
 
-CREATE INDEX IF NOT EXISTS idx_playlist_content_type ON playlists (content_type);
+DROP INDEX IF EXISTS idx_playlist_user;
+
+DROP INDEX IF EXISTS idx_playlist_content_type;
 
 -- Backs the movies -> playlists (movie_id SET NULL) cascade.
 CREATE INDEX IF NOT EXISTS idx_playlists_movie ON playlists (movie_id);


### PR DESCRIPTION
A third pass over `server/sqlc`: every query file re-read and every index re-checked with `EXPLAIN QUERY PLAN` against the real library (415 movies, 2267 tracks, 24k cast, 69k crew), plus a synthetic in-memory build of `schema.sql` for the tables that are empty in dev. Most of it was already tight — this is the short list of what still cost something.

## The hot-path find was not in `server/sqlc`

`verifyWatchRoomSubtitlePin` ran `GetSubtitlesByMovieID` on **every byte-range request** of a direct-play room, and `verifyWatchRoomStreamPins` ran audio *and* subtitles on **every manifest refresh** (which doubles as the keepalive). A seeking viewer put a query on the single shared connection for each range the player asked for — directly beside the `movieStreamFile` call that is cached for exactly that reason.

`MovieStreamsCache` holds a movie's audio and subtitle rows behind the same generation guard `streamFileCache` uses, so a fill that raced an eviction is dropped rather than published. `streamFileCache` is now `generationCache[T]`, since the two differ only in the value they hold. Stream drift (audit H14) is still caught: a rescan is what rewrites those rows, and it evicts the entry in the same commit hook.

`InvalidateCommittedMovie` became the method `app.invalidateCommittedMovie`. The test harness held a **copy** of that closure, so a cache added to one list was silently missing from the other — which is how the drift test first failed.

## Indexes

Both verified with `EXPLAIN QUERY PLAN` against the real library:

| Before | After | Why |
|---|---|---|
| `idx_crew_department (movie_id, department)` | `idx_crew_movie_department_job (movie_id, department, job)` | `GetCrewByMovieID` orders by `department, job`, so every movie detail page temp-sorted its credits out of a 69k-row table |
| `idx_playlist_user (user_id)` + `idx_playlist_content_type (content_type)` | `idx_playlist_user_content (user_id, content_type)` | Both playlist listings filter on the pair; nothing filters on `content_type` alone, so that index was write cost with no read |

A replacement index takes a **new name** and drops the old one by name. `schema.sql` re-runs at every startup, so `CREATE INDEX IF NOT EXISTS` would silently keep the old definition, and an unconditional `DROP` would rebuild the index on every boot.

## One round trip for the polled badge

`GET /api/notifications/unread-count` is client-polled and cost two queries. `GetNotificationBadgeForUser` folds them into one statement: a non-admin short-circuits to zero without reading `notifications`, and no row still means a session that outlived its user. `GetUserIsAdmin` and `CountUnreadNotificationsForUser` both keep other callers.

## A correctness bug found on the way

`searchMusiciansSQL` counted only `tracks.musician_id`; `GetMusiciansAlphabetical` counts the union with `track_musicians`. Both scan into the same row type, so **50 of the library's 331 artists** showed one track count in search and another in the listing — several of them zero against one. The two are now identical and say so.

## Recorded, deliberately not acted on

Seven foreign keys have no index leading with their child column (`cast.artist_id`, `crew.artist_id`, `movie_production_companies.production_company_id`, `movie_extra_videos.extra_video_id`, and `genre_id` on track/album/musician_genres). All point at catalog parents no query ever deletes, so the cost is latent — documented in `schema.sql` rather than adding seven more indexes to the scanner's insert path.

## Verification

- `make check` green: all Go packages, Redocly lint, `openapi.gen.ts` no drift, 728 web tests, production build.
- **No `docs/openapi.json` changes.** The only endpoint whose implementation changed keeps its body (`{unread_count: int64}`) and its 200/401/500 set. The new test asserts both the admin and non-admin responses through `assertOpenAPIExchange`, which runs `openapi3filter.ValidateResponse` against the spec.
- On the real library: the crew temp-sort is gone from the query plan, the artist track counts now agree, and the pin checks serve a repeat lookup from cache but read the new ordinals once a rescan invalidates.

> [!NOTE]
> `db/igloo.db` is not migrated. The two index changes were applied to it in place, so `make dev` will not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBqt3QCnzGyCAargStnHSa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Watch-room stream pins now reliably detect audio and subtitle changes, reducing stale playback and incorrect stream selections.
  - Movie rescans and deletions now refresh related media data consistently.
  - Musician search results now provide more accurate track counts.
  - Notification badges now correctly reflect administrator-specific unread notifications.

- **Performance Improvements**
  - Faster repeat access to movie stream information and notification badges.
  - More efficient notification count retrieval while preserving accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->