### PR TITLE
Fix and triage the react-doctor findings in web/

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,7 @@
     "test:e2e:watch-room": "playwright test e2e/watch-room.spec.ts",
     "test:e2e:quick-connect": "playwright test e2e/quick-connect.spec.ts",
     "preview": "vite preview",
-    "doctor": "bun x react-doctor@latest --yes"
+    "doctor": "bun x react-doctor@0.9.12 --yes"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,7 @@
     "test:e2e:watch-room": "playwright test e2e/watch-room.spec.ts",
     "test:e2e:quick-connect": "playwright test e2e/quick-connect.spec.ts",
     "preview": "vite preview",
-    "doctor": "bun x react-doctor@0.5.5 --yes"
+    "doctor": "bun x react-doctor@latest --yes"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/web/src/components/movies/EditMovieDialog.tsx
+++ b/web/src/components/movies/EditMovieDialog.tsx
@@ -322,6 +322,9 @@ function ManualTab({
     }
 
     const res = await updateMovieMetadata(movieId, body);
+    // updateMovieMetadata resolves an envelope and never rejects, so this clears on
+    // both outcomes; `finally` would bail the React Compiler out of the component.
+    // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
     setSaving(false);
 
     if (res.error) {

--- a/web/src/components/music/AddToPlaylistDialog.tsx
+++ b/web/src/components/music/AddToPlaylistDialog.tsx
@@ -117,17 +117,20 @@ export default function AddToPlaylistDialog({
   };
 
   const togglePlaylist = (id: number, playlistName: string) => {
-    setSelectedPlaylists((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-        setAnnouncement(`${playlistName} deselected. ${next.size} playlist${next.size !== 1 ? "s" : ""} selected.`);
-      } else {
-        next.add(id);
-        setAnnouncement(`${playlistName} selected. ${next.size} playlist${next.size !== 1 ? "s" : ""} selected.`);
-      }
-      return next;
-    });
+    // Computed outside the updater: React may invoke an updater more than once,
+    // and announcing from inside it is a render-phase update.
+    const next = new Set(selectedPlaylists);
+    const wasSelected = next.delete(id);
+    if (!wasSelected) {
+      next.add(id);
+    }
+
+    setSelectedPlaylists(next);
+    setAnnouncement(
+      wasSelected
+        ? `${playlistName} deselected. ${next.size} playlist${next.size !== 1 ? "s" : ""} selected.`
+        : `${playlistName} selected. ${next.size} playlist${next.size !== 1 ? "s" : ""} selected.`,
+    );
   };
 
   const handleAdd = () => {

--- a/web/src/components/music/PlaylistFormDialog.tsx
+++ b/web/src/components/music/PlaylistFormDialog.tsx
@@ -128,7 +128,7 @@ function PlaylistForm({
   // Initialize form state based on mode
   const [name, setName] = useState(playlist?.name ?? "");
   const [description, setDescription] = useState(
-    unwrapString(playlist?.description) ?? ""
+    () => unwrapString(playlist?.description) ?? ""
   );
 
   // Create mutation

--- a/web/src/components/music/TrackItem.tsx
+++ b/web/src/components/music/TrackItem.tsx
@@ -50,6 +50,11 @@ type TrackItemProps = {
   dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>;
 };
 
+// The flag count is arity, not complexity: each one drives a single independent
+// thing (a class, an icon, one rendered block) and none is read together with
+// another, so the nominal combinations never arise. Every call site passes a
+// fixed preset determined by `variant`.
+// react-doctor-disable-next-line react-doctor/no-many-boolean-props
 export default function TrackItem({
   id,
   title,

--- a/web/src/components/playback/AudioPlayer.tsx
+++ b/web/src/components/playback/AudioPlayer.tsx
@@ -58,6 +58,9 @@ export default function AudioPlayer({
 
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
+  // Driven by the <audio> element's loadstart/canplay/error events, not by a
+  // state transition, so useTransition does not apply.
+  // react-doctor-disable-next-line react-doctor/rendering-usetransition-loading
   const [isLoading, setIsLoading] = useState(false);
 
   const artist = musicianName || albumTitle;
@@ -313,6 +316,8 @@ export default function AudioPlayer({
 
   return (
     <>
+      {/* Audio-only music playback; captions do not apply. */}
+      {/* react-doctor-disable-next-line react-doctor/media-has-caption */}
       <audio ref={audioRef} preload="metadata" className="hidden">
         {streamUrl && (
           <source src={streamUrl} type={track.mime_type || undefined} />

--- a/web/src/components/playback/VideoPlayer.tsx
+++ b/web/src/components/playback/VideoPlayer.tsx
@@ -297,6 +297,9 @@ export default function VideoPlayer({
   // playlist URL can stay identical while the resume target changes (any seek
   // inside the rewind buffer keeps start=0 in the URL), and rebuilding with
   // `startPosition` is what applies that seek.
+  // The cleanup calls disposeHls() -> hls.destroy(), which removes every listener
+  // registered below; the rule does not model destroy().
+  // react-doctor-disable-next-line react-doctor/effect-needs-cleanup
   useEffect(() => {
     const video = videoRef.current;
     if (!video || !src) return;
@@ -623,6 +626,8 @@ export default function VideoPlayer({
             : "aspect-video w-full max-w-6xl"
         }
       >
+        {/* Subtitle tracks are attached imperatively below, keyed on subtitleUrl. */}
+        {/* react-doctor-disable-next-line react-doctor/media-has-caption */}
         <video
           ref={videoRef}
           className={`size-full bg-black object-contain ${isFullscreen ? "rounded-none" : "rounded-lg"}`}

--- a/web/src/components/settings/QuickConnectApproveCard.tsx
+++ b/web/src/components/settings/QuickConnectApproveCard.tsx
@@ -107,6 +107,9 @@ export default function QuickConnectApproveCard() {
     }
   }, [step]);
 
+  // A pure in-memory lookup, POST only because the code travels in the body.
+  // It changes no server state and no query caches it.
+  // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation
   const lookupMutation = useMutation({
     mutationFn: (deviceCode: string) => lookupQuickConnect(deviceCode),
     onSuccess: res => {
@@ -124,6 +127,9 @@ export default function QuickConnectApproveCard() {
     },
   });
 
+  // The mutationFn refreshes [DEVICES_KEY] itself via fetchQuery, and the poll
+  // below keeps it current, so there is nothing left to invalidate.
+  // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation
   const approveMutation = useMutation({
     mutationFn: async (deviceCode: string): Promise<ApprovalResult> => {
       let baselineDeviceIds: number[] | null = null;
@@ -198,6 +204,9 @@ export default function QuickConnectApproveCard() {
 
       const fresh = devices.find(
         device =>
+          // One user's own devices - a handful of entries, and inside a 2s poll rather
+          // than a render path.
+          // react-doctor-disable-next-line react-doctor/js-set-map-lookups
           !currentKnownDeviceIds.includes(device.id) &&
           matchesPendingDevice(device, pendingDevice),
       );

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -68,6 +68,9 @@ function SidebarProvider({
   }
 
   return (
+    // The React Compiler memoizes contextValue; a manual useMemo here would go
+    // against web/AGENTS.md.
+    // react-doctor-disable-next-line react-doctor/context-provider-value-from-unmemoized-local-literal
     <SidebarContext.Provider value={contextValue}>
       <div
         data-slot="sidebar-wrapper"

--- a/web/src/components/watch-room/CreateWatchRoomDialog.tsx
+++ b/web/src/components/watch-room/CreateWatchRoomDialog.tsx
@@ -91,6 +91,9 @@ export default function CreateWatchRoomDialog({
           );
         });
   const selectedUsers = inviteUsers.filter(user =>
+    // selectedUserIds is what the operator checked in this dialog - single digits,
+    // hard-bounded by the account roster.
+    // react-doctor-disable-next-line react-doctor/js-set-map-lookups
     selectedUserIds.includes(user.id),
   );
 
@@ -365,6 +368,8 @@ export default function CreateWatchRoomDialog({
                 ) : (
                   <ul className="divide-y divide-border">
                     {filteredUsers.map(user => {
+                      // Same short selectedUserIds list as above.
+                      // react-doctor-disable-next-line react-doctor/js-set-map-lookups
                       const checked = selectedUserIds.includes(user.id);
                       return (
                         <li key={user.id}>

--- a/web/src/components/watch-room/WatchRoomPage.tsx
+++ b/web/src/components/watch-room/WatchRoomPage.tsx
@@ -260,6 +260,8 @@ export function WatchRoomPage({ roomId }: WatchRoomPageProps) {
   }
 
   const connectedMembers = room.members.filter((member) =>
+    // connectedUserIds is live presence for one watch room - a handful of people.
+    // react-doctor-disable-next-line react-doctor/js-set-map-lookups
     connectedUserIds.includes(member.id),
   );
 
@@ -732,6 +734,8 @@ function WatchRoomMembersPanel({
 
       <ul className="mt-4 space-y-3">
         {members.map((member) => {
+          // Same room-sized presence list as above.
+          // react-doctor-disable-next-line react-doctor/js-set-map-lookups
           const isConnected = connectedUserIds.includes(member.id);
           return (
             <li

--- a/web/src/components/watch-room/useWatchRoomConnection.ts
+++ b/web/src/components/watch-room/useWatchRoomConnection.ts
@@ -241,6 +241,9 @@ export function useWatchRoomConnection({
     setPlaybackError("Realtime sync connection failed for this watch room.");
   });
 
+  // The cleanup closes the socket, which releases its four listeners, and clears
+  // both the heartbeat interval and the reconnect timeout.
+  // react-doctor-disable-next-line react-doctor/effect-needs-cleanup
   useEffect(() => {
     roomDeletionHandledRef.current = false;
     intentionalCloseRef.current = false;

--- a/web/src/components/watch-room/useWatchRoomConnection.ts
+++ b/web/src/components/watch-room/useWatchRoomConnection.ts
@@ -217,9 +217,12 @@ export function useWatchRoomConnection({
   });
 
   const handleSocketClose = useEffectEvent((closedInstanceId: number) => {
+    // Guard first: a replaced socket's close event can land after the new one
+    // has opened, and clearing the heartbeat/ready flag here would silence the
+    // live connection until the server dropped it.
+    if (closedInstanceId !== socketInstanceIdRef.current) return;
     setConnectionReady(false);
     clearHeartbeat();
-    if (closedInstanceId !== socketInstanceIdRef.current) return;
     if (!intentionalCloseRef.current) {
       const delay = Math.min(
         1000 * 2 ** Math.min(reconnectAttemptsRef.current, 10),
@@ -297,6 +300,8 @@ export function useWatchRoomConnection({
       }
 
       clearHeartbeat();
+      // Teardown owns this now that a stale close returns early above.
+      setConnectionReady(false);
 
       if (socketRef.current === socket) {
         socketRef.current = null;

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -587,7 +587,13 @@ export function AudioPlayerProvider({
   };
 
   return (
+    // The React Compiler memoizes both provider values - this component is kept
+    // compilable on purpose (see the try-block comments above). Splitting actions
+    // from now-playing is already the structural fix for consumer re-renders.
+    // react-doctor-disable-next-line react-doctor/context-provider-value-from-unmemoized-local-literal
     <AudioPlayerActionsContext.Provider value={actionsValue}>
+      {/* Compiler-memoized, as above. */}
+      {/* react-doctor-disable-next-line react-doctor/context-provider-value-from-unmemoized-local-literal */}
       <AudioPlayerNowPlayingContext.Provider value={nowPlayingValue}>
         {children}
         <AudioPlayer

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -106,9 +106,8 @@ export function AudioPlayerProvider({
   };
 
   // Append a fetched batch to an endless queue, trimming played tracks beyond
-  // MAX_TRACKS_BEHIND and pruning their metadata so multi-hour shuffle or
-  // play-all sessions stay bounded. The map deletions are idempotent, so
-  // StrictMode's double-invoked updater is harmless.
+  // MAX_TRACKS_BEHIND so multi-hour shuffle or play-all sessions stay bounded.
+  // The updater stays pure: their metadata is pruned by the effect below.
   const appendToQueue = (appended: TrackType[]) => {
     setQueueState(prev => {
       const { tracks: kept, dropped } = trimQueueHistory(
@@ -117,12 +116,6 @@ export function AudioPlayerProvider({
         MAX_TRACKS_BEHIND,
       );
 
-      for (const track of dropped) {
-        trackCoversRef.current?.delete(track.id);
-        trackMusiciansRef.current?.delete(track.id);
-        trackAlbumTitlesRef.current?.delete(track.id);
-      }
-
       return {
         ...prev,
         tracks: [...kept, ...appended],
@@ -130,6 +123,34 @@ export function AudioPlayerProvider({
       };
     });
   };
+
+  // Drop metadata for tracks that have left the queue, keyed on the committed
+  // queue rather than done inside the updater above: React may run an updater
+  // for a render it discards, and these deletions are permanent, which would
+  // strand a still-queued track without its cover or artist (see setTrack's
+  // has() lookups). Reconciling against the commit is idempotent instead.
+  useEffect(() => {
+    const liveIds = new Set(queueState.tracks.map(track => track.id));
+    if (queueState.currentTrack) {
+      liveIds.add(queueState.currentTrack.id);
+    }
+
+    const maps = [
+      trackCoversRef.current,
+      trackMusiciansRef.current,
+      trackAlbumTitlesRef.current,
+    ];
+
+    for (const map of maps) {
+      if (!map) continue;
+
+      for (const id of [...map.keys()]) {
+        if (!liveIds.has(id)) {
+          map.delete(id);
+        }
+      }
+    }
+  }, [queueState.tracks, queueState.currentTrack]);
 
   const clearMetadataRefs = () => {
     trackCoversRef.current?.clear();

--- a/web/src/hooks/useHlsCapacityRetry.ts
+++ b/web/src/hooks/useHlsCapacityRetry.ts
@@ -36,6 +36,9 @@ export function useHlsCapacityRetry({
       window.clearTimeout(timerRef.current);
       timerRef.current = null;
     }
+    // Not derivable from props: the flag is set by hls.js 503 responses. The reset
+    // also cancels a live timer, which render-phase adjustment cannot do.
+    // react-doctor-disable-next-line react-doctor/no-adjust-state-on-prop-change
     setWaitingForCapacity(false);
   }, [streamWindowKey]);
 

--- a/web/src/hooks/useHlsSessionKeepalive.ts
+++ b/web/src/hooks/useHlsSessionKeepalive.ts
@@ -20,6 +20,9 @@ export function useHlsSessionKeepalive({
   enabled,
   streamUrl,
 }: HlsSessionKeepaliveOptions) {
+  // Not data fetching: the response is discarded. The ping exists only for its
+  // server-side effect of refreshing the HLS session TTL.
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect
   useEffect(() => {
     if (!enabled || !streamUrl) return;
 

--- a/web/src/hooks/useHlsSessionRecovery.ts
+++ b/web/src/hooks/useHlsSessionRecovery.ts
@@ -27,6 +27,9 @@ export function useHlsSessionRecovery({
       trackedKeyRef.current = streamWindowKey;
       attemptsRef.current = 0;
       lastAttemptAtRef.current = 0;
+      // recoveryAttempt mirrors a ref driven by hls.js error callbacks; the reset
+      // clears those refs too, so it cannot move into render.
+      // react-doctor-disable-next-line react-doctor/no-adjust-state-on-prop-change
       setRecoveryAttempt(0);
     }
   }, [streamWindowKey]);

--- a/web/src/hooks/useMoviePlaybackData.ts
+++ b/web/src/hooks/useMoviePlaybackData.ts
@@ -239,6 +239,10 @@ export function useMoviePlaybackData({
       return;
     }
 
+    // The 'parent' is the router's URL search params, not a component holding
+    // duplicate state. The URL is also the upstream input, so this is a one-way
+    // reconciliation guarded above against a navigate loop.
+    // react-doctor-disable-next-line react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent
     syncSearch(resolvedSettings);
   }, [
     audioTrack,

--- a/web/src/hooks/useMovieWatchProgressSaver.ts
+++ b/web/src/hooks/useMovieWatchProgressSaver.ts
@@ -30,7 +30,8 @@ export function useMovieWatchProgressSaver({
   durationRef,
   fallbackDurationSec,
 }: MovieWatchProgressSaverOptions) {
-  const pendingSaveRef = useRef<Promise<void>>(Promise.resolve());
+  // Null until the first save; the chain starts from a resolved promise then.
+  const pendingSaveRef = useRef<Promise<void> | null>(null);
   const fallbackDurationRef = useRef(fallbackDurationSec ?? 0);
   const saveSessionIdRef = useRef<string | null>(null);
   const saveSequenceRef = useRef(0);
@@ -51,7 +52,7 @@ export function useMovieWatchProgressSaver({
   const queueProgressSave = useCallback(
     (progressSec: number, durationSec: number) => {
       const saveSequence = ++saveSequenceRef.current;
-      const save = pendingSaveRef.current.then(() =>
+      const save = (pendingSaveRef.current ?? Promise.resolve()).then(() =>
         persistMovieWatchProgress(
           movieId,
           progressSec,

--- a/web/src/hooks/useTrackLikeToggle.ts
+++ b/web/src/hooks/useTrackLikeToggle.ts
@@ -12,6 +12,7 @@ import type { ApiResponseType } from "@/types";
 
 type LikedTrackIdsPayload = { liked_track_ids: number[] };
 const TRACK_LIKE_MUTATION_KEY = "track-like-toggle";
+const LIKED_IDS_QUERY_KEY = [LIKED_TRACK_IDS_KEY] as const;
 
 const likedIdsResponse = (
   ids: number[],
@@ -32,7 +33,6 @@ function setTrackLiked(ids: number[], trackId: number, isLiked: boolean) {
  */
 function useTrackLikeToggle(trackId: number) {
   const queryClient = useQueryClient();
-  const key = [LIKED_TRACK_IDS_KEY] as const;
   const mutationKey = [TRACK_LIKE_MUTATION_KEY, trackId] as const;
   const likedIdsQuery = useQuery({
     ...likedTrackIdsQueryOpts(),
@@ -47,14 +47,14 @@ function useTrackLikeToggle(trackId: number) {
 
   const rollback = (previousIsLiked: boolean | undefined) => {
     const current =
-      queryClient.getQueryData<ApiResponseType<LikedTrackIdsPayload>>(key);
+      queryClient.getQueryData<ApiResponseType<LikedTrackIdsPayload>>(LIKED_IDS_QUERY_KEY);
     if (previousIsLiked === undefined || current?.error !== false) {
-      void queryClient.invalidateQueries({ queryKey: key });
+      void queryClient.invalidateQueries({ queryKey: LIKED_IDS_QUERY_KEY });
       return;
     }
 
     queryClient.setQueryData(
-      key,
+      LIKED_IDS_QUERY_KEY,
       likedIdsResponse(
         setTrackLiked(
           current.data.liked_track_ids,
@@ -69,13 +69,13 @@ function useTrackLikeToggle(trackId: number) {
     mutationKey,
     mutationFn: () => toggleLikeTrack(trackId),
     onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: key });
+      await queryClient.cancelQueries({ queryKey: LIKED_IDS_QUERY_KEY });
       const previous =
-        queryClient.getQueryData<ApiResponseType<LikedTrackIdsPayload>>(key);
+        queryClient.getQueryData<ApiResponseType<LikedTrackIdsPayload>>(LIKED_IDS_QUERY_KEY);
       if (previous?.error === false) {
         const ids = previous.data.liked_track_ids;
         queryClient.setQueryData(
-          key,
+          LIKED_IDS_QUERY_KEY,
           likedIdsResponse(
             setTrackLiked(ids, trackId, !ids.includes(trackId)),
           ),
@@ -102,10 +102,10 @@ function useTrackLikeToggle(trackId: number) {
         return;
       }
       const current =
-        queryClient.getQueryData<ApiResponseType<LikedTrackIdsPayload>>(key);
+        queryClient.getQueryData<ApiResponseType<LikedTrackIdsPayload>>(LIKED_IDS_QUERY_KEY);
       if (current?.error === false) {
         queryClient.setQueryData(
-          key,
+          LIKED_IDS_QUERY_KEY,
           likedIdsResponse(
             setTrackLiked(
               current.data.liked_track_ids,
@@ -115,7 +115,7 @@ function useTrackLikeToggle(trackId: number) {
           ),
         );
       } else {
-        void queryClient.invalidateQueries({ queryKey: key });
+        void queryClient.invalidateQueries({ queryKey: LIKED_IDS_QUERY_KEY });
       }
       void queryClient.invalidateQueries({ queryKey: [LIKED_TRACKS_KEY] });
     },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -249,19 +249,30 @@ export const uploadUserAvatar = async (
       return ERROR_NOTFOUND;
     }
 
-    const data = (await response.json()) as ApiResponseType<{ user: AuthUser }>;
+    const uploadFailed: ApiFailureType = {
+      error: true,
+      message: `${response.status} - The avatar could not be uploaded.`,
+      status: response.status,
+    };
+
+    // A malformed body — empty, non-JSON, or literal `null` — must not fall
+    // through to the catch below, which would report the generic 500 instead
+    // of the status the server actually sent.
+    const data: unknown = await response.json().catch(() => null);
+
+    if (typeof data !== "object" || data === null) {
+      return response.ok ? NETWORK_ERROR : uploadFailed;
+    }
+
+    const body = data as ApiResponseType<{ user: AuthUser }>;
 
     // An HTTP failure whose body is not already an error envelope would
     // otherwise be reported to the caller as a successful upload.
-    if (!response.ok && !data.error) {
-      return {
-        error: true,
-        message: `${response.status} - The avatar could not be uploaded.`,
-        status: response.status,
-      };
+    if (!response.ok && !body.error) {
+      return uploadFailed;
     }
 
-    return data;
+    return body;
   } catch {
     return NETWORK_ERROR;
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -245,8 +245,23 @@ export const uploadUserAvatar = async (
       credentials: "include",
     });
 
-    const data: unknown = await response.json();
-    return data as ApiResponseType<{ user: AuthUser }>;
+    if (response.status === 404) {
+      return ERROR_NOTFOUND;
+    }
+
+    const data = (await response.json()) as ApiResponseType<{ user: AuthUser }>;
+
+    // An HTTP failure whose body is not already an error envelope would
+    // otherwise be reported to the caller as a successful upload.
+    if (!response.ok && !data.error) {
+      return {
+        error: true,
+        message: `${response.status} - The avatar could not be uploaded.`,
+        status: response.status,
+      };
+    }
+
+    return data;
   } catch {
     return NETWORK_ERROR;
   }

--- a/web/src/lib/playback-preferences.ts
+++ b/web/src/lib/playback-preferences.ts
@@ -30,6 +30,8 @@ export const DEFAULT_DEVICE_PLAYBACK_PREFERENCES: DevicePlaybackPreferences = {
 
 // The profiles a client may pick as a default, mirroring the server's catalog:
 // transcode profiles only, so neither "direct" nor "remux" can be stored here.
+// Module scope: runs once at import over a handful of constant entries.
+// react-doctor-disable-next-line react-doctor/js-combine-iterations
 const SELECTABLE_PROFILE_IDS: readonly string[] = STREAM_MODES.filter(
   mode => mode.type === "transcode",
 ).map(mode => mode.id);

--- a/web/src/routes/_auth/movies/$id/play.tsx
+++ b/web/src/routes/_auth/movies/$id/play.tsx
@@ -656,6 +656,9 @@ function PlayMoviePage() {
   const handleStartFromBeginning = async () => {
     setResumeActionPending(true);
     const res = await deleteMovieWatchProgress(movieId);
+    // deleteMovieWatchProgress resolves an envelope and never rejects, so this
+    // clears on both outcomes; `finally` would bail out the React Compiler.
+    // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
     setResumeActionPending(false);
 
     if (res.error) {
@@ -865,6 +868,7 @@ function PlayMoviePage() {
         // Click-to-toggle is a pointer convenience only; the same toggle is
         // reachable from the footer play button and Space/K, so the surface
         // carries no button role (audit D14).
+        // react-doctor-disable-next-line react-doctor/click-events-have-key-events, react-doctor/no-static-element-interactions
         <div
           className="relative flex min-h-0 flex-1 flex-col"
           onClick={handlePlaybackSurfaceClick}

--- a/web/src/routes/_auth/movies/index.tsx
+++ b/web/src/routes/_auth/movies/index.tsx
@@ -377,6 +377,9 @@ function MoreMenu({
 
     setRefreshingLibrary(true);
     await refreshLibraryWithToasts(queryClient, refreshMovieLibraryCache, "Movie");
+    // refreshLibraryWithToasts owns the try/catch and never throws, precisely so
+    // this reset can be plain sequential code (see its doc comment).
+    // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
     setRefreshingLibrary(false);
     setMenuOpen(false);
   };

--- a/web/src/routes/_auth/music/album.$id.tsx
+++ b/web/src/routes/_auth/music/album.$id.tsx
@@ -256,6 +256,9 @@ function AlbumDetailsContent({
         "delete album",
         "An unexpected error occurred. Please try again.",
       );
+      // This line is the catch-block reset. The success path deliberately stays busy
+      // while navigating away to /music.
+      // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
       setIsDeleting(false);
     }
   };

--- a/web/src/routes/_auth/music/index.tsx
+++ b/web/src/routes/_auth/music/index.tsx
@@ -293,6 +293,9 @@ function MoreMenu() {
 
     setRefreshingLibrary(true);
     await refreshLibraryWithToasts(queryClient, refreshMusicLibraryCache, "Music");
+    // refreshLibraryWithToasts owns the try/catch and never throws (see its doc
+    // comment), so this reset runs on every outcome.
+    // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
     setRefreshingLibrary(false);
     setMenuOpen(false);
   };
@@ -825,6 +828,9 @@ function VirtualizedTracksList({
     <div
       ref={listRef}
       className={TRACK_LIST_CONTAINER_CLASS}
+      // Tailwind's preflight sets list-style:none on every <ul>, which drops list
+      // semantics in Safari/VoiceOver; the role restores them.
+      // react-doctor-disable-next-line react-doctor/prefer-tag-over-role
       role="list"
       aria-label="Tracks"
     >

--- a/web/src/routes/_auth/settings/account.tsx
+++ b/web/src/routes/_auth/settings/account.tsx
@@ -210,6 +210,8 @@ function AccountSettings() {
   });
 
   // Password update mutation
+  // A password change touches no field held by any cached query.
+  // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation
   const updatePasswordMutation = useMutation({
     mutationFn: ({
       currentPassword,

--- a/web/src/routes/_auth/settings/users.tsx
+++ b/web/src/routes/_auth/settings/users.tsx
@@ -211,6 +211,9 @@ function UsersSettings() {
     },
   });
 
+  // An admin password reset changes nothing the [ADMIN_USERS_KEY] list renders,
+  // which is why it is the only mutation here without an invalidate.
+  // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation
   const resetPasswordMutation = useMutation({
     mutationFn: ({ id, password }: { id: number; password: string }) =>
       adminResetUserPassword(id, password),

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -106,6 +106,9 @@ function LoginPage() {
         "Login failed",
         "Something went wrong after sign-in. Please try again.",
       );
+      // This line is the catch-block reset. After a successful login the form stays
+      // disabled on purpose while the router navigates away.
+      // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
       setIsSubmitting(false);
     }
   };


### PR DESCRIPTION
## Why

`bun run doctor` pinned `react-doctor@0.5.5`, which reported 170 warnings and **zero errors**. Every one of its 36 Bugs and Performance findings turned out to be a false positive — it doesn't model the idioms this codebase settled on in the August audit (render-phase state adjustment, reset-via-`key`, media-element subscriptions, invalidation through a shared helper, `role="list"` restored after Tailwind preflight), and its dead-code pass ignores `src/test/**`, so all 7 `unused-export` hits were wrong too.

Pointing the script at the current release changed the picture completely: a sharper rule set that surfaced four genuine defects.

## Real defects fixed

**Watch-room heartbeat race** (`useWatchRoomConnection.ts`) — the one with live user impact, and not what the rule actually reported. `handleSocketClose` cleared the ready flag and the 25s ping interval *before* the stale-instance guard, so a replaced socket's late `close` event silenced the new, healthy connection; pings stopped and the server eventually dropped the room. The guard now runs first, and teardown owns `setConnectionReady(false)`.

**`AddToPlaylistDialog`** — `setAnnouncement` was nested inside the `setSelectedPlaylists` updater, which React may invoke more than once. Computed outside now; the announcement strings are unchanged.

**`uploadUserAvatar`** (`lib/api.ts`) — read the response body with no status check, so an HTTP failure returning JSON without `error: true` was blind-cast, reported "Avatar uploaded successfully", and written into the `AUTH_USER_KEY` cache. Now mirrors `apiRequest`: 404 handling plus a `!response.ok` guard.

**`AudioPlayerContext`** — `appendToQueue` deleted from three metadata maps inside its state updater. Idempotent under StrictMode, but the deletions are permanent while the state they derive from may never commit, which would leave still-queued tracks showing the previous track's cover and artist. Pruning now reconciles against the committed queue.

Plus a static query key hoisted to module scope and two lazy initializers.

## Triage of the rest

The remaining Bugs, Performance and Accessibility diagnostics were each read against the source and confirmed false positive, then suppressed **per site with its reason** — never rule-level in `doctor.config.json`, so a future genuine hit of the same rule still reports. The main ones:

- `apiRequest` resolves an envelope instead of rejecting and `refreshLibraryWithToasts` never throws, so the flagged loading flags can't stick. Two of the six flagged lines are already inside a `catch`, and in `login.tsx` / `album.$id.tsx` the success path stays busy on purpose while navigating away. A `finally` would also bail the React Compiler out of the whole component.
- The two `effect-needs-cleanup` **errors**: the hls.js effect tears down via `hls.destroy()`, the watch-room effect closes its socket, which releases its listeners.
- The compiler memoizes the context provider values, and `web/AGENTS.md` forbids adding manual memoization.
- The HLS keepalive/recovery/capacity hooks synchronize external systems; `useMoviePlaybackData` reconciles the URL, not a parent component.

## Result

Errors **2 → 0**, findings **112 → 79**. What's left is the maintainability backlog, deliberately still visible: `no-multi-component-file` ×62 (single-file-route convention), `no-giant-component` ×16 (deferred refactors), and `only-export-components` on shadcn's `button.tsx`.

## Verification

`bun run typecheck`, `bun run lint` and `bun run test` (**83 files / 728 tests**) all green, unchanged from the pre-change baseline.

Watch-room behaviour has no unit coverage, so the race fix is verified by inspection; `e2e/watch-room.spec.ts` needs a real instance and real media and stays opt-in. Worth a manual pass before merge: two browsers in one room, force a reconnect, confirm sync keeps working.

One note on tooling: the script now uses `@latest`, which resolved 0.9.8 → 0.9.12 within a single session. If this ever gates CI, pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EeRBBHLCbj5K2pzyPbrAz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch-room connection handling so reconnecting users remain connected when an older socket closes.
  * Avatar uploads now show appropriate not-found and upload failure errors instead of treating failed responses as successful.
  * Improved reliability when saving movie watch progress and managing queued playback metadata.

* **Chores**
  * Updated the React Doctor diagnostic tool to its latest version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->