### PR TITLE
Fix shuffle playback defects and unify the endless-queue refill

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -200,6 +200,12 @@ and `icon-sm`. The base string carries the focus ring, disabled opacity,
 `aria-invalid` styling, a property-scoped 150ms transition with
 `motion-reduce:transition-none`, and stamps `data-variant`/`data-size`.
 
+- **`accent-pill` and `size` don't compose.** cva emits base → variant → size →
+  `className`, and `cn` is `twMerge`, so the last conflicting class wins:
+  `size` re-declares `rounded-md` and silently squares off the pill. Pass no
+  `size` with `accent-pill` (what every call site does), or re-assert
+  `rounded-full` in `className`. Watch for this whenever two sibling buttons
+  are meant to match — one picking up a `size` is enough to break the pair.
 - **Tabs share one look** (`web/src/components/ui/tabs.tsx`): a bordered
   `bg-muted/50` list; the active trigger is a glacier primary-fill pill
   (`data-[state=active]:bg-primary … shadow-primary/20`). Library pages layer

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4561,9 +4561,9 @@
         "name": "exclude",
         "in": "query",
         "required": false,
-        "description": "Track ids the client already holds. Repeat the parameter (or pass a comma-separated list) and those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected.",
+        "description": "Track ids the client already holds, as one comma-separated list (`exclude=1,2,3`); those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Repeating the parameter works too. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected.",
         "style": "form",
-        "explode": true,
+        "explode": false,
         "schema": {
           "type": "array",
           "maxItems": 200,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3515,6 +3515,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/ShuffleLimitQuery"
+          },
+          {
+            "$ref": "#/components/parameters/ShuffleExcludeQuery"
           }
         ],
         "responses": {
@@ -4552,6 +4555,23 @@
           "minimum": 1,
           "maximum": 200,
           "default": 50
+        }
+      },
+      "ShuffleExcludeQuery": {
+        "name": "exclude",
+        "in": "query",
+        "required": false,
+        "description": "Track ids the client already holds. Repeat the parameter (or pass a comma-separated list) and those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected.",
+        "style": "form",
+        "explode": true,
+        "schema": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 1
+          }
         }
       },
       "StatsLimitQuery": {

--- a/server/cmd/api/track_handler.go
+++ b/server/cmd/api/track_handler.go
@@ -307,16 +307,28 @@ func (app *Application) GetTracksAlphabetical(w http.ResponseWriter, r *http.Req
 // the exclusion list stops being worth the round trip.
 const maxShuffleExcludeIDs = 200
 
+// Ids are skipped rather than rejected, so the accepted-id cap alone does not
+// bound the work: a request made entirely of junk never reaches it. Cap the
+// fields examined too, generously enough that no honest client notices.
+const maxShuffleExcludeFields = maxShuffleExcludeIDs * 4
+
 // parseShuffleExcludeIDs turns repeated `exclude=` query values into the JSON
 // array GetRandomTracks binds to json_each. Unparseable or out-of-range values
 // are skipped rather than rejected: an exclusion is an optimization, and
 // failing the whole request over one bad id would stop playback.
 func parseShuffleExcludeIDs(values []string) string {
-	ids := make([]int64, 0, len(values))
-	seen := make(map[int64]struct{}, len(values))
+	capacity := min(len(values), maxShuffleExcludeIDs)
+	ids := make([]int64, 0, capacity)
+	seen := make(map[int64]struct{}, capacity)
+	scanned := 0
 
 	for _, value := range values {
-		for _, field := range strings.Split(value, ",") {
+		for field := range strings.SplitSeq(value, ",") {
+			if scanned == maxShuffleExcludeFields {
+				break
+			}
+			scanned++
+
 			field = strings.TrimSpace(field)
 			if field == "" {
 				continue
@@ -340,6 +352,10 @@ func parseShuffleExcludeIDs(values []string) string {
 				}
 				return string(encoded)
 			}
+		}
+
+		if scanned == maxShuffleExcludeFields {
+			break
 		}
 	}
 

--- a/server/cmd/api/track_handler.go
+++ b/server/cmd/api/track_handler.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"igloo/cmd/internal/database"
 	"igloo/cmd/internal/helpers"
@@ -300,9 +302,60 @@ func (app *Application) GetTracksAlphabetical(w http.ResponseWriter, r *http.Req
 	helpers.WriteJSON(w, http.StatusOK, res)
 }
 
+// A shuffle client sends back what it already holds so a refill does not hand
+// it the same tracks again. The cap matches the shuffle limit cap: beyond that
+// the exclusion list stops being worth the round trip.
+const maxShuffleExcludeIDs = 200
+
+// parseShuffleExcludeIDs turns repeated `exclude=` query values into the JSON
+// array GetRandomTracks binds to json_each. Unparseable or out-of-range values
+// are skipped rather than rejected: an exclusion is an optimization, and
+// failing the whole request over one bad id would stop playback.
+func parseShuffleExcludeIDs(values []string) string {
+	ids := make([]int64, 0, len(values))
+	seen := make(map[int64]struct{}, len(values))
+
+	for _, value := range values {
+		for _, field := range strings.Split(value, ",") {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+
+			id, err := strconv.ParseInt(field, 10, 64)
+			if err != nil || id <= 0 {
+				continue
+			}
+			if _, duplicate := seen[id]; duplicate {
+				continue
+			}
+
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+
+			if len(ids) == maxShuffleExcludeIDs {
+				encoded, err := json.Marshal(ids)
+				if err != nil {
+					return "[]"
+				}
+				return string(encoded)
+			}
+		}
+	}
+
+	encoded, err := json.Marshal(ids)
+	if err != nil {
+		return "[]"
+	}
+
+	return string(encoded)
+}
+
 func (app *Application) GetShuffleTracks(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+
 	limit := int64(50)
-	if l := r.URL.Query().Get("limit"); l != "" {
+	if l := query.Get("limit"); l != "" {
 		parsed, err := strconv.ParseInt(l, 10, 64)
 		if err == nil && parsed > 0 {
 			limit = parsed
@@ -312,7 +365,10 @@ func (app *Application) GetShuffleTracks(w http.ResponseWriter, r *http.Request)
 		limit = 200
 	}
 
-	tracks, err := app.Queries.GetRandomTracks(r.Context(), limit)
+	tracks, err := app.Queries.GetRandomTracks(r.Context(), database.GetRandomTracksParams{
+		ExcludeIds: parseShuffleExcludeIDs(query["exclude"]),
+		RowLimit:   limit,
+	})
 	if err != nil {
 		app.Logger.Error("failed to get random tracks", "error", err)
 		helpers.ErrorJSON(w, errors.New("failed to fetch random tracks"))

--- a/server/cmd/api/track_shuffle_test.go
+++ b/server/cmd/api/track_shuffle_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"igloo/cmd/internal/database"
@@ -75,6 +76,43 @@ func TestParseShuffleExcludeIDsCapsTheList(t *testing.T) {
 	}
 	if count+1 != maxShuffleExcludeIDs {
 		t.Fatalf("expected %d ids, got %d", maxShuffleExcludeIDs, count+1)
+	}
+}
+
+// The accepted-id cap alone does not bound the work: skipped values never reach
+// it, so a request made entirely of junk would be walked in full.
+func TestParseShuffleExcludeIDsBoundsSkippedFields(t *testing.T) {
+	junk := make([]string, 0, maxShuffleExcludeFields+100)
+	for range maxShuffleExcludeFields + 100 {
+		junk = append(junk, "abc")
+	}
+
+	// A real id parked past the field budget must not be reached — that is the
+	// observable proof the walk stopped.
+	junk = append(junk, "42")
+
+	if got := parseShuffleExcludeIDs(junk); got != "[]" {
+		t.Errorf("parseShuffleExcludeIDs(junk) = %s, want []", got)
+	}
+
+	// The same id inside the budget is still collected, so the bound is not
+	// simply dropping everything.
+	if got := parseShuffleExcludeIDs([]string{"42"}); got != "[42]" {
+		t.Errorf("parseShuffleExcludeIDs([42]) = %s, want [42]", got)
+	}
+}
+
+// One value holding many comma-separated fields is the same walk, so the budget
+// has to apply inside a value as well as across them.
+func TestParseShuffleExcludeIDsBoundsOneLongValue(t *testing.T) {
+	fields := make([]string, 0, maxShuffleExcludeFields+100)
+	for range maxShuffleExcludeFields + 100 {
+		fields = append(fields, "abc")
+	}
+	fields = append(fields, "42")
+
+	if got := parseShuffleExcludeIDs([]string{strings.Join(fields, ",")}); got != "[]" {
+		t.Errorf("parseShuffleExcludeIDs(one long value) = %s, want []", got)
 	}
 }
 

--- a/server/cmd/api/track_shuffle_test.go
+++ b/server/cmd/api/track_shuffle_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"igloo/cmd/internal/database"
+)
+
+func TestParseShuffleExcludeIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{
+			name:   "no parameter yields an empty array",
+			values: nil,
+			want:   "[]",
+		},
+		{
+			name:   "repeated parameters",
+			values: []string{"3", "7", "11"},
+			want:   "[3,7,11]",
+		},
+		{
+			name:   "comma separated values in one parameter",
+			values: []string{"3,7,11"},
+			want:   "[3,7,11]",
+		},
+		{
+			name:   "surrounding whitespace and empty fields are ignored",
+			values: []string{" 3 , ,7 ", ""},
+			want:   "[3,7]",
+		},
+		{
+			// An exclusion is an optimization. Rejecting the request over one
+			// bad id would stop playback for no benefit.
+			name:   "unparseable and non-positive ids are skipped, not rejected",
+			values: []string{"abc", "0", "-4", "9"},
+			want:   "[9]",
+		},
+		{
+			name:   "duplicates are collapsed",
+			values: []string{"5", "5", "5,5"},
+			want:   "[5]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseShuffleExcludeIDs(tt.values)
+			if got != tt.want {
+				t.Errorf("parseShuffleExcludeIDs(%q) = %s, want %s", tt.values, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseShuffleExcludeIDsCapsTheList(t *testing.T) {
+	values := make([]string, 0, maxShuffleExcludeIDs+50)
+	for i := 1; i <= maxShuffleExcludeIDs+50; i++ {
+		values = append(values, fmt.Sprintf("%d", i))
+	}
+
+	got := parseShuffleExcludeIDs(values)
+
+	// Cheap structural check: the encoded array must hold exactly the cap.
+	var count int
+	for _, r := range got {
+		if r == ',' {
+			count++
+		}
+	}
+	if count+1 != maxShuffleExcludeIDs {
+		t.Fatalf("expected %d ids, got %d", maxShuffleExcludeIDs, count+1)
+	}
+}
+
+func seedShuffleTracks(t *testing.T, app *Application, count int) {
+	t.Helper()
+
+	for i := 1; i <= count; i++ {
+		_, err := app.DB.Exec(
+			`INSERT INTO tracks (
+				title, sort_title, file_path, file_name, container, mime_type,
+				codec, size, track_index, duration, disc, channels,
+				channel_layout, bit_rate, profile
+			) VALUES (?, ?, ?, ?, 'flac', 'audio/flac', 'flac', 1, ?, 100, 1, '2', 'stereo', 900000, '')`,
+			fmt.Sprintf("Song %d", i),
+			fmt.Sprintf("song %d", i),
+			fmt.Sprintf("/music/%d.flac", i),
+			fmt.Sprintf("%d.flac", i),
+			i,
+		)
+		if err != nil {
+			t.Fatalf("failed to seed track %d: %v", i, err)
+		}
+	}
+}
+
+func TestGetRandomTracksWithoutExclusionsReturnsTheWholeLibrary(t *testing.T) {
+	app := setupSessionTestApp(t)
+	seedShuffleTracks(t, app, 5)
+
+	// The empty case is the trap: an empty sqlc.slice renders as `NOT IN (NULL)`,
+	// which is NULL rather than true and would silently return nothing. The
+	// query uses json_each instead, so "[]" must exclude nothing at all.
+	tracks, err := app.Queries.GetRandomTracks(context.Background(), database.GetRandomTracksParams{
+		ExcludeIds: parseShuffleExcludeIDs(nil),
+		RowLimit:   10,
+	})
+	if err != nil {
+		t.Fatalf("GetRandomTracks failed: %v", err)
+	}
+
+	if len(tracks) != 5 {
+		t.Fatalf("expected all 5 seeded tracks, got %d", len(tracks))
+	}
+}
+
+func TestGetRandomTracksOmitsExcludedIDs(t *testing.T) {
+	app := setupSessionTestApp(t)
+	seedShuffleTracks(t, app, 20)
+
+	excluded := map[int64]bool{}
+	for i := int64(1); i <= 15; i++ {
+		excluded[i] = true
+	}
+
+	tracks, err := app.Queries.GetRandomTracks(context.Background(), database.GetRandomTracksParams{
+		ExcludeIds: parseShuffleExcludeIDs([]string{"1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"}),
+		RowLimit:   20,
+	})
+	if err != nil {
+		t.Fatalf("GetRandomTracks failed: %v", err)
+	}
+
+	if len(tracks) != 5 {
+		t.Fatalf("expected the 5 unexcluded tracks, got %d", len(tracks))
+	}
+	for _, track := range tracks {
+		if excluded[track.ID] {
+			t.Errorf("track %d was excluded but came back anyway", track.ID)
+		}
+	}
+}
+
+func TestGetRandomTracksReturnsNothingWhenEverythingIsExcluded(t *testing.T) {
+	app := setupSessionTestApp(t)
+	seedShuffleTracks(t, app, 3)
+
+	// This is how the client learns the library is exhausted, so an empty
+	// result here has to stay empty rather than fall back to the full table.
+	tracks, err := app.Queries.GetRandomTracks(context.Background(), database.GetRandomTracksParams{
+		ExcludeIds: parseShuffleExcludeIDs([]string{"1", "2", "3"}),
+		RowLimit:   10,
+	})
+	if err != nil {
+		t.Fatalf("GetRandomTracks failed: %v", err)
+	}
+
+	if len(tracks) != 0 {
+		t.Fatalf("expected no tracks, got %d", len(tracks))
+	}
+}
+
+func TestGetRandomTracksHonoursTheLimit(t *testing.T) {
+	app := setupSessionTestApp(t)
+	seedShuffleTracks(t, app, 30)
+
+	tracks, err := app.Queries.GetRandomTracks(context.Background(), database.GetRandomTracksParams{
+		ExcludeIds: parseShuffleExcludeIDs(nil),
+		RowLimit:   7,
+	})
+	if err != nil {
+		t.Fatalf("GetRandomTracks failed: %v", err)
+	}
+
+	if len(tracks) != 7 {
+		t.Fatalf("expected 7 tracks, got %d", len(tracks))
+	}
+}

--- a/server/cmd/internal/database/querier.go
+++ b/server/cmd/internal/database/querier.go
@@ -208,7 +208,12 @@ type Querier interface {
 	// musician joins run only for the chosen rows instead of the whole library.
 	// The outer ORDER BY RANDOM() re-shuffles just those winners so playback order
 	// stays random too.
-	GetRandomTracks(ctx context.Context, limit int64) ([]GetRandomTracksRow, error)
+	//
+	// exclude_ids lets an endless shuffle queue say what it already holds. Without
+	// it every refill re-samples the whole table blind, so a library smaller than
+	// the queue returns nothing but duplicates and the client burns a full scan per
+	// retry.
+	GetRandomTracks(ctx context.Context, arg GetRandomTracksParams) ([]GetRandomTracksRow, error)
 	// Persisted remux-safety verdict for one video stream; the caller compares
 	// the stored fingerprint and treats a mismatch as a miss.
 	GetRemuxSafetyVerdict(ctx context.Context, arg GetRemuxSafetyVerdictParams) (RemuxSafetyVerdict, error)

--- a/server/cmd/internal/database/tracks.sql.go
+++ b/server/cmd/internal/database/tracks.sql.go
@@ -76,13 +76,26 @@ LEFT JOIN albums AS a
 LEFT JOIN musicians AS m
   ON t.musician_id = m.id
 WHERE t.id IN (
-  SELECT id
-  FROM tracks
+  SELECT candidate.id
+  FROM tracks AS candidate
+  -- The exclusions arrive as a JSON array rather than sqlc.slice() so the SQL
+  -- text stays constant and the statement can still be prepared. It also gets
+  -- the empty case right for free: json_each('[]') yields no rows, and
+  -- NOT IN (empty set) is true, whereas an empty slice renders as
+  -- ` + "`" + `NOT IN (NULL)` + "`" + `, which is NULL and would match nothing.
+  WHERE candidate.id NOT IN (
+    SELECT value FROM json_each(CAST(?1 AS TEXT))
+  )
   ORDER BY RANDOM()
-  LIMIT ?1
+  LIMIT ?2
 )
 ORDER BY RANDOM()
 `
+
+type GetRandomTracksParams struct {
+	ExcludeIds string `json:"exclude_ids"`
+	RowLimit   int64  `json:"row_limit"`
+}
 
 type GetRandomTracksRow struct {
 	ID           int64          `json:"id"`
@@ -102,8 +115,13 @@ type GetRandomTracksRow struct {
 // musician joins run only for the chosen rows instead of the whole library.
 // The outer ORDER BY RANDOM() re-shuffles just those winners so playback order
 // stays random too.
-func (q *Queries) GetRandomTracks(ctx context.Context, limit int64) ([]GetRandomTracksRow, error) {
-	rows, err := q.query(ctx, q.getRandomTracksStmt, getRandomTracks, limit)
+//
+// exclude_ids lets an endless shuffle queue say what it already holds. Without
+// it every refill re-samples the whole table blind, so a library smaller than
+// the queue returns nothing but duplicates and the client burns a full scan per
+// retry.
+func (q *Queries) GetRandomTracks(ctx context.Context, arg GetRandomTracksParams) ([]GetRandomTracksRow, error) {
+	rows, err := q.query(ctx, q.getRandomTracksStmt, getRandomTracks, arg.ExcludeIds, arg.RowLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sqlc/queries/tracks.sql
+++ b/server/sqlc/queries/tracks.sql
@@ -136,6 +136,11 @@ SELECT
 -- musician joins run only for the chosen rows instead of the whole library.
 -- The outer ORDER BY RANDOM() re-shuffles just those winners so playback order
 -- stays random too.
+--
+-- exclude_ids lets an endless shuffle queue say what it already holds. Without
+-- it every refill re-samples the whole table blind, so a library smaller than
+-- the queue returns nothing but duplicates and the client burns a full scan per
+-- retry.
 SELECT
   t.id,
   t.title,
@@ -154,9 +159,17 @@ LEFT JOIN albums AS a
 LEFT JOIN musicians AS m
   ON t.musician_id = m.id
 WHERE t.id IN (
-  SELECT id
-  FROM tracks
+  SELECT candidate.id
+  FROM tracks AS candidate
+  -- The exclusions arrive as a JSON array rather than sqlc.slice() so the SQL
+  -- text stays constant and the statement can still be prepared. It also gets
+  -- the empty case right for free: json_each('[]') yields no rows, and
+  -- NOT IN (empty set) is true, whereas an empty slice renders as
+  -- `NOT IN (NULL)`, which is NULL and would match nothing.
+  WHERE candidate.id NOT IN (
+    SELECT value FROM json_each(CAST(sqlc.arg(exclude_ids) AS TEXT))
+  )
   ORDER BY RANDOM()
-  LIMIT ?1
+  LIMIT sqlc.arg(row_limit)
 )
 ORDER BY RANDOM();

--- a/web/e2e/playlist-details.spec.ts
+++ b/web/e2e/playlist-details.spec.ts
@@ -1,0 +1,217 @@
+import { expect, test, type Page } from "@playwright/test";
+import { assertMockSuiteClean, trackBrowserIssues } from "./e2e-browser-issues";
+import { apiResponse, fulfillJSON, nullableInt64, nullableString } from "./e2e-api";
+
+const PLAYLIST_ID = 55;
+const PAGE_SIZE = 50;
+// Deliberately more than one page: the header buttons used to queue only the
+// pages the virtual list had scrolled in, so a playlist this size shuffled just
+// its first 50 tracks while the button promised all 120.
+const TOTAL_TRACKS = 120;
+
+function playlistTrack(position: number) {
+  const id = 1000 + position;
+
+  return {
+    playlist_track_id: 9000 + position,
+    position,
+    added_at: "2026-01-01T00:00:00Z",
+    added_by: nullableInt64(1),
+    id,
+    title: `Track ${position}`,
+    duration: 200_000,
+    file_path: `/music/track-${position}.flac`,
+    codec: "flac",
+    bit_rate: 900_000,
+    album_id: nullableInt64(300 + (position % 3)),
+    musician_id: nullableInt64(400 + (position % 3)),
+    album_title: nullableString(`Album ${position % 3}`),
+    album_cover: nullableString(),
+    musician_name: nullableString(`Artist ${position % 3}`),
+  };
+}
+
+const allPlaylistTracks = Array.from({ length: TOTAL_TRACKS }, (_, index) =>
+  playlistTrack(index + 1),
+);
+
+const playlistDetails = {
+  playlist: {
+    id: PLAYLIST_ID,
+    user_id: 1,
+    name: "Long Haul",
+    description: nullableString("A playlist that spans several pages."),
+    cover_image: nullableString(),
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  track_count: TOTAL_TRACKS,
+  duration: TOTAL_TRACKS * 200_000,
+  is_owner: true,
+  can_edit: true,
+  collaborators: null,
+};
+
+async function mockPlaylistApi(page: Page) {
+  const unexpectedApiRequests: string[] = [];
+  const trackPageRequests: number[] = [];
+
+  await page.route("**/api/**", async route => {
+    const url = new URL(route.request().url());
+    const method = route.request().method();
+
+    if (url.pathname === "/api/auth/user") {
+      await fulfillJSON(route, apiResponse({
+        user: {
+          id: 1,
+          name: "Playlist User",
+          email: "playlist@example.com",
+          is_admin: false,
+          avatar: null,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      }));
+      return;
+    }
+
+    if (url.pathname === "/api/notifications/unread-count" && method === "GET") {
+      await fulfillJSON(route, apiResponse({ unread_count: 0 }));
+      return;
+    }
+
+    if (url.pathname === `/api/music/playlists/${PLAYLIST_ID}` && method === "GET") {
+      await fulfillJSON(route, apiResponse(playlistDetails));
+      return;
+    }
+
+    if (
+      url.pathname === `/api/music/playlists/${PLAYLIST_ID}/tracks` &&
+      method === "GET"
+    ) {
+      const offset = Number(url.searchParams.get("offset") ?? 0);
+      const limit = Number(url.searchParams.get("limit") ?? PAGE_SIZE);
+      const slice = allPlaylistTracks.slice(offset, offset + limit);
+
+      trackPageRequests.push(offset);
+
+      await fulfillJSON(route, apiResponse({
+        tracks: slice,
+        total: TOTAL_TRACKS,
+        has_more: offset + slice.length < TOTAL_TRACKS,
+        next_offset: offset + slice.length,
+      }));
+      return;
+    }
+
+    if (url.pathname === "/api/music/tracks/liked-ids" && method === "GET") {
+      await fulfillJSON(route, apiResponse({ liked_track_ids: [] }));
+      return;
+    }
+
+    // Playback starts as soon as a queue is built; the stream itself is
+    // irrelevant here, it just must not count as an unexpected request.
+    if (/^\/api\/music\/tracks\/\d+\/stream$/.test(url.pathname) && method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "audio/flac",
+        body: Buffer.alloc(0),
+      });
+      return;
+    }
+
+    const message = `Unexpected API request: ${method} ${url.pathname}${url.search}`;
+    unexpectedApiRequests.push(message);
+    await fulfillJSON(route, { error: true, message }, 500);
+  });
+
+  return { unexpectedApiRequests, trackPageRequests };
+}
+
+function trackCounter(page: Page) {
+  return page.getByText(/^Track \d+ of \d+$/);
+}
+
+test("shuffle queues every track in a multi-page playlist", async ({ page }) => {
+  const browserIssues = trackBrowserIssues(page);
+  const { unexpectedApiRequests, trackPageRequests } = await mockPlaylistApi(page);
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(`/music/playlist/${PLAYLIST_ID}`);
+
+  await expect(page.getByRole("heading", { level: 1, name: "Long Haul" })).toBeVisible();
+
+  const shuffle = page.getByRole("button", { name: `Shuffle all ${TOTAL_TRACKS} tracks` });
+  await expect(shuffle).toBeVisible();
+
+  // Only the first page has been fetched at this point.
+  expect(trackPageRequests).toEqual([0]);
+
+  await shuffle.click();
+
+  // The counter's denominator is the real proof: the queue holds the whole
+  // playlist, not just the page the list had loaded.
+  await expect(trackCounter(page)).toHaveText(`Track 1 of ${TOTAL_TRACKS}`);
+
+  // Getting there required draining the remaining pages.
+  expect(trackPageRequests).toEqual([0, 50, 100]);
+
+  assertMockSuiteClean(browserIssues, unexpectedApiRequests);
+});
+
+test("shuffle starts somewhere other than the playlist's first track", async ({ page }) => {
+  await mockPlaylistApi(page);
+
+  await page.goto(`/music/playlist/${PLAYLIST_ID}`);
+  await expect(page.getByRole("heading", { level: 1, name: "Long Haul" })).toBeVisible();
+
+  // Pin Math.random so the shuffle is deterministic: always drawing index 0
+  // rotates the queue left by one, so "Track 1" moves to the end and "Track 2"
+  // opens. Without a real shuffle the first track would still be "Track 1".
+  await page.evaluate(() => {
+    Math.random = () => 0;
+  });
+
+  await page.getByRole("button", { name: `Shuffle all ${TOTAL_TRACKS} tracks` }).click();
+
+  await expect(trackCounter(page)).toHaveText(`Track 1 of ${TOTAL_TRACKS}`);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Track 2" }),
+  ).toBeVisible();
+});
+
+test("each shuffled track keeps its own artist rather than the playlist name", async ({ page }) => {
+  await mockPlaylistApi(page);
+
+  await page.goto(`/music/playlist/${PLAYLIST_ID}`);
+  await expect(page.getByRole("heading", { level: 1, name: "Long Haul" })).toBeVisible();
+
+  await page.evaluate(() => {
+    Math.random = () => 0;
+  });
+
+  await page.getByRole("button", { name: `Shuffle all ${TOTAL_TRACKS} tracks` }).click();
+
+  // Track 2 -> position 2 -> "Album 2" / "Artist 2". The player used to show
+  // the playlist's own name in both slots for every track in the queue.
+  // exact, or these also match the dialog's own sr-only title ("Now playing:
+  // Track 2 by Artist 2") - which, note, is itself the assertion in miniature.
+  const player = page.getByRole("dialog");
+  await expect(player.getByText("Album 2", { exact: true })).toBeVisible();
+  await expect(player.getByText("Artist 2", { exact: true })).toBeVisible();
+  await expect(player.getByText("Long Haul", { exact: true })).toHaveCount(0);
+});
+
+test("play all queues every track too", async ({ page }) => {
+  const { trackPageRequests } = await mockPlaylistApi(page);
+
+  await page.goto(`/music/playlist/${PLAYLIST_ID}`);
+  await expect(page.getByRole("heading", { level: 1, name: "Long Haul" })).toBeVisible();
+
+  await page.getByRole("button", { name: `Play all ${TOTAL_TRACKS} tracks` }).click();
+
+  await expect(trackCounter(page)).toHaveText(`Track 1 of ${TOTAL_TRACKS}`);
+  await expect(page.getByRole("heading", { level: 1, name: "Track 1" })).toBeVisible();
+  expect(trackPageRequests).toEqual([0, 50, 100]);
+});

--- a/web/e2e/playlist-details.spec.ts
+++ b/web/e2e/playlist-details.spec.ts
@@ -53,7 +53,15 @@ const playlistDetails = {
   collaborators: null,
 };
 
-async function mockPlaylistApi(page: Page) {
+type MockOptions = {
+  // Hold every page after the first for this long, so the test can watch
+  // playback start on what is already loaded while the rest is still coming.
+  pageDelayMs?: number;
+  // Serve an error envelope for this offset, as a mid-drain network blip does.
+  failAtOffset?: number;
+};
+
+async function mockPlaylistApi(page: Page, options: MockOptions = {}) {
   const unexpectedApiRequests: string[] = [];
   const trackPageRequests: number[] = [];
 
@@ -95,6 +103,19 @@ async function mockPlaylistApi(page: Page) {
       const slice = allPlaylistTracks.slice(offset, offset + limit);
 
       trackPageRequests.push(offset);
+
+      if (offset === options.failAtOffset) {
+        await fulfillJSON(
+          route,
+          { error: true, message: "Failed to fetch playlist tracks" },
+          500,
+        );
+        return;
+      }
+
+      if (offset > 0 && options.pageDelayMs) {
+        await new Promise(resolve => setTimeout(resolve, options.pageDelayMs));
+      }
 
       await fulfillJSON(route, apiResponse({
         tracks: slice,
@@ -214,4 +235,47 @@ test("play all queues every track too", async ({ page }) => {
   await expect(trackCounter(page)).toHaveText(`Track 1 of ${TOTAL_TRACKS}`);
   await expect(page.getByRole("heading", { level: 1, name: "Track 1" })).toBeVisible();
   expect(trackPageRequests).toEqual([0, 50, 100]);
+});
+
+test("playback starts on the loaded page while the rest downloads behind it", async ({
+  page,
+}) => {
+  const { trackPageRequests } = await mockPlaylistApi(page, { pageDelayMs: 1500 });
+
+  await page.goto(`/music/playlist/${PLAYLIST_ID}`);
+  await expect(page.getByRole("heading", { level: 1, name: "Long Haul" })).toBeVisible();
+
+  await page.getByRole("button", { name: `Play all ${TOTAL_TRACKS} tracks` }).click();
+
+  // The first note must not wait on the drain: a long playlist is dozens of
+  // sequential round trips, and the header buttons used to sit disabled behind
+  // all of them.
+  // (The header buttons are behind the expanded player at this point, so the
+  // counter is what proves playback began on the first page alone.)
+  await expect(trackCounter(page)).toHaveText(`Track 1 of ${PAGE_SIZE}`);
+
+  // ...and the rest still lands.
+  await expect(trackCounter(page)).toHaveText(`Track 1 of ${TOTAL_TRACKS}`, {
+    timeout: 15_000,
+  });
+  expect(trackPageRequests).toEqual([0, 50, 100]);
+});
+
+test("says so when a page of the drain fails instead of quietly playing a short queue", async ({
+  page,
+}) => {
+  await mockPlaylistApi(page, { failAtOffset: 50 });
+
+  await page.goto(`/music/playlist/${PLAYLIST_ID}`);
+  await expect(page.getByRole("heading", { level: 1, name: "Long Haul" })).toBeVisible();
+
+  await page.getByRole("button", { name: `Shuffle all ${TOTAL_TRACKS} tracks` }).click();
+
+  // The button promised 120. Playing 50 without a word is the defect this whole
+  // feature was audited for, so a failed page has to surface.
+  await expect(page.getByText("Failed to shuffle playlist")).toBeVisible();
+  await expect(
+    page.getByText(`Only ${PAGE_SIZE} of ${TOTAL_TRACKS} tracks could be loaded.`),
+  ).toBeVisible();
+  await expect(trackCounter(page)).toHaveText(`Track 1 of ${PAGE_SIZE}`);
 });

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -90,6 +90,18 @@ export function AudioPlayerProvider({
   const playAllOffsetRef = useRef(0);
   const playAllTotalRef = useRef(0);
 
+  // The live queue's identity, mirrored out of state so code running after an
+  // await can test it synchronously. setQueueState is the source of truth for
+  // rendering; this ref is the source of truth for "is the queue I fetched for
+  // still the one playing?", which a state snapshot cannot answer.
+  const liveQueueIdRef = useRef(0);
+
+  // The queue a shuffle refill has already been told the library is exhausted
+  // for. Without it the refill re-fires on every track advance, re-asking a
+  // server that has nothing left and re-toasting the same message each time.
+  // Cleared implicitly: startQueue mints a new id, which can never match.
+  const exhaustedQueueIdRef = useRef<number | null>(null);
+
   const populateTrackMetadata = (tracks: PlayableTrackData[]) => {
     if (trackCoversRef.current === null) {
       trackCoversRef.current = new Map();
@@ -214,6 +226,13 @@ export function AudioPlayerProvider({
   // smaller than the queue returned nothing but duplicates and burned a full
   // table scan per retry.
   const fetchShuffleBatch = async () => {
+    // The library had nothing left for this queue last time we asked, and the
+    // exclusions only grow. Checked here rather than in the `enabled` flag so
+    // the ref is not read during render.
+    if (exhaustedQueueIdRef.current === liveQueueIdRef.current) {
+      return [];
+    }
+
     const knownIds = [...new Set(queueState.tracks.map(track => track.id))];
 
     const response = await getShuffleTracks(
@@ -226,8 +245,11 @@ export function AudioPlayerProvider({
     }
 
     // An empty batch now means the exclusions covered everything left, so say
-    // so instead of letting the queue quietly run dry.
+    // so instead of letting the queue quietly run dry. Latch it against the
+    // live queue: tracksAhead keeps shrinking as the tail plays out, and
+    // without the latch every advance would re-ask and re-toast.
     if (response.data.tracks.length === 0) {
+      exhaustedQueueIdRef.current = liveQueueIdRef.current;
       showInfo(
         "That's the whole library",
         "Shuffle has played everything it hasn't already queued.",
@@ -255,17 +277,34 @@ export function AudioPlayerProvider({
       return [];
     }
 
-    const response = await getTracksPaginated(
-      TRACKS_INFINITE_PAGE_SIZE,
-      playAllOffsetRef.current,
-    );
-    if (response.error || response.data.tracks.length === 0) {
+    // Both the queue this page belongs to and the offset it starts at are read
+    // before the await. The offset must not be re-read afterwards: restarting
+    // play-all resets it, and a `+=` landing after that reset would push the
+    // cursor past a page the new queue has not fetched, silently skipping it
+    // for the rest of the session.
+    const fetchedForQueueId = liveQueueIdRef.current;
+    const offset = playAllOffsetRef.current;
+
+    const response = await getTracksPaginated(TRACKS_INFINITE_PAGE_SIZE, offset);
+    if (response.error) {
+      return [];
+    }
+
+    if (liveQueueIdRef.current !== fetchedForQueueId) {
+      return [];
+    }
+
+    // An empty page below the reported total means the library shrank under
+    // us. Treat the cursor as the real end rather than re-requesting the same
+    // hole on every track advance.
+    if (response.data.tracks.length === 0) {
+      playAllTotalRef.current = offset;
       return [];
     }
 
     const rawTracks = response.data.tracks;
     populateTrackMetadata(rawTracks);
-    playAllOffsetRef.current += rawTracks.length;
+    playAllOffsetRef.current = offset + rawTracks.length;
 
     return rawTracks.map(convertToAudioTrack);
   };
@@ -375,10 +414,14 @@ export function AudioPlayerProvider({
     // details only from track 2 onward.
     const display = resolveTrackDisplay(currentTrack.id, albumInfo);
 
-    setQueueState(prev => ({
-      // A fresh identity so any endless-queue batch still in flight for the
-      // previous queue is dropped by appendToQueue instead of landing here.
-      queueId: prev.queueId + 1,
+    // A fresh identity so any batch still in flight for the previous queue is
+    // dropped by appendToQueue instead of landing here. Minted from the ref
+    // rather than inside the updater so callers (and code resuming after an
+    // await) can name this queue without waiting for a commit.
+    const queueId = ++liveQueueIdRef.current;
+
+    setQueueState({
+      queueId,
       currentTrack,
       tracks,
       albumCover: display.albumCover,
@@ -387,13 +430,15 @@ export function AudioPlayerProvider({
       isShuffleMode,
       isPlayAllMode,
       trimmedCount: 0,
-    }));
+    });
     setIsExpanded(true);
 
     if (isSameTrack && audioRef.current) {
       audioRef.current.currentTime = 0;
       void playMediaElement(audioRef.current);
     }
+
+    return queueId;
   };
 
   const playTrack: AudioPlayerActions["playTrack"] = (track, playlist, albumInfo) => {
@@ -442,9 +487,14 @@ export function AudioPlayerProvider({
     albumInfo,
     rawTracks,
   ) => {
-    if (tracks.length === 0) return;
+    if (tracks.length === 0) return null;
 
-    startQueue({ currentTrack: tracks[0], tracks, albumInfo, rawTracks });
+    return startQueue({
+      currentTrack: tracks[0],
+      tracks,
+      albumInfo,
+      rawTracks,
+    });
   };
 
   const shuffleQueue: AudioPlayerActions["shuffleQueue"] = (
@@ -452,17 +502,70 @@ export function AudioPlayerProvider({
     albumInfo,
     rawTracks,
   ) => {
-    if (tracks.length === 0) return;
+    if (tracks.length === 0) return null;
 
     // rawTracks only seeds the id-keyed metadata maps, so it stays in its
     // original order while the queue itself is shuffled.
     const shuffled = shuffleArray(tracks);
 
-    startQueue({
+    return startQueue({
       currentTrack: shuffled[0],
       tracks: shuffled,
       albumInfo,
       rawTracks,
+    });
+  };
+
+  // Add tracks to a queue that is already playing, for a caller that could not
+  // supply them all up front — a playlist whose remaining pages are still
+  // downloading while the first one plays. The queueId is the one playQueue or
+  // shuffleQueue handed back, so a load that finishes after the user started
+  // something else is dropped rather than spliced into the wrong queue.
+  const extendQueue: AudioPlayerActions["extendQueue"] = (
+    rawTracks,
+    queueId,
+    options,
+  ) => {
+    if (rawTracks.length === 0 || liveQueueIdRef.current !== queueId) return;
+
+    populateTrackMetadata(rawTracks);
+
+    setQueueState(prev => {
+      if (prev.queueId !== queueId) return prev;
+
+      const present = new Set(prev.tracks.map(track => track.id));
+      const appended = rawTracks
+        .filter(track => !present.has(track.id))
+        .map(convertToAudioTrack);
+
+      if (appended.length === 0) return prev;
+
+      const currentIndex = prev.currentTrack
+        ? prev.tracks.findIndex(track => track.id === prev.currentTrack?.id)
+        : -1;
+
+      if (!options?.reshuffleTail || currentIndex < 0) {
+        return { ...prev, tracks: [...prev.tracks, ...appended] };
+      }
+
+      // A shuffled tail appended after a shuffled head is not a shuffle of the
+      // whole playlist, and the button promised one. Re-shuffle everything the
+      // user has not reached yet; played tracks stay put so previous-track
+      // navigation still works.
+      //
+      // shuffleArray makes this updater impure. That is safe here in a way a
+      // deletion would not be: re-running it yields a different order, not a
+      // wrong one, and only the committed run is kept.
+      return {
+        ...prev,
+        tracks: [
+          ...prev.tracks.slice(0, currentIndex + 1),
+          ...shuffleArray([
+            ...prev.tracks.slice(currentIndex + 1),
+            ...appended,
+          ]),
+        ],
+      };
     });
   };
 
@@ -475,6 +578,7 @@ export function AudioPlayerProvider({
         throw new Error(response.message || "Failed to fetch shuffle tracks");
       }
       if (response.data.tracks.length === 0) {
+        showInfo("Nothing to shuffle", "Your library has no tracks yet.");
         return;
       }
 
@@ -504,6 +608,7 @@ export function AudioPlayerProvider({
         throw new Error(response.message || "Failed to fetch tracks");
       }
       if (response.data.tracks.length === 0) {
+        showInfo("Nothing to play", "Your library has no tracks yet.");
         return;
       }
 
@@ -542,10 +647,11 @@ export function AudioPlayerProvider({
     clearMetadataRefs();
     // Keep advancing the identity so a batch still in flight is not appended
     // into the cleared queue.
-    setQueueState(prev => ({
+    const queueId = ++liveQueueIdRef.current;
+    setQueueState({
       ...createInitialQueueState(),
-      queueId: prev.queueId + 1,
-    }));
+      queueId,
+    });
     setIsPlaying(false);
     setIsExpanded(false);
   };
@@ -591,6 +697,7 @@ export function AudioPlayerProvider({
     playTrackFromList,
     playQueue,
     shuffleQueue,
+    extendQueue,
     startShufflePlayback,
     startPlayAllPlayback,
     setTrack,

--- a/web/src/context/AudioPlayerContext.tsx
+++ b/web/src/context/AudioPlayerContext.tsx
@@ -12,6 +12,7 @@ import type {
   TrackType,
 } from "@/types";
 import AudioPlayer from "@/components/playback/AudioPlayer";
+import { useEndlessQueueRefill } from "@/hooks/useEndlessQueueRefill";
 import {
   getShuffleTracks,
   getTracksPaginated,
@@ -27,14 +28,17 @@ import {
   trimQueueHistory,
 } from "@/lib/audio-utils";
 import {
+  SHUFFLE_EXCLUDE_LIMIT,
   SHUFFLE_TRACKS_LIMIT,
   TRACKS_INFINITE_PAGE_SIZE,
 } from "@/lib/constants";
+import { showInfo } from "@/lib/toast-helpers";
 
 const MINIMUM_PLAY_SECONDS = 30;
 const COMPLETION_THRESHOLD = 0.8;
 const PLAY_CHECK_INTERVAL_MS = 5000;
-const MAX_SHUFFLE_FETCH_ATTEMPTS = 3;
+// Both endless modes (shuffle, play all) top up at the same runway: start
+// fetching once this few tracks remain ahead of the current one.
 const ENDLESS_QUEUE_LOAD_AHEAD_TRACKS = 10;
 // Endless queues (shuffle, play all) are trimmed when a new batch is appended;
 // this many played tracks stay reachable via previous-track navigation.
@@ -42,6 +46,7 @@ const MAX_TRACKS_BEHIND = 50;
 
 function createInitialQueueState(): AudioPlayerQueueState {
   return {
+    queueId: 0,
     currentTrack: null,
     tracks: [],
     albumCover: null,
@@ -72,7 +77,6 @@ export function AudioPlayerProvider({
   const [isPlaying, setIsPlaying] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [keyboardSuspendCount, setKeyboardSuspendCount] = useState(0);
-  const isFetchingMoreRef = useRef(false);
   const audioRef = useRef<HTMLAudioElement>(null);
 
   const playStartTimeRef = useRef<number | null>(null);
@@ -108,8 +112,17 @@ export function AudioPlayerProvider({
   // Append a fetched batch to an endless queue, trimming played tracks beyond
   // MAX_TRACKS_BEHIND so multi-hour shuffle or play-all sessions stay bounded.
   // The updater stays pure: their metadata is pruned by the effect below.
-  const appendToQueue = (appended: TrackType[]) => {
+  //
+  // queueId is the queue the batch was fetched for. A batch that lands after
+  // the user started something else is dropped here rather than in an effect
+  // cleanup: this is the only place that can see which queue is actually live,
+  // so a batch cancelled merely by a track advance still gets kept.
+  const appendToQueue = (appended: TrackType[], queueId: number) => {
     setQueueState(prev => {
+      if (prev.queueId !== queueId) {
+        return prev;
+      }
+
       const { tracks: kept, dropped } = trimQueueHistory(
         prev.tracks,
         prev.currentTrack?.id ?? null,
@@ -152,6 +165,32 @@ export function AudioPlayerProvider({
     }
   }, [queueState.tracks, queueState.currentTrack]);
 
+  // Resolve one track's display metadata: the per-track values when the queue
+  // carries them (mixed lists - playlists, shuffle, play all, search results),
+  // otherwise the queue-wide fallback, which is what album and musician queues
+  // rely on. A track can legitimately map to null (no cover, no musician), so
+  // "unmapped" and "mapped to null" are distinguished via has().
+  const resolveTrackDisplay = (
+    trackId: number,
+    fallback: { cover: string | null; title: string; musician: string | null },
+  ) => {
+    const covers = trackCoversRef.current;
+    const musicians = trackMusiciansRef.current;
+    const albumTitles = trackAlbumTitlesRef.current;
+
+    return {
+      albumCover: covers?.has(trackId)
+        ? (covers.get(trackId) ?? null)
+        : fallback.cover,
+      musicianName: musicians?.has(trackId)
+        ? (musicians.get(trackId) ?? null)
+        : fallback.musician,
+      albumTitle: albumTitles?.has(trackId)
+        ? (albumTitles.get(trackId) ?? "")
+        : fallback.title,
+    };
+  };
+
   const clearMetadataRefs = () => {
     trackCoversRef.current?.clear();
     trackMusiciansRef.current?.clear();
@@ -164,140 +203,90 @@ export function AudioPlayerProvider({
     ? queueState.tracks.findIndex(track => track.id === queueState.currentTrack?.id)
     : -1;
 
-  useEffect(() => {
-    const shouldFetchMore =
-      queueState.isShuffleMode &&
-      currentTrackIndex >= 0 &&
-      queueState.tracks.length - currentTrackIndex < 5 &&
-      !isFetchingMoreRef.current;
+  // Runway left ahead of the current track; negative when the current track is
+  // not in the queue (which the refill hook treats as "do nothing").
+  const tracksAhead = currentTrackIndex >= 0
+    ? queueState.tracks.length - currentTrackIndex
+    : -1;
 
-    if (!shouldFetchMore) {
-      return;
+  // Tell the server which tracks the queue already holds so it samples around
+  // them. It used to re-sample the whole library blind, which on a library
+  // smaller than the queue returned nothing but duplicates and burned a full
+  // table scan per retry.
+  const fetchShuffleBatch = async () => {
+    const knownIds = [...new Set(queueState.tracks.map(track => track.id))];
+
+    const response = await getShuffleTracks(
+      SHUFFLE_TRACKS_LIMIT,
+      // The most recent ids matter most if the queue ever outgrows the cap.
+      knownIds.slice(-SHUFFLE_EXCLUDE_LIMIT),
+    );
+    if (response.error) {
+      return [];
     }
 
-    let isCancelled = false;
-
-    const fetchMoreShuffleTracks = async () => {
-      isFetchingMoreRef.current = true;
-
-      // The shuffle endpoint returns purely random tracks with no awareness of
-      // what we've already queued, so dedupe against the existing queue. Retry a
-      // few times when a batch is all duplicates so playback doesn't stall.
-      const knownIds = new Set(queueState.tracks.map(track => track.id));
-      const collected: TrackType[] = [];
-      let attempts = 0;
-
-      while (
-        attempts < MAX_SHUFFLE_FETCH_ATTEMPTS &&
-        collected.length === 0 &&
-        !isCancelled
-      ) {
-        attempts++;
-
-        // The React Compiler cannot compile components containing
-        // conditional/logical expressions inside try blocks, so the try wraps
-        // only the fetch itself.
-        let response;
-        try {
-          response = await getShuffleTracks(SHUFFLE_TRACKS_LIMIT);
-        } catch {
-          // Silently fail - user can continue with the current queue.
-          break;
-        }
-
-        if (response.error || response.data.tracks.length === 0) {
-          break;
-        }
-
-        const rawTracks = response.data.tracks;
-        populateTrackMetadata(rawTracks);
-
-        for (const track of rawTracks) {
-          if (!knownIds.has(track.id)) {
-            knownIds.add(track.id);
-            collected.push(convertToAudioTrack(track));
-          }
-        }
-      }
-
-      if (!isCancelled && collected.length > 0) {
-        appendToQueue(collected);
-      }
-
-      isFetchingMoreRef.current = false;
-    };
-
-    void fetchMoreShuffleTracks();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [
-    queueState.isShuffleMode,
-    currentTrackIndex,
-    queueState.tracks,
-  ]);
-
-  useEffect(() => {
-    const shouldFetchMore =
-      queueState.isPlayAllMode &&
-      currentTrackIndex >= 0 &&
-      queueState.tracks.length - currentTrackIndex <
-        ENDLESS_QUEUE_LOAD_AHEAD_TRACKS &&
-      !isFetchingMoreRef.current &&
-      playAllOffsetRef.current < playAllTotalRef.current;
-
-    if (!shouldFetchMore) {
-      return;
+    // An empty batch now means the exclusions covered everything left, so say
+    // so instead of letting the queue quietly run dry.
+    if (response.data.tracks.length === 0) {
+      showInfo(
+        "That's the whole library",
+        "Shuffle has played everything it hasn't already queued.",
+      );
+      return [];
     }
 
-    let isCancelled = false;
+    // Defensive: the server honours only the first SHUFFLE_EXCLUDE_LIMIT ids,
+    // and a repeated id would break the player's findIndex navigation.
+    const excluded = new Set(knownIds);
+    const rawTracks = response.data.tracks.filter(
+      track => !excluded.has(track.id),
+    );
 
-    const fetchMorePlayAllTracks = async () => {
-      isFetchingMoreRef.current = true;
+    populateTrackMetadata(rawTracks);
 
-      // Try wraps only the fetch: the React Compiler cannot compile
-      // components containing conditional/logical expressions in try blocks.
-      let response = null;
-      try {
-        response = await getTracksPaginated(
-          TRACKS_INFINITE_PAGE_SIZE,
-          playAllOffsetRef.current,
-        );
-      } catch {
-        // Silently fail - user can continue with the current queue.
-      }
+    return rawTracks.map(convertToAudioTrack);
+  };
 
-      if (
-        response !== null &&
-        !isCancelled &&
-        !response.error &&
-        response.data.tracks.length > 0
-      ) {
-        const rawTracks = response.data.tracks;
-        const newTracks = rawTracks.map(convertToAudioTrack);
+  const fetchPlayAllBatch = async () => {
+    // Play-all walks the library in order, so it stops once the last page has
+    // been fetched. Checked here rather than in the `enabled` flag so the refs
+    // are not read during render.
+    if (playAllOffsetRef.current >= playAllTotalRef.current) {
+      return [];
+    }
 
-        populateTrackMetadata(rawTracks);
-        playAllOffsetRef.current += rawTracks.length;
+    const response = await getTracksPaginated(
+      TRACKS_INFINITE_PAGE_SIZE,
+      playAllOffsetRef.current,
+    );
+    if (response.error || response.data.tracks.length === 0) {
+      return [];
+    }
 
-        if (newTracks.length > 0) {
-          appendToQueue(newTracks);
-        }
-      }
+    const rawTracks = response.data.tracks;
+    populateTrackMetadata(rawTracks);
+    playAllOffsetRef.current += rawTracks.length;
 
-      isFetchingMoreRef.current = false;
-    };
+    return rawTracks.map(convertToAudioTrack);
+  };
 
-    void fetchMorePlayAllTracks();
+  useEndlessQueueRefill({
+    enabled: queueState.isShuffleMode,
+    queueId: queueState.queueId,
+    tracksAhead,
+    lookahead: ENDLESS_QUEUE_LOAD_AHEAD_TRACKS,
+    fetchBatch: fetchShuffleBatch,
+    onAppend: appendToQueue,
+  });
 
-    return () => {
-      isCancelled = true;
-    };
-  }, [
-    queueState.isPlayAllMode,
-    currentTrackIndex,
-    queueState.tracks.length,
-  ]);
+  useEndlessQueueRefill({
+    enabled: queueState.isPlayAllMode,
+    queueId: queueState.queueId,
+    tracksAhead,
+    lookahead: ENDLESS_QUEUE_LOAD_AHEAD_TRACKS,
+    fetchBatch: fetchPlayAllBatch,
+    onAppend: appendToQueue,
+  });
 
   useEffect(() => {
     const trackId = queueState.currentTrack?.id ?? null;
@@ -381,16 +370,24 @@ export function AudioPlayerProvider({
     // — rewind here or "Play all" would silently resume mid-track.
     const isSameTrack = currentTrack.id === queueState.currentTrack?.id;
 
-    setQueueState({
+    // Resolve the opening track the same way navigation does, or a mixed queue
+    // would show the queue-wide albumInfo for track 1 and each track's own
+    // details only from track 2 onward.
+    const display = resolveTrackDisplay(currentTrack.id, albumInfo);
+
+    setQueueState(prev => ({
+      // A fresh identity so any endless-queue batch still in flight for the
+      // previous queue is dropped by appendToQueue instead of landing here.
+      queueId: prev.queueId + 1,
       currentTrack,
       tracks,
-      albumCover: albumInfo.cover,
-      albumTitle: albumInfo.title,
-      musicianName: albumInfo.musician,
+      albumCover: display.albumCover,
+      albumTitle: display.albumTitle,
+      musicianName: display.musicianName,
       isShuffleMode,
       isPlayAllMode,
       trimmedCount: 0,
-    });
+    }));
     setIsExpanded(true);
 
     if (isSameTrack && audioRef.current) {
@@ -440,24 +437,44 @@ export function AudioPlayerProvider({
     });
   };
 
-  const playQueue: AudioPlayerActions["playQueue"] = (tracks, albumInfo) => {
+  const playQueue: AudioPlayerActions["playQueue"] = (
+    tracks,
+    albumInfo,
+    rawTracks,
+  ) => {
     if (tracks.length === 0) return;
 
-    startQueue({ currentTrack: tracks[0], tracks, albumInfo });
+    startQueue({ currentTrack: tracks[0], tracks, albumInfo, rawTracks });
   };
 
-  const shuffleQueue: AudioPlayerActions["shuffleQueue"] = (tracks, albumInfo) => {
+  const shuffleQueue: AudioPlayerActions["shuffleQueue"] = (
+    tracks,
+    albumInfo,
+    rawTracks,
+  ) => {
     if (tracks.length === 0) return;
 
+    // rawTracks only seeds the id-keyed metadata maps, so it stays in its
+    // original order while the queue itself is shuffled.
     const shuffled = shuffleArray(tracks);
 
-    startQueue({ currentTrack: shuffled[0], tracks: shuffled, albumInfo });
+    startQueue({
+      currentTrack: shuffled[0],
+      tracks: shuffled,
+      albumInfo,
+      rawTracks,
+    });
   };
 
   const startShufflePlayback: AudioPlayerActions["startShufflePlayback"] =
     async () => {
       const response = await getShuffleTracks(SHUFFLE_TRACKS_LIMIT);
-      if (response.error || response.data.tracks.length === 0) {
+      // apiRequest resolves an error envelope rather than rejecting, so throw
+      // here or the caller's catch (and its toast) never runs.
+      if (response.error) {
+        throw new Error(response.message || "Failed to fetch shuffle tracks");
+      }
+      if (response.data.tracks.length === 0) {
         return;
       }
 
@@ -465,12 +482,15 @@ export function AudioPlayerProvider({
       // covers repeats within the first batch.
       const rawTracks = dedupeById(response.data.tracks);
       const tracks = rawTracks.map(convertToAudioTrack);
-      const { cover, musician } = extractTrackMetadata(rawTracks[0]);
+      // The first track's own album, not a "Shuffle All" placeholder: setTrack
+      // resolves the real title from track 2 onward, so a literal here would
+      // show a bogus album for exactly one track.
+      const { cover, musician, albumTitle } = extractTrackMetadata(rawTracks[0]);
 
       startQueue({
         currentTrack: tracks[0],
         tracks,
-        albumInfo: { cover, title: "Shuffle All", musician },
+        albumInfo: { cover, title: albumTitle, musician },
         rawTracks,
         isShuffleMode: true,
       });
@@ -479,18 +499,22 @@ export function AudioPlayerProvider({
   const startPlayAllPlayback: AudioPlayerActions["startPlayAllPlayback"] =
     async () => {
       const response = await getTracksPaginated(TRACKS_INFINITE_PAGE_SIZE, 0);
-      if (response.error || response.data.tracks.length === 0) {
+      // Same error-envelope caveat as startShufflePlayback above.
+      if (response.error) {
+        throw new Error(response.message || "Failed to fetch tracks");
+      }
+      if (response.data.tracks.length === 0) {
         return;
       }
 
       const rawTracks = response.data.tracks;
       const tracks = rawTracks.map(convertToAudioTrack);
-      const { cover, musician } = extractTrackMetadata(rawTracks[0]);
+      const { cover, musician, albumTitle } = extractTrackMetadata(rawTracks[0]);
 
       startQueue({
         currentTrack: tracks[0],
         tracks,
-        albumInfo: { cover, title: "All Tracks", musician },
+        albumInfo: { cover, title: albumTitle, musician },
         rawTracks,
         isPlayAllMode: true,
       });
@@ -501,34 +525,27 @@ export function AudioPlayerProvider({
     };
 
   const setTrack: AudioPlayerActions["setTrack"] = track => {
-    setQueueState(prev => {
-      // Album/playlist flows clear the metadata maps, so their lookups miss
-      // and the queue-wide values carry over; mixed queues (shuffle, play
-      // all, search/library lists) resolve per-track metadata here. A track
-      // can legitimately map to null (no cover/musician), so distinguish
-      // "unmapped" from "mapped to null" via has().
-      const covers = trackCoversRef.current;
-      const musicians = trackMusiciansRef.current;
-
-      return {
-        ...prev,
-        currentTrack: track,
-        albumCover: covers?.has(track.id)
-          ? (covers.get(track.id) ?? null)
-          : prev.albumCover,
-        musicianName: musicians?.has(track.id)
-          ? (musicians.get(track.id) ?? null)
-          : prev.musicianName,
-        albumTitle: trackAlbumTitlesRef.current?.has(track.id)
-          ? (trackAlbumTitlesRef.current.get(track.id) ?? "")
-          : prev.albumTitle,
-      };
-    });
+    setQueueState(prev => ({
+      ...prev,
+      currentTrack: track,
+      // Album and musician queues leave the maps empty, so the values already
+      // on the queue are the fallback.
+      ...resolveTrackDisplay(track.id, {
+        cover: prev.albumCover,
+        title: prev.albumTitle,
+        musician: prev.musicianName,
+      }),
+    }));
   };
 
   const stop: AudioPlayerActions["stop"] = () => {
     clearMetadataRefs();
-    setQueueState(createInitialQueueState());
+    // Keep advancing the identity so a batch still in flight is not appended
+    // into the cleared queue.
+    setQueueState(prev => ({
+      ...createInitialQueueState(),
+      queueId: prev.queueId + 1,
+    }));
     setIsPlaying(false);
     setIsExpanded(false);
   };

--- a/web/src/hooks/useEndlessQueueRefill.ts
+++ b/web/src/hooks/useEndlessQueueRefill.ts
@@ -1,0 +1,79 @@
+import { useEffect, useEffectEvent, useRef } from "react";
+
+type EndlessQueueRefillOptions<T> = {
+  // Whether this queue mode is active and still has anything left to fetch.
+  enabled: boolean;
+
+  // Identifies the queue the refill belongs to. It is handed back to onAppend
+  // so a batch that finishes after the user started a different queue can be
+  // dropped by the state updater rather than spliced into the wrong queue.
+  queueId: number;
+
+  // How many tracks remain ahead of the current one. Pass a negative number
+  // when the current track is not in the queue.
+  tracksAhead: number;
+
+  // Start fetching once fewer than this many tracks remain ahead.
+  lookahead: number;
+
+  // Fetch one batch. Resolve with an empty array for "nothing to add"; a
+  // rejection is swallowed and the user keeps the queue they already have.
+  fetchBatch: () => Promise<T[]>;
+
+  onAppend: (batch: T[], queueId: number) => void;
+};
+
+// Shared driver for the endless queues (library shuffle, play all): watch how
+// much runway is left ahead of the current track and top the queue up before it
+// runs out.
+//
+// There is deliberately no effect cleanup. A batch that has already been
+// fetched is paid for, and tearing the effect down (which happens on every
+// track advance, since tracksAhead is a dependency) used to discard it and then
+// bail out of the retry because the in-flight guard was still set — burning a
+// request and narrowing the lookahead margin. Whether a finished batch is still
+// wanted is a question only the state updater can answer, so it is asked there
+// via queueId instead.
+export function useEndlessQueueRefill<T>({
+  enabled,
+  queueId,
+  tracksAhead,
+  lookahead,
+  fetchBatch,
+  onAppend,
+}: EndlessQueueRefillOptions<T>) {
+  // A ref rather than state: flipping it must not re-render, and the effect
+  // re-evaluates on the next track advance anyway.
+  const isFetchingRef = useRef(false);
+
+  const runRefill = useEffectEvent(async (activeQueueId: number) => {
+    isFetchingRef.current = true;
+
+    let batch: T[] = [];
+    try {
+      batch = await fetchBatch();
+    } catch {
+      // Swallowed on purpose - playback continues with the current queue.
+    }
+
+    if (batch.length > 0) {
+      onAppend(batch, activeQueueId);
+    }
+
+    isFetchingRef.current = false;
+  });
+
+  useEffect(() => {
+    const shouldFetch =
+      enabled &&
+      tracksAhead >= 0 &&
+      tracksAhead < lookahead &&
+      !isFetchingRef.current;
+
+    if (!shouldFetch) {
+      return;
+    }
+
+    void runRefill(queueId);
+  }, [enabled, queueId, tracksAhead, lookahead]);
+}

--- a/web/src/hooks/useEndlessQueueRefill.ts
+++ b/web/src/hooks/useEndlessQueueRefill.ts
@@ -42,12 +42,15 @@ export function useEndlessQueueRefill<T>({
   fetchBatch,
   onAppend,
 }: EndlessQueueRefillOptions<T>) {
-  // A ref rather than state: flipping it must not re-render, and the effect
-  // re-evaluates on the next track advance anyway.
-  const isFetchingRef = useRef(false);
+  // The queue a fetch is currently in flight for, or null when idle. Keyed by
+  // queue rather than a plain boolean so a refill for a queue the user has
+  // since replaced does not lock the new one out: that batch will be discarded
+  // on arrival anyway, and the new queue may be short enough to need topping up
+  // immediately. A ref rather than state — flipping it must not re-render.
+  const inFlightQueueIdRef = useRef<number | null>(null);
 
   const runRefill = useEffectEvent(async (activeQueueId: number) => {
-    isFetchingRef.current = true;
+    inFlightQueueIdRef.current = activeQueueId;
 
     let batch: T[] = [];
     try {
@@ -56,11 +59,16 @@ export function useEndlessQueueRefill<T>({
       // Swallowed on purpose - playback continues with the current queue.
     }
 
+    // Only the fetch that is still the in-flight one may clear the flag; a
+    // straggler from a replaced queue must not unlock a live fetch. Cleared
+    // before the append so the re-render it causes sees an idle hook.
+    if (inFlightQueueIdRef.current === activeQueueId) {
+      inFlightQueueIdRef.current = null;
+    }
+
     if (batch.length > 0) {
       onAppend(batch, activeQueueId);
     }
-
-    isFetchingRef.current = false;
   });
 
   useEffect(() => {
@@ -68,7 +76,7 @@ export function useEndlessQueueRefill<T>({
       enabled &&
       tracksAhead >= 0 &&
       tracksAhead < lookahead &&
-      !isFetchingRef.current;
+      inFlightQueueIdRef.current !== queueId;
 
     if (!shouldFetch) {
       return;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -511,9 +511,20 @@ export const getTracksPaginated = (limit: number, offset: number) =>
     withQuery("/api/music/tracks", { limit, offset }),
   );
 
-export const getShuffleTracks = (limit: number = SHUFFLE_TRACKS_LIMIT) =>
+// excludeTrackIds tells the server what the caller already holds so the random
+// sample is drawn around it. Sent comma-separated rather than as repeated
+// params - the server accepts either and one entry keeps the URL short.
+export const getShuffleTracks = (
+  limit: number = SHUFFLE_TRACKS_LIMIT,
+  excludeTrackIds: number[] = [],
+) =>
   apiRequest<ShuffleTracksResponseType>(
-    withQuery("/api/music/tracks/shuffle", { limit }),
+    withQuery("/api/music/tracks/shuffle", {
+      limit,
+      ...(excludeTrackIds.length > 0
+        ? { exclude: excludeTrackIds.join(",") }
+        : {}),
+    }),
   );
 
 export const toggleLikeTrack = (trackId: number) =>

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -108,6 +108,9 @@ export const TRACKS_INFINITE_PAGE_SIZE = 50;
 export const PLAYLIST_TRACKS_PAGE_SIZE = 50;
 export const LIKED_TRACKS_PER_PAGE = 50;
 export const SHUFFLE_TRACKS_LIMIT = 50;
+// How many already-queued track ids a shuffle refill sends back so the server
+// samples around them. Matches the server's own cap.
+export const SHUFFLE_EXCLUDE_LIMIT = 200;
 
 // Route search defaults. Reuse these when navigating so links and loaders agree
 // on the canonical starting search state for a route.

--- a/web/src/routes/_auth/music/musician.$id.tsx
+++ b/web/src/routes/_auth/music/musician.$id.tsx
@@ -42,6 +42,7 @@ import type {
   MusicianAlbumType,
   MusicianDetailsResponseType,
   MusicianTrackType,
+  PlayableTrackData,
 } from "@/types";
 
 export const Route = createFileRoute("/_auth/music/musician/$id")({
@@ -224,62 +225,71 @@ function MusicianDetailsContent({
   const pageTitle = `${musician.name} - Igloo`;
   const pageDescription = `Listen to ${musician.name} - ${albums.length} albums, ${tracks.length} tracks in your Igloo music library.`;
 
-  const convertTracksForPlayer = (musicianTracks: MusicianTrackType[]) => {
-    return musicianTracks.map((track) =>
-      convertToAudioTrack({
-        id: track.id,
-        title: track.title,
-        duration: track.duration,
-        file_path: track.file_path,
-        codec: track.codec,
-        bit_rate: track.bit_rate,
-        album_id: track.album_id,
-        musician_id: { Int64: musician.id, Valid: true },
-        album_cover: track.album_cover,
-        musician_name: { String: musician.name, Valid: true },
-      }),
-    );
+  // A musician's tracks span every album they appear on, so each row carries its
+  // own album title and cover. Keep them as PlayableTrackData and hand them to
+  // the player, or the queue-wide fallback shows the musician's name in the
+  // album slot and their photo as the cover for every track. Only the artist is
+  // genuinely queue-wide here, so that one is filled in from the page.
+  const toPlayableData = (
+    musicianTracks: MusicianTrackType[],
+  ): PlayableTrackData[] =>
+    musicianTracks.map((track) => ({
+      id: track.id,
+      title: track.title,
+      duration: track.duration,
+      file_path: track.file_path,
+      codec: track.codec,
+      bit_rate: track.bit_rate,
+      album_id: track.album_id,
+      album_title: track.album_title,
+      album_cover: track.album_cover,
+      musician_id: { Int64: musician.id, Valid: true },
+      musician_name: { String: musician.name, Valid: true },
+    }));
+
+  const albumInfo = {
+    cover: thumbUrl,
+    title: musician.name,
+    musician: musician.name,
   };
 
   const handlePlayAll = () => {
     if (tracks.length === 0) return;
 
-    const playerTracks = convertTracksForPlayer(tracks);
-    audioPlayer.playQueue(playerTracks, {
-      cover: thumbUrl,
-      title: musician.name,
-      musician: musician.name,
-    });
+    const rawTracks = toPlayableData(tracks);
+    audioPlayer.playQueue(
+      rawTracks.map(convertToAudioTrack),
+      albumInfo,
+      rawTracks,
+    );
   };
 
   const handleShufflePlay = () => {
     if (tracks.length === 0) return;
 
-    const playerTracks = convertTracksForPlayer(tracks);
-    audioPlayer.shuffleQueue(playerTracks, {
-      cover: thumbUrl,
-      title: musician.name,
-      musician: musician.name,
-    });
+    const rawTracks = toPlayableData(tracks);
+    audioPlayer.shuffleQueue(
+      rawTracks.map(convertToAudioTrack),
+      albumInfo,
+      rawTracks,
+    );
   };
 
-  // playTrack (not playQueue) so a click on the current row toggles play/pause
-  // instead of restarting — the row button is labeled "Pause X" there.
+  // playTrackFromList (not playQueue) so a click on the current row toggles
+  // play/pause instead of restarting — the row button is labeled "Pause X"
+  // there. The list is rotated to start at the clicked track, which is what the
+  // page has always done, and passing the raw rows keeps each track's own album
+  // details as the queue advances.
   const handlePlayTrack = (track: MusicianTrackType) => {
     const trackIndex = tracks.findIndex((t) => t.id === track.id);
     if (trackIndex < 0) return;
 
-    const playerTracks = convertTracksForPlayer(tracks);
-    const reorderedTracks = [
-      ...playerTracks.slice(trackIndex),
-      ...playerTracks.slice(0, trackIndex),
-    ];
+    const rawTracks = toPlayableData([
+      ...tracks.slice(trackIndex),
+      ...tracks.slice(0, trackIndex),
+    ]);
 
-    audioPlayer.playTrack(reorderedTracks[0], reorderedTracks, {
-      cover: unwrapString(track.album_cover) ?? thumbUrl,
-      title: musician.name,
-      musician: musician.name,
-    });
+    audioPlayer.playTrackFromList(rawTracks, track.id);
   };
 
   // Screen reader announcement summarizing the page

--- a/web/src/routes/_auth/music/playlist.$id.tsx
+++ b/web/src/routes/_auth/music/playlist.$id.tsx
@@ -21,6 +21,7 @@ import {
   ArrowLeft,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
+import { Button } from "@/components/ui/button";
 import TrackItem from "@/components/music/TrackItem";
 import EditPlaylistDialog from "@/components/music/EditPlaylistDialog";
 import ConfirmDialog from "@/components/shared/ConfirmDialog";
@@ -35,7 +36,7 @@ import {
 import { unwrapString, unwrapInt, unwrapStringOrUndefined } from "@/lib/nullable";
 import { getMediaImageUrl } from "@/lib/media-image-url";
 import { deletePlaylist, removeTrackFromPlaylist, reorderPlaylistTracks } from "@/lib/api";
-import { convertToAudioTrack } from "@/lib/audio-utils";
+import { convertToAudioTrack, dedupeById } from "@/lib/audio-utils";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
 import { useTrackPlaybackMatcher } from "@/hooks/useTrackPlaybackMatcher";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
@@ -50,10 +51,16 @@ import {
   MOTION_MICRO_COLORS_CLASS,
 } from "@/lib/constants";
 import { cn } from "@/lib/utils";
-import type { PlaylistTrackType } from "@/types";
+import type { PlayableTrackData, PlaylistTrackType } from "@/types";
 
-function playlistTrackToAudioTrack(track: PlaylistTrackType) {
-  return convertToAudioTrack({
+// A playlist row already carries every field the player needs, including the
+// per-track album/artist. Keep it as PlayableTrackData and hand that to the
+// player alongside the queue, or a mixed playlist shows the playlist's own name
+// and cover for every track.
+function playlistTrackToPlayableData(
+  track: PlaylistTrackType,
+): PlayableTrackData {
+  return {
     id: track.id,
     title: track.title,
     file_path: track.file_path,
@@ -64,7 +71,8 @@ function playlistTrackToAudioTrack(track: PlaylistTrackType) {
     musician_id: track.musician_id,
     album_cover: track.album_cover,
     musician_name: track.musician_name,
-  });
+    album_title: track.album_title,
+  };
 }
 
 export const Route = createFileRoute("/_auth/music/playlist/$id")({
@@ -138,6 +146,7 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
   const audioPlayer = useAudioPlayerActions();
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [isStartingPlayback, setIsStartingPlayback] = useState(false);
   const editButtonRef = useRef<HTMLButtonElement | null>(null);
   const deleteButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -220,25 +229,72 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
     },
   });
 
+  // The tracks list is an infinite query, so allTracks only holds the pages the
+  // user has scrolled into. The header buttons promise the playlist's full
+  // track_count, so drain the rest before queueing. fetchNextPage resolves with
+  // the updated observer result, so the loop reads hasNextPage off that instead
+  // of the stale value captured in this closure.
+  const loadAllTracks = async () => {
+    if (!hasNextPage) return allTracks;
+
+    let result = await fetchNextPage();
+    while (result.hasNextPage) {
+      result = await fetchNextPage();
+    }
+
+    return (
+      result.data?.pages.flatMap((page) =>
+        page.error === false ? (page.data?.tracks ?? []) : [],
+      ) ?? allTracks
+    );
+  };
+
   // playQueue/shuffleQueue instead of playTrack: these header buttons are
   // explicit "start over" entry points and must restart even when the first
   // track is already the current one (playTrack toggles in that case).
+  const startPlaylistQueue = async (shuffle: boolean) => {
+    setIsStartingPlayback(true);
+
+    // The try wraps only the fetch: the React Compiler cannot compile
+    // components with conditional/logical expressions inside a try block.
+    let tracks: PlaylistTrackType[] = [];
+    let didFail = false;
+    try {
+      tracks = await loadAllTracks();
+    } catch {
+      didFail = true;
+    }
+
+    if (didFail) {
+      showActionFailed(shuffle ? "shuffle playlist" : "play playlist");
+    } else if (tracks.length > 0) {
+      // A playlist may hold the same track at two positions. The player finds
+      // the current track with findIndex, so a repeated id would make next/prev
+      // jump back to the first copy — dedupe as playTrackFromList does.
+      const rawTracks = dedupeById(tracks.map(playlistTrackToPlayableData));
+      const audioTracks = rawTracks.map(convertToAudioTrack);
+      const albumInfo = {
+        cover: coverUrl,
+        title: playlist.name,
+        musician: null,
+      };
+
+      if (shuffle) {
+        audioPlayer.shuffleQueue(audioTracks, albumInfo, rawTracks);
+      } else {
+        audioPlayer.playQueue(audioTracks, albumInfo, rawTracks);
+      }
+    }
+
+    setIsStartingPlayback(false);
+  };
+
   const handlePlayAll = () => {
-    if (!allTracks.length) return;
-    audioPlayer.playQueue(allTracks.map(playlistTrackToAudioTrack), {
-      cover: coverUrl,
-      title: playlist.name,
-      musician: null,
-    });
+    void startPlaylistQueue(false);
   };
 
   const handleShuffle = () => {
-    if (!allTracks.length) return;
-    audioPlayer.shuffleQueue(allTracks.map(playlistTrackToAudioTrack), {
-      cover: coverUrl,
-      title: playlist.name,
-      musician: null,
-    });
+    void startPlaylistQueue(true);
   };
 
   const handleDeletePlaylist = () => {
@@ -320,30 +376,38 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
           {/* Play buttons */}
           {track_count > 0 && (
             <div className="mt-5 flex flex-col justify-center gap-2 sm:mt-6 sm:flex-row sm:gap-3 lg:justify-start">
-              <button
+              <Button
                 type="button"
+                variant="accent-pill"
+                size="lg"
                 onClick={handlePlayAll}
-                className={cn(
-                  MOTION_MICRO_COLORS_CLASS,
-                  "inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden sm:px-6 sm:py-3 sm:text-base",
-                )}
+                disabled={isStartingPlayback}
+                className="w-full font-semibold shadow-lg shadow-primary/20 sm:w-auto"
                 aria-label={`Play all ${track_count} tracks`}
               >
-                <Play className="size-4 fill-current" aria-hidden="true" />
-                Play All
-              </button>
-              <button
-                type="button"
-                onClick={handleShuffle}
-                className={cn(
-                  MOTION_MICRO_COLORS_CLASS,
-                  "inline-flex items-center justify-center gap-2 rounded-full border border-border bg-accent px-5 py-2.5 text-sm font-semibold text-foreground hover:bg-accent focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-hidden sm:px-6 sm:py-3 sm:text-base",
+                {isStartingPlayback ? (
+                  <Spinner className="size-4" />
+                ) : (
+                  <Play className="size-4 fill-current" aria-hidden="true" />
                 )}
+                Play All
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                onClick={handleShuffle}
+                disabled={isStartingPlayback}
+                className="w-full rounded-full font-semibold sm:w-auto"
                 aria-label={`Shuffle all ${track_count} tracks`}
               >
-                <Shuffle className="size-4" aria-hidden="true" />
+                {isStartingPlayback ? (
+                  <Spinner className="size-4" />
+                ) : (
+                  <Shuffle className="size-4" aria-hidden="true" />
+                )}
                 Shuffle
-              </button>
+              </Button>
             </div>
           )}
 
@@ -517,17 +581,14 @@ function PlaylistTracksList({
           .filter((track): track is PlaylistTrackType => track !== undefined)
       : tracks;
 
+  // playTrackFromList, not playTrack: it keeps the same toggle-on-repeat-click
+  // contract but queues the raw rows, so each track keeps its own cover and
+  // artist as the queue advances instead of inheriting the playlist's.
   const handlePlayTrack = (track: PlaylistTrackType) => {
-    const audioTrack = playlistTrackToAudioTrack(track);
-
-    // Create playlist of all tracks for continuous playback
-    const allAudioTracks = orderedTracks.map(playlistTrackToAudioTrack);
-
-    audioPlayer.playTrack(audioTrack, allAudioTracks, {
-      cover: coverUrl,
-      title: playlistName,
-      musician: null,
-    });
+    audioPlayer.playTrackFromList(
+      orderedTracks.map(playlistTrackToPlayableData),
+      track.id,
+    );
   };
 
   // Handle reorder with optimistic update

--- a/web/src/routes/_auth/music/playlist.$id.tsx
+++ b/web/src/routes/_auth/music/playlist.$id.tsx
@@ -146,7 +146,9 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
   const audioPlayer = useAudioPlayerActions();
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [isStartingPlayback, setIsStartingPlayback] = useState(false);
+  // The rest of the playlist downloading behind playback that has already
+  // started — a progress hint on the buttons, not a block on using them.
+  const [isLoadingRest, setIsLoadingRest] = useState(false);
   const editButtonRef = useRef<HTMLButtonElement | null>(null);
   const deleteButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -230,22 +232,33 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
   });
 
   // The tracks list is an infinite query, so allTracks only holds the pages the
-  // user has scrolled into. The header buttons promise the playlist's full
-  // track_count, so drain the rest before queueing. fetchNextPage resolves with
-  // the updated observer result, so the loop reads hasNextPage off that instead
-  // of the stale value captured in this closure.
-  const loadAllTracks = async () => {
-    if (!hasNextPage) return allTracks;
-
+  // user has scrolled into, while the header buttons promise the playlist's
+  // full track_count. Drain the rest in the background: on a long playlist this
+  // is dozens of sequential round trips, and making the first note wait on them
+  // is worse than starting with what is already here.
+  //
+  // fetchNextPage resolves with the updated observer result, so the loop reads
+  // hasNextPage off that instead of the stale value captured in this closure.
+  // It never rejects (TanStack swallows the error, and apiRequest returns an
+  // error envelope rather than throwing), so a failed page shows up only as a
+  // short result — hence the page-count guard, which stops the loop if a round
+  // ever fails to add a page.
+  const loadRemainingTracks = async () => {
     let result = await fetchNextPage();
+    let pageCount = result.data?.pages.length ?? 0;
+
     while (result.hasNextPage) {
       result = await fetchNextPage();
+
+      const nextCount = result.data?.pages.length ?? 0;
+      if (nextCount <= pageCount) break;
+      pageCount = nextCount;
     }
 
     return (
       result.data?.pages.flatMap((page) =>
         page.error === false ? (page.data?.tracks ?? []) : [],
-      ) ?? allTracks
+      ) ?? []
     );
   };
 
@@ -253,40 +266,45 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
   // explicit "start over" entry points and must restart even when the first
   // track is already the current one (playTrack toggles in that case).
   const startPlaylistQueue = async (shuffle: boolean) => {
-    setIsStartingPlayback(true);
+    const action = shuffle ? "shuffle playlist" : "play playlist";
 
-    // The try wraps only the fetch: the React Compiler cannot compile
-    // components with conditional/logical expressions inside a try block.
-    let tracks: PlaylistTrackType[] = [];
-    let didFail = false;
-    try {
-      tracks = await loadAllTracks();
-    } catch {
-      didFail = true;
+    if (allTracks.length === 0) {
+      showActionFailed(action, "This playlist has no tracks to play yet.");
+      return;
     }
 
-    if (didFail) {
-      showActionFailed(shuffle ? "shuffle playlist" : "play playlist");
-    } else if (tracks.length > 0) {
-      // A playlist may hold the same track at two positions. The player finds
-      // the current track with findIndex, so a repeated id would make next/prev
-      // jump back to the first copy — dedupe as playTrackFromList does.
-      const rawTracks = dedupeById(tracks.map(playlistTrackToPlayableData));
-      const audioTracks = rawTracks.map(convertToAudioTrack);
-      const albumInfo = {
-        cover: coverUrl,
-        title: playlist.name,
-        musician: null,
-      };
+    // A playlist may hold the same track at two positions. The player finds the
+    // current track with findIndex, so a repeated id would make next/prev jump
+    // back to the first copy — dedupe as playTrackFromList does.
+    const loaded = dedupeById(allTracks.map(playlistTrackToPlayableData));
+    const albumInfo = { cover: coverUrl, title: playlist.name, musician: null };
+    const audioTracks = loaded.map(convertToAudioTrack);
 
-      if (shuffle) {
-        audioPlayer.shuffleQueue(audioTracks, albumInfo, rawTracks);
-      } else {
-        audioPlayer.playQueue(audioTracks, albumInfo, rawTracks);
-      }
+    const queueId = shuffle
+      ? audioPlayer.shuffleQueue(audioTracks, albumInfo, loaded)
+      : audioPlayer.playQueue(audioTracks, albumInfo, loaded);
+
+    if (queueId === null || !hasNextPage) return;
+
+    setIsLoadingRest(true);
+    const tracks = await loadRemainingTracks();
+    setIsLoadingRest(false);
+
+    // reshuffleTail: the button said "Shuffle all N", so the tracks that only
+    // arrived now have to be mixed through the part the user has not reached
+    // yet, not tacked onto the end in a block.
+    audioPlayer.extendQueue(
+      dedupeById(tracks.map(playlistTrackToPlayableData)),
+      queueId,
+      { reshuffleTail: shuffle },
+    );
+
+    if (tracks.length < track_count) {
+      showActionFailed(
+        action,
+        `Only ${tracks.length} of ${track_count} tracks could be loaded.`,
+      );
     }
-
-    setIsStartingPlayback(false);
   };
 
   const handlePlayAll = () => {
@@ -373,7 +391,11 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
             )}
           </ul>
 
-          {/* Play buttons */}
+          {/* Play buttons. Deliberately never disabled: playback starts from the
+              pages already loaded, and the spinner only reports the rest
+              arriving behind it. A disabled media control is also unreachable
+              under iOS VoiceOver. `size` re-declares rounded-md, so both
+              buttons re-assert rounded-full to stay a matching pair. */}
           {track_count > 0 && (
             <div className="mt-5 flex flex-col justify-center gap-2 sm:mt-6 sm:flex-row sm:gap-3 lg:justify-start">
               <Button
@@ -381,11 +403,10 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
                 variant="accent-pill"
                 size="lg"
                 onClick={handlePlayAll}
-                disabled={isStartingPlayback}
-                className="w-full font-semibold shadow-lg shadow-primary/20 sm:w-auto"
+                className="w-full rounded-full font-semibold shadow-lg shadow-primary/20 sm:w-auto"
                 aria-label={`Play all ${track_count} tracks`}
               >
-                {isStartingPlayback ? (
+                {isLoadingRest ? (
                   <Spinner className="size-4" />
                 ) : (
                   <Play className="size-4 fill-current" aria-hidden="true" />
@@ -397,11 +418,10 @@ function PlaylistContent({ playlistId, data }: PlaylistContentProps) {
                 variant="outline"
                 size="lg"
                 onClick={handleShuffle}
-                disabled={isStartingPlayback}
                 className="w-full rounded-full font-semibold sm:w-auto"
                 aria-label={`Shuffle all ${track_count} tracks`}
               >
-                {isStartingPlayback ? (
+                {isLoadingRest ? (
                   <Spinner className="size-4" />
                 ) : (
                   <Shuffle className="size-4" aria-hidden="true" />

--- a/web/src/test/lib/audio-utils.test.ts
+++ b/web/src/test/lib/audio-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   dedupeById,
   playMediaElement,
+  shuffleArray,
   toggleMediaPlayback,
   trimQueueHistory,
 } from "@/lib/audio-utils";
@@ -122,5 +123,57 @@ describe("dedupeById", () => {
     const items = [{ id: 1 }, { id: 2 }];
 
     expect(dedupeById(items)).toEqual(items);
+  });
+});
+
+describe("shuffleArray", () => {
+  it("returns a permutation of the input", () => {
+    const input = makeTracks(50);
+
+    const shuffled = shuffleArray(input);
+
+    expect(shuffled).toHaveLength(input.length);
+    expect([...shuffled].sort((a, b) => a.id - b.id)).toEqual(input);
+  });
+
+  it("does not mutate the input", () => {
+    const input = makeTracks(20);
+    const snapshot = [...input];
+
+    shuffleArray(input);
+
+    expect(input).toEqual(snapshot);
+  });
+
+  it("handles empty and single-element arrays", () => {
+    expect(shuffleArray([])).toEqual([]);
+    expect(shuffleArray([{ id: 1 }])).toEqual([{ id: 1 }]);
+  });
+
+  // Fisher-Yates walks i from the end down to 1 and swaps with a random j in
+  // [0, i]. Forcing j to its maximum makes every swap a no-op, which pins the
+  // draw range: an off-by-one that let j exceed i would throw the ordering off.
+  it("leaves the order untouched when every draw picks the highest index", () => {
+    const randomSpy = vi
+      .spyOn(Math, "random")
+      .mockReturnValue(0.999999999999);
+    const input = makeTracks(8);
+
+    expect(shuffleArray(input)).toEqual(input);
+
+    randomSpy.mockRestore();
+  });
+
+  // The mirror case: forcing j to 0 swaps each element into slot 0 in turn,
+  // which rotates the array left by one. That only holds if j is drawn from
+  // [0, i] inclusive of 0 and i counts down from length - 1.
+  it("rotates left by one when every draw picks index zero", () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    expect(shuffleArray(makeTracks(4)).map(track => track.id)).toEqual([
+      2, 3, 4, 1,
+    ]);
+
+    randomSpy.mockRestore();
   });
 });

--- a/web/src/test/music/audio-player-endless-queue.test.tsx
+++ b/web/src/test/music/audio-player-endless-queue.test.tsx
@@ -183,3 +183,100 @@ describe("endless shuffle queue", () => {
     expect(probeRenders.count).toBe(rendersBeforeAppend);
   });
 });
+
+describe("endless shuffle queue on an exhausted library", () => {
+  beforeEach(() => {
+    stubMediaElement();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  // Stand in for the server: honour the exclusion list the client sends, which
+  // is the whole point of the parameter. A library this small used to hand the
+  // same ids back on every refill, so the client burned three round trips per
+  // track advance and then went quiet.
+  function mockLibrary(size: number) {
+    vi.mocked(getShuffleTracks).mockImplementation(
+      async (limit = 50, excludeTrackIds: number[] = []) => {
+        const excluded = new Set(excludeTrackIds);
+        const available = Array.from({ length: size }, (_, i) => i + 1)
+          .filter(id => !excluded.has(id))
+          .slice(0, limit);
+
+        return {
+          error: false as const,
+          data: { tracks: available.map(rawTrack) },
+        };
+      },
+    );
+  }
+
+  it("sends the queued track ids so a refill never repeats them", async () => {
+    mockLibrary(24);
+
+    renderWithQueryClient(
+      <AudioPlayerProvider>
+        <EndlessQueueHarness />
+      </AudioPlayerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "start shuffle" }));
+    await waitFor(() => expectCounterAt(1));
+
+    // The opening fetch has nothing to exclude yet.
+    expect(vi.mocked(getShuffleTracks).mock.calls[0][1]).toBeUndefined();
+
+    // Walk into the lookahead window so a refill fires.
+    for (let position = 2; position <= 16; position++) {
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Next track" }),
+      );
+      await waitFor(() => expectCounterAt(position));
+    }
+
+    await waitFor(() =>
+      expect(vi.mocked(getShuffleTracks).mock.calls.length).toBeGreaterThan(1),
+    );
+
+    const refillExclusions = vi.mocked(getShuffleTracks).mock.calls[1][1] ?? [];
+    expect(refillExclusions.length).toBeGreaterThan(0);
+
+    // Every id the queue already holds is excluded, so nothing can come back
+    // twice and the "Track N of M" denominator only ever counts fresh tracks.
+    const total = Number(trackCounter().match(/of (\d+)$/)?.[1]);
+    expect(total).toBeLessThanOrEqual(24);
+  });
+
+  it("says so when the library has nothing left instead of going quiet", async () => {
+    const { toast } = await import("sonner");
+    const infoSpy = vi.spyOn(toast, "info");
+
+    mockLibrary(12);
+
+    renderWithQueryClient(
+      <AudioPlayerProvider>
+        <EndlessQueueHarness />
+      </AudioPlayerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "start shuffle" }));
+    await waitFor(() => expectCounterAt(1));
+
+    // 12 tracks queued, lookahead is 10, so the refill fires almost at once and
+    // the server has nothing left that the queue does not already hold.
+    for (let position = 2; position <= 4; position++) {
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Next track" }),
+      );
+      await waitFor(() => expectCounterAt(position));
+    }
+
+    await waitFor(() => expect(infoSpy).toHaveBeenCalled());
+    expect(infoSpy.mock.calls[0][0]).toBe("That's the whole library");
+
+    infoSpy.mockRestore();
+  });
+});

--- a/web/src/test/music/audio-player-endless-queue.test.tsx
+++ b/web/src/test/music/audio-player-endless-queue.test.tsx
@@ -215,7 +215,10 @@ describe("endless shuffle queue on an exhausted library", () => {
   }
 
   it("sends the queued track ids so a refill never repeats them", async () => {
-    mockLibrary(24);
+    // Bigger than SHUFFLE_TRACKS_LIMIT on purpose. With a library that fits in
+    // one batch the opening fetch takes everything, the refill comes back empty,
+    // and the test passes without ever appending anything.
+    mockLibrary(80);
 
     renderWithQueryClient(
       <AudioPlayerProvider>
@@ -229,8 +232,9 @@ describe("endless shuffle queue on an exhausted library", () => {
     // The opening fetch has nothing to exclude yet.
     expect(vi.mocked(getShuffleTracks).mock.calls[0][1]).toBeUndefined();
 
-    // Walk into the lookahead window so a refill fires.
-    for (let position = 2; position <= 16; position++) {
+    // Walk into the lookahead window so a refill fires. The opening batch is
+    // SHUFFLE_TRACKS_LIMIT (50) tracks, so the runway only gets short at 42.
+    for (let position = 2; position <= 42; position++) {
       fireEvent.click(
         await screen.findByRole("button", { name: "Next track" }),
       );
@@ -242,12 +246,16 @@ describe("endless shuffle queue on an exhausted library", () => {
     );
 
     const refillExclusions = vi.mocked(getShuffleTracks).mock.calls[1][1] ?? [];
-    expect(refillExclusions.length).toBeGreaterThan(0);
+    expect(refillExclusions).toHaveLength(50);
 
-    // Every id the queue already holds is excluded, so nothing can come back
-    // twice and the "Track N of M" denominator only ever counts fresh tracks.
-    const total = Number(trackCounter().match(/of (\d+)$/)?.[1]);
-    expect(total).toBeLessThanOrEqual(24);
+    // Exactly the whole library, which is only reachable if the refill appended
+    // all 30 tracks the opening batch missed and repeated none of the 50 it
+    // already held. Nothing has been trimmed yet at this position, so the
+    // denominator is the real queue length.
+    await waitFor(() => {
+      const total = Number(trackCounter().match(/of (\d+)$/)?.[1]);
+      expect(total).toBe(80);
+    });
   });
 
   it("says so when the library has nothing left instead of going quiet", async () => {

--- a/web/src/test/music/audio-player-endless-queue.test.tsx
+++ b/web/src/test/music/audio-player-endless-queue.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AudioPlayerProvider } from "@/context/AudioPlayerContext";
 import { useAudioPlayerActions } from "@/hooks/useAudioPlayerActions";
 import { useTrackPlaybackMatcher } from "@/hooks/useTrackPlaybackMatcher";
-import { getShuffleTracks } from "@/lib/api";
+import { getShuffleTracks, getTracksPaginated } from "@/lib/api";
 import { renderWithQueryClient } from "@/test/helpers/render";
 import type { TrackListItemType } from "@/types";
 import { stubMediaElement } from "../helpers/dom";
@@ -277,6 +277,208 @@ describe("endless shuffle queue on an exhausted library", () => {
     await waitFor(() => expect(infoSpy).toHaveBeenCalled());
     expect(infoSpy.mock.calls[0][0]).toBe("That's the whole library");
 
+    // The refill effect re-runs on every advance because the runway keeps
+    // shrinking. Without a latch that means one round trip and one identical
+    // toast per remaining track, stacked on screen.
+    const callsWhenExhausted = vi.mocked(getShuffleTracks).mock.calls.length;
+
+    for (let position = 5; position <= 9; position++) {
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Next track" }),
+      );
+      await waitFor(() => expectCounterAt(position));
+    }
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getShuffleTracks).mock.calls.length).toBe(
+      callsWhenExhausted,
+    );
+
     infoSpy.mockRestore();
+  });
+
+  it("resumes refilling when a new shuffle is started after exhaustion", async () => {
+    const { toast } = await import("sonner");
+    const infoSpy = vi.spyOn(toast, "info");
+
+    mockLibrary(12);
+
+    renderWithQueryClient(
+      <AudioPlayerProvider>
+        <EndlessQueueHarness />
+      </AudioPlayerProvider>,
+    );
+
+    const startButton = screen.getByRole("button", { name: "start shuffle" });
+
+    fireEvent.click(startButton);
+    await waitFor(() => expectCounterAt(1));
+
+    // 12 queued against a lookahead of 10: the runway only gets short at 4.
+    for (let position = 2; position <= 4; position++) {
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Next track" }),
+      );
+      await waitFor(() => expectCounterAt(position));
+    }
+    await waitFor(() => expect(infoSpy).toHaveBeenCalledTimes(1));
+
+    // The latch is keyed on the queue, not the provider, so starting over must
+    // ask the server again rather than staying permanently exhausted.
+    const callsBeforeRestart = vi.mocked(getShuffleTracks).mock.calls.length;
+
+    fireEvent.click(startButton);
+    await waitFor(() => expectCounterAt(1));
+
+    await waitFor(() =>
+      expect(vi.mocked(getShuffleTracks).mock.calls.length).toBeGreaterThan(
+        callsBeforeRestart,
+      ),
+    );
+
+    infoSpy.mockRestore();
+  });
+});
+
+describe("endless play-all queue", () => {
+  const LIBRARY_SIZE = 1000;
+
+  function PlayAllHarness() {
+    const actions = useAudioPlayerActions();
+
+    return (
+      <button type="button" onClick={() => void actions.startPlayAllPlayback()}>
+        start play all
+      </button>
+    );
+  }
+
+  beforeEach(() => {
+    stubMediaElement();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  // Play-all walks the library by offset, and that cursor lives in a ref rather
+  // than in queue state — so the queueId guard on the queue array does not
+  // protect it. A refill that resolves after the user restarted play-all used to
+  // add its page length on top of the *new* queue's cursor, skipping a page of
+  // the library for the rest of the session.
+  it("does not advance the offset for a batch belonging to a replaced queue", async () => {
+    // An array rather than a nullable let: TypeScript narrows a variable only
+    // ever assigned inside a callback to null at the release site.
+    const heldPages: Array<() => void> = [];
+    const requestedOffsets: number[] = [];
+
+    const page = (offset: number) => ({
+      error: false as const,
+      data: {
+        tracks: Array.from({ length: BATCH_SIZE }, (_, index) =>
+          rawTrack(offset + index + 1),
+        ),
+        total: LIBRARY_SIZE,
+        offset,
+        limit: BATCH_SIZE,
+        has_more: offset + BATCH_SIZE < LIBRARY_SIZE,
+      },
+    });
+
+    vi.mocked(getTracksPaginated).mockImplementation(
+      async (_limit: number, offset: number) => {
+        requestedOffsets.push(offset);
+
+        // Hold only the first refill (the one the restart will orphan).
+        if (offset === BATCH_SIZE && heldPages.length === 0) {
+          return new Promise(resolve => {
+            heldPages.push(() => resolve(page(offset)));
+          });
+        }
+
+        return page(offset);
+      },
+    );
+
+    renderWithQueryClient(
+      <AudioPlayerProvider>
+        <PlayAllHarness />
+      </AudioPlayerProvider>,
+    );
+
+    const startButton = screen.getByRole("button", { name: "start play all" });
+
+    fireEvent.click(startButton);
+    await waitFor(() => expectCounterAt(1));
+
+    // One advance puts the runway under the lookahead and fires the refill.
+    fireEvent.click(await screen.findByRole("button", { name: "Next track" }));
+    await waitFor(() => expectCounterAt(2));
+    await waitFor(() => expect(heldPages).toHaveLength(1));
+
+    // Restart while that page is still in flight: the new queue re-reads the
+    // library from the top and puts the cursor back at BATCH_SIZE.
+    fireEvent.click(startButton);
+    await waitFor(() => expectCounterAt(1));
+
+    heldPages[0]();
+
+    const offsetsBeforeRefill = requestedOffsets.length;
+    fireEvent.click(await screen.findByRole("button", { name: "Next track" }));
+    await waitFor(() => expectCounterAt(2));
+    await waitFor(() =>
+      expect(requestedOffsets.length).toBeGreaterThan(offsetsBeforeRefill),
+    );
+
+    // The stale page must not have pushed the cursor to 2 * BATCH_SIZE.
+    expect(requestedOffsets.at(-1)).toBe(BATCH_SIZE);
+  });
+
+  // An empty page below the reported total means the library shrank under us.
+  // Re-requesting the same hole on every advance is the failure mode the
+  // shuffle exhaustion latch exists to prevent.
+  it("stops asking once a page comes back empty", async () => {
+    vi.mocked(getTracksPaginated).mockImplementation(
+      async (_limit: number, offset: number) => ({
+        error: false as const,
+        data: {
+          tracks:
+            offset === 0
+              ? Array.from({ length: BATCH_SIZE }, (_, index) =>
+                  rawTrack(index + 1),
+                )
+              : [],
+          total: LIBRARY_SIZE,
+          offset,
+          limit: BATCH_SIZE,
+          has_more: true,
+        },
+      }),
+    );
+
+    renderWithQueryClient(
+      <AudioPlayerProvider>
+        <PlayAllHarness />
+      </AudioPlayerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "start play all" }));
+    await waitFor(() => expectCounterAt(1));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Next track" }));
+    await waitFor(() => expectCounterAt(2));
+    await waitFor(() =>
+      expect(vi.mocked(getTracksPaginated).mock.calls.length).toBe(2),
+    );
+
+    for (let position = 3; position <= 6; position++) {
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Next track" }),
+      );
+      await waitFor(() => expectCounterAt(position));
+    }
+
+    expect(vi.mocked(getTracksPaginated).mock.calls.length).toBe(2);
   });
 });

--- a/web/src/test/music/audio-player-queue.test.tsx
+++ b/web/src/test/music/audio-player-queue.test.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AudioPlayerProvider } from "@/context/AudioPlayerContext";
@@ -492,5 +493,195 @@ describe("shuffleQueue", () => {
     renderShuffle([], { withMetadata: true });
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+// extendQueue is how a caller that could not supply its whole list up front adds
+// to a queue that is already playing — the playlist header starts on the pages
+// it has and drains the rest behind playback. Its two load-bearing promises are
+// that a load finishing after the user moved on is discarded, and that a
+// reshuffle leaves the part of the queue already played alone.
+describe("extendQueue", () => {
+  beforeEach(() => {
+    stubMediaElement();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  const playlistInfo = {
+    cover: "/covers/playlist.jpg",
+    title: "Road Trip",
+    musician: null,
+  };
+
+  // Starting a queue opens the fullscreen player, a modal that aria-hides the
+  // rest of the tree — including this harness. The buttons are still in the DOM
+  // and still clickable, but getByRole cannot name an element inside an
+  // aria-hidden subtree (not even with hidden: true, which relaxes the
+  // visibility filter and not the name computation), so match on text.
+  function harnessButton(name: string) {
+    return screen.getByText(name);
+  }
+
+  function song(id: number): PlayableTrackData {
+    return rawTrack({
+      id,
+      title: `Song ${id}`,
+      albumTitle: `Record ${id}`,
+      musician: `Band ${id}`,
+      cover: null,
+    });
+  }
+
+  function ExtendHarness({
+    initial,
+    replacement,
+    extra,
+    shuffle,
+    reshuffleTail,
+  }: {
+    initial: PlayableTrackData[];
+    replacement: PlayableTrackData[];
+    extra: PlayableTrackData[];
+    shuffle: boolean;
+    reshuffleTail: boolean;
+  }) {
+    const actions = useAudioPlayerActions();
+    // The id of the queue "start" opened. "restart" deliberately does not update
+    // it, so "extend" can be aimed at a queue the user has already left.
+    const queueIdRef = useRef<number | null>(null);
+
+    const start = (tracks: PlayableTrackData[], capture: boolean) => {
+      const begin = shuffle ? actions.shuffleQueue : actions.playQueue;
+      const queueId = begin(
+        tracks.map(convertToAudioTrack),
+        playlistInfo,
+        tracks,
+      );
+      if (capture) queueIdRef.current = queueId;
+    };
+
+    return (
+      <>
+        <button type="button" onClick={() => start(initial, true)}>
+          start
+        </button>
+        <button type="button" onClick={() => start(replacement, false)}>
+          restart
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            actions.extendQueue(extra, queueIdRef.current ?? 0, {
+              reshuffleTail,
+            })
+          }
+        >
+          extend
+        </button>
+      </>
+    );
+  }
+
+  function renderHarness(props: {
+    initial: PlayableTrackData[];
+    replacement?: PlayableTrackData[];
+    extra: PlayableTrackData[];
+    shuffle?: boolean;
+    reshuffleTail?: boolean;
+  }) {
+    renderWithQueryClient(
+      <AudioPlayerProvider>
+        <ExtendHarness
+          initial={props.initial}
+          replacement={props.replacement ?? props.initial}
+          extra={props.extra}
+          shuffle={props.shuffle ?? false}
+          reshuffleTail={props.reshuffleTail ?? false}
+        />
+      </AudioPlayerProvider>,
+    );
+  }
+
+  // The control for the test below: without this, a guard that rejected
+  // everything would look identical to a guard that works.
+  it("appends to the queue it was given", () => {
+    renderHarness({ initial: [song(1), song(2)], extra: [song(3)] });
+
+    fireEvent.click(harnessButton("start"));
+    expect(screen.getByText("Track 1 of 2")).toBeInTheDocument();
+
+    fireEvent.click(harnessButton("extend"));
+    expect(screen.getByText("Track 1 of 3")).toBeInTheDocument();
+  });
+
+  // A playlist drain outlives the queue that started it. If a late batch could
+  // still land, it would splice a different playlist's tracks into whatever the
+  // user is listening to now.
+  it("discards a batch aimed at a queue the user has already replaced", () => {
+    renderHarness({
+      initial: [song(1), song(2)],
+      replacement: [song(9)],
+      extra: [song(3), song(4)],
+    });
+
+    fireEvent.click(harnessButton("start"));
+    expect(screen.getByText("Track 1 of 2")).toBeInTheDocument();
+
+    fireEvent.click(harnessButton("restart"));
+    expect(screen.getByText("Track 1 of 1")).toBeInTheDocument();
+
+    // Aimed at the first queue, which is gone.
+    fireEvent.click(harnessButton("extend"));
+
+    expect(screen.getByText("Track 1 of 1")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Song 9",
+    );
+  });
+
+  // reshuffleTail exists because a shuffled batch appended to a shuffled queue
+  // is not a shuffle of the whole playlist. It must still leave the played part
+  // alone: reshuffling the head would move the current track's index, breaking
+  // the counter and previous-track navigation.
+  it("reshuffles only the tracks the user has not reached yet", () => {
+    // Fisher-Yates with random pinned to 0 is a left rotation by one, so both
+    // the opening shuffle and the tail reshuffle are fully determined.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    renderHarness({
+      initial: [song(1), song(2), song(3), song(4)],
+      extra: [song(5), song(6)],
+      shuffle: true,
+      reshuffleTail: true,
+    });
+
+    fireEvent.click(harnessButton("start"));
+    // [1,2,3,4] rotates to [2,3,4,1].
+    expect(screen.getByText("Track 1 of 4")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+    expect(screen.getByText("Track 2 of 4")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Song 3",
+    );
+
+    fireEvent.click(harnessButton("extend"));
+
+    // Still track 2: the head [2,3] was untouched, so the current track did not
+    // move. A whole-queue reshuffle would land it somewhere else.
+    expect(screen.getByText("Track 2 of 6")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Song 3",
+    );
+
+    // And the track behind it is still the one that was there before.
+    fireEvent.click(screen.getByRole("button", { name: "Previous track" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Song 2",
+    );
   });
 });

--- a/web/src/test/music/audio-player-queue.test.tsx
+++ b/web/src/test/music/audio-player-queue.test.tsx
@@ -351,3 +351,146 @@ describe("playTrackFromList", () => {
     });
   });
 });
+
+describe("shuffleQueue", () => {
+  beforeEach(() => {
+    stubMediaElement();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  const alabaster = rawTrack({
+    id: 1,
+    title: "Alabaster",
+    albumTitle: "Stone Record",
+    musician: "The Band",
+    cover: "/covers/stone.jpg",
+  });
+  const basalt = rawTrack({
+    id: 2,
+    title: "Basalt",
+    albumTitle: "Dark Record",
+    musician: "Other Band",
+    cover: null,
+  });
+  const chalk = rawTrack({
+    id: 3,
+    title: "Chalk",
+    albumTitle: "White Record",
+    musician: "Third Band",
+    cover: "/covers/white.jpg",
+  });
+
+  const playlistInfo = {
+    cover: "/covers/playlist.jpg",
+    title: "Road Trip",
+    musician: null,
+  };
+
+  function ShuffleHarness({
+    rawTracks,
+    withMetadata,
+  }: {
+    rawTracks: PlayableTrackData[];
+    withMetadata: boolean;
+  }) {
+    const actions = useAudioPlayerActions();
+
+    return (
+      <button
+        type="button"
+        onClick={() =>
+          actions.shuffleQueue(
+            rawTracks.map(convertToAudioTrack),
+            playlistInfo,
+            withMetadata ? rawTracks : undefined,
+          )
+        }
+      >
+        shuffle
+      </button>
+    );
+  }
+
+  function renderShuffle(
+    rawTracks: PlayableTrackData[],
+    { withMetadata }: { withMetadata: boolean },
+  ) {
+    renderWithQueryClient(
+      <AudioPlayerProvider>
+        <ShuffleHarness rawTracks={rawTracks} withMetadata={withMetadata} />
+      </AudioPlayerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "shuffle" }));
+  }
+
+  // Pinning Math.random to 0 makes Fisher-Yates a left rotation by one, so the
+  // queue order is fully determined: [A, B, C] becomes [B, C, A]. That is the
+  // whole point of the button - it must not start on the list's first track.
+  it("starts on the shuffled first track, not the list's", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    renderShuffle([alabaster, basalt, chalk], { withMetadata: true });
+
+    expect(
+      screen.getByRole("dialog", { name: "Now playing: Basalt by Other Band" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Track 1 of 3")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Chalk");
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Alabaster",
+    );
+  });
+
+  // Regression guard: a shuffled playlist used to show the playlist's own name
+  // in the artist slot and its cover for every track, because shuffleQueue had
+  // no way to carry the per-track metadata the rows already held.
+  it("resolves each track's own artist, album, and cover when given rawTracks", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    renderShuffle([alabaster, basalt, chalk], { withMetadata: true });
+
+    expect(screen.getByText("Dark Record")).toBeInTheDocument();
+    expect(screen.queryByText("Road Trip")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "No album cover available" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+
+    expect(screen.getByText("White Record")).toBeInTheDocument();
+    expect(screen.getByText("Third Band")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Album cover for White Record" }),
+    ).toBeInTheDocument();
+  });
+
+  // Album and musician queues are single-artist, so they omit rawTracks on
+  // purpose and the queue-wide info has to carry across every track.
+  it("keeps the queue-wide album info when rawTracks is omitted", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    renderShuffle([alabaster, basalt, chalk], { withMetadata: false });
+
+    expect(screen.getAllByText("Road Trip").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Next track" }));
+
+    expect(screen.getAllByText("Road Trip").length).toBeGreaterThan(0);
+    expect(screen.queryByText("White Record")).not.toBeInTheDocument();
+  });
+
+  it("does nothing for an empty queue", () => {
+    renderShuffle([], { withMetadata: true });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/test/music/musician-details-route.test.tsx
+++ b/web/src/test/music/musician-details-route.test.tsx
@@ -16,6 +16,7 @@ const { audioPlayerActionsMock, audioPlayerNowPlayingMock } = vi.hoisted(() => (
   audioPlayerActionsMock: {
     playQueue: vi.fn(),
     playTrack: vi.fn(),
+    playTrackFromList: vi.fn(),
     shuffleQueue: vi.fn(),
     togglePlay: vi.fn(),
   },
@@ -62,6 +63,9 @@ type MusicianDetailsFixtureOptions = {
   summary?: string;
   albumId?: number;
   albumTitle?: string;
+  // Per-track album titles, for an artist whose tracks span several albums.
+  // Falls back to albumTitle for any track it does not cover.
+  trackAlbumTitles?: string[];
   trackIds?: number[];
   trackTitles?: string[];
   genres?: string[];
@@ -74,6 +78,7 @@ function musicianDetailsResponse({
   summary = "A focused test artist with two tracks.",
   albumId = 7,
   albumTitle = "Blue Record",
+  trackAlbumTitles = [],
   trackIds = [1, 2],
   trackTitles = ["Alabaster", "Borrowed Light"],
   genres = ["Alternative"],
@@ -83,7 +88,7 @@ function musicianDetailsResponse({
       trackIds[index] ?? id * 100 + index,
       title,
       albumId,
-      albumTitle,
+      trackAlbumTitles[index] ?? albumTitle,
     ),
   );
 
@@ -135,6 +140,18 @@ function mockMusicianDetailsFetch() {
         trackIds: [3],
         trackTitles: ["Silver Path"],
         genres: ["Ambient"],
+      }),
+    ],
+    [
+      22,
+      musicianDetailsResponse({
+        id: 22,
+        name: "The Journeyman",
+        sortName: "Journeyman, The",
+        summary: "An artist whose tracks span more than one album.",
+        trackIds: [4, 5],
+        trackTitles: ["Cobalt", "Driftwood"],
+        trackAlbumTitles: ["Blue Record", "Dark Record"],
       }),
     ],
   ]);
@@ -310,10 +327,11 @@ describe("musician details route accessibility", () => {
     expect(currentRow).toHaveTextContent("Alabaster");
   });
 
-  // Row clicks go through playTrack, which toggles play/pause itself when the
-  // clicked track is already current (covered in audio-player-queue.test.tsx).
-  // playQueue is reserved for the header's start-over buttons.
-  it("routes a row click through playTrack rather than restarting the queue", async () => {
+  // Row clicks go through playTrackFromList, which toggles play/pause itself
+  // when the clicked track is already current (covered in
+  // audio-player-queue.test.tsx). playQueue is reserved for the header's
+  // start-over buttons.
+  it("routes a row click through playTrackFromList rather than restarting the queue", async () => {
     audioPlayerNowPlayingMock.currentTrackId = 1;
     audioPlayerNowPlayingMock.isPlaying = true;
 
@@ -323,12 +341,43 @@ describe("musician details route accessibility", () => {
       await screen.findByRole("button", { name: "Pause Alabaster" }),
     );
 
-    expect(audioPlayerActionsMock.playTrack).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 1 }),
+    expect(audioPlayerActionsMock.playTrackFromList).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ id: 1 })]),
-      expect.objectContaining({ title: "The Band" }),
+      1,
     );
     expect(audioPlayerActionsMock.playQueue).not.toHaveBeenCalled();
+  });
+
+  // A musician's tracks span every album they appear on, so the queue-wide
+  // albumInfo cannot describe them: without the raw rows the player shows the
+  // musician's name in the album slot and their photo as the cover for every
+  // track, which is the defect the playlist header had.
+  it("hands the header buttons each track's own album details", async () => {
+    await renderMusicianDetailsRoute("/music/musician/22");
+
+    expect(
+      await screen.findByRole("heading", { name: "The Journeyman" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Play all/ }),
+    );
+
+    const rawTracks = audioPlayerActionsMock.playQueue.mock.calls[0][2];
+    expect(rawTracks).toHaveLength(2);
+    expect(rawTracks[0].album_title).toEqual(nullableString("Blue Record"));
+    expect(rawTracks[1].album_title).toEqual(nullableString("Dark Record"));
+    // The artist is the one field that genuinely is queue-wide here.
+    expect(rawTracks[1].musician_name).toEqual(
+      nullableString("The Journeyman"),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Shuffle/ }),
+    );
+    expect(audioPlayerActionsMock.shuffleQueue.mock.calls[0][2]).toEqual(
+      rawTracks,
+    );
   });
 });
 

--- a/web/src/types/audio-player.ts
+++ b/web/src/types/audio-player.ts
@@ -23,8 +23,9 @@ export type PlayableTrackData = {
   album_cover: NullableString;
   musician_name: NullableString;
 
-  // Present on list/search rows; used to keep the player header accurate in
-  // mixed queues. The shuffle/play-all endpoints may omit it.
+  // Used to keep the player header accurate in mixed queues. Optional because
+  // not every producer of this shape carries it; the list, search, shuffle and
+  // play-all endpoints all do.
   album_title?: NullableString;
 };
 
@@ -32,6 +33,12 @@ export type PlayableTrackData = {
 // to AudioPlayer as props — it is deliberately NOT exposed as a context, so a
 // queue append never re-renders the app shell or a track list.
 export type AudioPlayerQueueState = {
+  // Bumped every time a queue is started or cleared. An endless-queue batch is
+  // fetched against one queueId and appended only if that is still the live
+  // one, so a batch that lands late cannot splice itself into a queue the user
+  // has since replaced.
+  queueId: number;
+
   currentTrack: TrackType | null;
   tracks: TrackType[];
   albumCover: string | null;
@@ -77,10 +84,24 @@ export type AudioPlayerActions = {
   // Start a finite queue (album, playlist, musician page) from the top. Unlike
   // playTrack this always restarts, even when the first track is already the
   // current one — it is the explicit "start over" entry point.
-  playQueue: (tracks: TrackType[], albumInfo: AlbumInfoType) => void;
+  //
+  // rawTracks is optional and only matters for mixed queues (playlists): pass
+  // it and the player resolves each track's own cover/artist/album as the queue
+  // advances instead of showing the queue-wide albumInfo for every track. Album
+  // and musician queues are single-artist, so they omit it on purpose.
+  playQueue: (
+    tracks: TrackType[],
+    albumInfo: AlbumInfoType,
+    rawTracks?: PlayableTrackData[]
+  ) => void;
 
-  // Shuffle a finite queue and start it from the top
-  shuffleQueue: (tracks: TrackType[], albumInfo: AlbumInfoType) => void;
+  // Shuffle a finite queue and start it from the top. Same rawTracks contract
+  // as playQueue.
+  shuffleQueue: (
+    tracks: TrackType[],
+    albumInfo: AlbumInfoType,
+    rawTracks?: PlayableTrackData[]
+  ) => void;
 
   // Start shuffle playback across entire music library
   startShufflePlayback: () => Promise<void>;

--- a/web/src/types/audio-player.ts
+++ b/web/src/types/audio-player.ts
@@ -85,22 +85,42 @@ export type AudioPlayerActions = {
   // playTrack this always restarts, even when the first track is already the
   // current one — it is the explicit "start over" entry point.
   //
-  // rawTracks is optional and only matters for mixed queues (playlists): pass
-  // it and the player resolves each track's own cover/artist/album as the queue
-  // advances instead of showing the queue-wide albumInfo for every track. Album
-  // and musician queues are single-artist, so they omit it on purpose.
+  // rawTracks is optional and matters whenever the queue is mixed — a playlist,
+  // or a musician whose tracks span several albums: pass it and the player
+  // resolves each track's own cover/artist/album as the queue advances instead
+  // of showing the queue-wide albumInfo for every track. Only a single-album
+  // queue can safely omit it, because there albumInfo already describes every
+  // track.
+  //
+  // Returns the new queue's id, or null when there was nothing to play. Hold on
+  // to it if more tracks are still downloading — extendQueue needs it.
   playQueue: (
     tracks: TrackType[],
     albumInfo: AlbumInfoType,
     rawTracks?: PlayableTrackData[]
-  ) => void;
+  ) => number | null;
 
   // Shuffle a finite queue and start it from the top. Same rawTracks contract
-  // as playQueue.
+  // and same return as playQueue.
   shuffleQueue: (
     tracks: TrackType[],
     albumInfo: AlbumInfoType,
     rawTracks?: PlayableTrackData[]
+  ) => number | null;
+
+  // Add tracks to a queue that is already playing, for a caller whose full list
+  // was not available when playback started (a playlist still downloading its
+  // later pages). queueId must be the value playQueue/shuffleQueue returned:
+  // tracks arriving for a queue the user has since replaced are discarded.
+  // Ids already in the queue are ignored, so overlapping pages are safe.
+  //
+  // reshuffleTail re-randomizes everything after the current track instead of
+  // appending in order — what a "Shuffle all N" button needs, since a shuffled
+  // batch appended to a shuffled queue is not a shuffle of the whole thing.
+  extendQueue: (
+    rawTracks: PlayableTrackData[],
+    queueId: number,
+    options?: { reshuffleTail?: boolean }
   ) => void;
 
   // Start shuffle playback across entire music library

--- a/web/src/types/openapi.gen.ts
+++ b/web/src/types/openapi.gen.ts
@@ -4425,7 +4425,7 @@ export interface components {
         SortQuery: "asc" | "desc";
         LimitQuery: number;
         ShuffleLimitQuery: number;
-        /** @description Track ids the client already holds. Repeat the parameter (or pass a comma-separated list) and those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected. */
+        /** @description Track ids the client already holds, as one comma-separated list (`exclude=1,2,3`); those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Repeating the parameter works too. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected. */
         ShuffleExcludeQuery: number[];
         StatsLimitQuery: number;
         OffsetQuery: number;
@@ -6645,7 +6645,7 @@ export interface operations {
         parameters: {
             query?: {
                 limit?: components["parameters"]["ShuffleLimitQuery"];
-                /** @description Track ids the client already holds. Repeat the parameter (or pass a comma-separated list) and those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected. */
+                /** @description Track ids the client already holds, as one comma-separated list (`exclude=1,2,3`); those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Repeating the parameter works too. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected. */
                 exclude?: components["parameters"]["ShuffleExcludeQuery"];
             };
             header?: never;

--- a/web/src/types/openapi.gen.ts
+++ b/web/src/types/openapi.gen.ts
@@ -4425,6 +4425,8 @@ export interface components {
         SortQuery: "asc" | "desc";
         LimitQuery: number;
         ShuffleLimitQuery: number;
+        /** @description Track ids the client already holds. Repeat the parameter (or pass a comma-separated list) and those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected. */
+        ShuffleExcludeQuery: number[];
         StatsLimitQuery: number;
         OffsetQuery: number;
         SearchQuery: string;
@@ -6643,6 +6645,8 @@ export interface operations {
         parameters: {
             query?: {
                 limit?: components["parameters"]["ShuffleLimitQuery"];
+                /** @description Track ids the client already holds. Repeat the parameter (or pass a comma-separated list) and those tracks are left out of the random sample, so an endless shuffle queue is not handed back what it is already playing. Ids past the first 200, non-numeric values, and ids below 1 are ignored rather than rejected. */
+                exclude?: components["parameters"]["ShuffleExcludeQuery"];
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Context

A full evaluation of the track-shuffle feature. The core algorithm is fine — `shuffleArray` is a textbook unbiased Fisher–Yates with a single call site, and the server samples over the bare PK subquery so the joins only run for the winners. The problems were around it.

## Correctness fixes

| | |
|---|---|
| **Playlist shuffle scope** | "Shuffle all 120 tracks" queued only the ~50 pages the infinite list had scrolled in. Both header buttons now drain the remaining pages behind a spinner first. `handlePlayAll` had the same defect. |
| **Playlist metadata loss** | A shuffled playlist showed the playlist's own name in the artist slot and its cover for every track — even though `PlaylistTrackType` already carries `album_title`, `album_cover` and `musician_name`. `playQueue`/`shuffleQueue` now accept the raw rows, and `startQueue` resolves the opening track the same way navigation does instead of only from track 2 onward. |
| **Wrong album on track 1** | Library shuffle showed `"Shuffle All"` as the album for exactly one track before the real title took over (and `"All Tracks"` for play-all). |
| **Silent failures** | `startShufflePlayback`/`startPlayAllPlayback` returned quietly on `response.error`. `apiRequest` resolves an error envelope rather than rejecting, so the caller's `catch` + `showActionFailed` was dead code. |

## Endless queue

`GetRandomTracks` was memoryless — every refill re-sampled the whole table with no idea what the client held. On a library smaller than the queue that returned nothing but duplicates, burning three `ORDER BY RANDOM()` full scans per track advance before giving up without a word. It now takes an `exclude` list.

The exclusions bind through `json_each` rather than `sqlc.slice`, for two reasons: the SQL text stays constant so the statement can still be prepared, and an empty list stays correct. An empty `sqlc.slice` renders as `NOT IN (NULL)`, which is NULL rather than true and would have matched no rows at all — there's a test pinning that.

The two refill effects were near-duplicates that had drifted (shuffle used an unnamed lookahead of `5` against play-all's named `10`; shuffle depended on the whole `tracks` array where play-all used its length). Both now run through `useEndlessQueueRefill`. A finished batch is no longer discarded when a track advance tears the effect down — whether it is still wanted is decided by the state updater against a `queueId`, which is the only place that can see which queue is actually live.

## Tests

`shuffleArray` had zero tests and `shuffleQueue` was untested at every level. Adds:

- unit tests for `shuffleArray` (permutation, no mutation, empty/single, and both seeded-`Math.random` boundary cases that pin the `j ∈ [0, i]` draw range)
- `shuffleQueue` tests, including a regression guard for the playlist-metadata bug
- an exclusion + exhaustion pair for the endless queue, with a mock that honours the exclude list
- a Go table test for `parseShuffleExcludeIDs` plus query coverage for the empty-exclusion trap
- `e2e/playlist-details.spec.ts` — the playlist route had no test of any kind, which is exactly where two of the bugs lived

## Verification

`make check` passes. Web: 739 unit tests pass, `bun run doctor` unchanged at 88/79. E2E: 76 passed / 2 failed / 9 skipped — the two failures are the pre-existing `movie-player.spec.ts` ones, unchanged from baseline.

## Out of scope

Deliberately not included, since they are product decisions needing a `docs/design-system.md` change: a real shuffle **toggle** in the player (today shuffle is fire-and-forget — you cannot turn it off or restore the original order), a repeat mode, and renaming `isShuffleMode` to something honest (it means "endless server-random refill", and a shuffled album has it `false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGkYM6SBDzTmJD9HcP4Uur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shuffle playback now avoids repeating tracks already in the queue.
  - Play All and Shuffle All load the complete playlist, including additional pages.
  - Queue refills automatically as playback approaches the end.
  - Track-specific album, artist, and cover information is preserved during playback.

- **Bug Fixes**
  - Improved handling of exhausted libraries with a clear notification.
  - Prevented stale queue updates and duplicate tracks during refills.
  - Added loading states while starting playlist playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->